### PR TITLE
Sending calibration info to outside app (Unity)

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -330,7 +330,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                 if self.active_site == 10:
                     self.stop()
                     return
-
+            events["calib_info"] = (self.screen_marker_state, self.active_site)
             # interpolation_weight = np.tanh(((s-1/6.*m)*10.)/(5/6.*m))*(-.5)+.5
             self.pattern_alpha = interp_fn(self.screen_marker_state,0.,1.,float(self.screen_marker_max),float(self.start_sample),float(self.stop_sample))
 

--- a/pupil_src/shared_modules/pupil_server.py
+++ b/pupil_src/shared_modules/pupil_server.py
@@ -80,6 +80,13 @@ class Pupil_Server(Plugin):
                 if key not in self.exclude_list:
                     msg +=key+":"+str(value)+'\n'
             self.socket.send( msg )
+            
+        for c in events.get('calib_info',[]):
+            msg = "Calibration\n"
+            for key,value in c.iteritems():
+                if key not in self.exclude_list:
+                    msg +=key+":"+str(value)+'\n'
+            self.socket.send( msg )
 
         # for e in events:
         #     msg = 'Event'+'\n'


### PR DESCRIPTION
Hello,
I try sending the location and status of the marker to another app, then using it there to recreate the behavior of the marker. If this happens then the calibration will work on any screen the other app is displayed at. 
Best,
Richard