### PR TITLE
allow easy to override surface initialization

### DIFF
--- a/pupil_src/shared_modules/offline_marker_detector.py
+++ b/pupil_src/shared_modules/offline_marker_detector.py
@@ -66,6 +66,7 @@ class Offline_Marker_Detector(Marker_Detector):
         if g_pool.app == 'capture':
            raise Exception('For Player only.')
         #in player we load from the rec_dir: but we have a couple options:
+        self.surface_definitions = None
         self.surfaces = None
         self.init_surfaces()
 

--- a/pupil_src/shared_modules/offline_marker_detector.py
+++ b/pupil_src/shared_modules/offline_marker_detector.py
@@ -89,7 +89,7 @@ class Offline_Marker_Detector(Marker_Detector):
         self.img = None
 
     def init_surfaces(self):
-        self.surface_definitions = Persistent_Dict(os.path.join(g_pool.rec_dir,'surface_definitions'))
+        self.surface_definitions = Persistent_Dict(os.path.join(self.g_pool.rec_dir,'surface_definitions'))
         if self.surface_definitions.get('offline_square_marker_surfaces',[]) != []:
             logger.debug("Found ref surfaces defined or copied in previous session.")
             self.surfaces = [Offline_Reference_Surface(self.g_pool,saved_definition=d) for d in self.surface_definitions.get('offline_square_marker_surfaces',[]) if isinstance(d,dict)]

--- a/pupil_src/shared_modules/offline_marker_detector.py
+++ b/pupil_src/shared_modules/offline_marker_detector.py
@@ -66,17 +66,8 @@ class Offline_Marker_Detector(Marker_Detector):
         if g_pool.app == 'capture':
            raise Exception('For Player only.')
         #in player we load from the rec_dir: but we have a couple options:
-        self.surface_definitions = Persistent_Dict(os.path.join(g_pool.rec_dir,'surface_definitions'))
-        if self.surface_definitions.get('offline_square_marker_surfaces',[]) != []:
-            logger.debug("Found ref surfaces defined or copied in previous session.")
-            self.surfaces = [Offline_Reference_Surface(self.g_pool,saved_definition=d) for d in self.surface_definitions.get('offline_square_marker_surfaces',[]) if isinstance(d,dict)]
-        elif self.surface_definitions.get('realtime_square_marker_surfaces',[]) != []:
-            logger.debug("Did not find ref surfaces def created or used by the user in player from earlier session. Loading surfaces defined during capture.")
-            self.surfaces = [Offline_Reference_Surface(self.g_pool,saved_definition=d) for d in self.surface_definitions.get('realtime_square_marker_surfaces',[]) if isinstance(d,dict)]
-        else:
-            logger.debug("No surface defs found. Please define using GUI.")
-            self.surfaces = []
-
+        self.surfaces = None
+        self.init_surfaces()
 
         # ui mode settings
         self.mode = mode
@@ -97,7 +88,17 @@ class Offline_Marker_Detector(Marker_Detector):
         self.img_shape = None
         self.img = None
 
-
+    def init_surfaces(self):
+        self.surface_definitions = Persistent_Dict(os.path.join(g_pool.rec_dir,'surface_definitions'))
+        if self.surface_definitions.get('offline_square_marker_surfaces',[]) != []:
+            logger.debug("Found ref surfaces defined or copied in previous session.")
+            self.surfaces = [Offline_Reference_Surface(self.g_pool,saved_definition=d) for d in self.surface_definitions.get('offline_square_marker_surfaces',[]) if isinstance(d,dict)]
+        elif self.surface_definitions.get('realtime_square_marker_surfaces',[]) != []:
+            logger.debug("Did not find ref surfaces def created or used by the user in player from earlier session. Loading surfaces defined during capture.")
+            self.surfaces = [Offline_Reference_Surface(self.g_pool,saved_definition=d) for d in self.surface_definitions.get('realtime_square_marker_surfaces',[]) if isinstance(d,dict)]
+        else:
+            logger.debug("No surface defs found. Please define using GUI.")
+            self.surfaces = []
 
     def init_gui(self):
         self.menu = ui.Scrolling_Menu('Offline Marker Tracker')


### PR DESCRIPTION
Moving surface initialization code to a separated method. I am having some problems trying to override the __init__ directly with multiple inheritance. This should make it easier to do it.