### PR TITLE
Enabled seeking bar on retina displays

### DIFF
--- a/pupil_src/player/seek_bar.py
+++ b/pupil_src/player/seek_bar.py
@@ -38,7 +38,7 @@ class Seek_Bar(Plugin):
         self.on_window_resize(glfwGetCurrentContext(),*glfwGetWindowSize(glfwGetCurrentContext()))
 
     def on_window_resize(self,window,w,h):
-        self.window_size = w,h
+        self.window_size = glfwGetWindowSize(glfwGetCurrentContext())
         self.h_pad = self.padding * self.frame_count/float(w)
         self.v_pad = self.padding * 1./h
 


### PR DESCRIPTION
Hi, I'm using pupil-pro in my lab. It really helps me.

I'm using pupil on MacBook Pro with retina display. But it seems that the seeking bar of pupil-player doesn't work on retina display. So I did some fixation on `SeekBar` class.

I'm new to contributing to open-source projects, so feel free to give feedback on my pull request process :)