### PR TITLE
fix slice((start > 0), stop, step) heatmap bug

### DIFF
--- a/pupil_src/shared_modules/offline_reference_surface.py
+++ b/pupil_src/shared_modules/offline_reference_surface.py
@@ -256,6 +256,7 @@ class Offline_Reference_Surface(Reference_Surface):
 
         for frame_idx,c_e in enumerate(self.cache[section]):
             if c_e:
+                frame_idx+=section.start
                 for gp in self.gaze_on_srf_by_frame_idx(frame_idx,c_e['m_from_screen']):
                     all_gaze.append(gp['norm_pos'])
 


### PR DESCRIPTION
when `section.start > 0`, frame_idx (L257) does not reflect the frame index producing buggy heatmaps;
The `gaze_on_srf_in_section` method is already using `frame_idx+=section.start`, so I just copy and paste it.