### PR TITLE
Improve circle marker detector

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/accuracy_test.py
+++ b/pupil_src/shared_modules/calibration_routines/accuracy_test.py
@@ -21,7 +21,6 @@ from gl_utils import adjust_gl_view,clear_gl_screen,basic_gl_setup
 import OpenGL.GL as gl
 from glfw import *
 import calibrate
-from circle_detector import get_candidate_ellipses
 
 import audio
 

--- a/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
@@ -127,7 +127,7 @@ class Adjust_Calibration(Calibration_Plugin):
             r['norm_pos'] = [ r['norm_pos'][0]-mean_offset[0],r['norm_pos'][1]-mean_offset[1] ]
 
 
-        finish_calibration(self.g_pool,self.pupil_list,self.ref_list,force='2d')
+        finish_calibration(self.g_pool,self.pupil_list,self.ref_list)
 
 
     def update(self,frame,events):

--- a/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
@@ -15,7 +15,7 @@ from methods import normalize,denormalize
 from file_methods import load_object
 from pyglui.cygl.utils import draw_points_norm,draw_polyline,RGBA
 from OpenGL.GL import GL_POLYGON
-from circle_detector import get_candidate_ellipses
+from circle_detector import find_concetric_circles
 from finish_calibration import finish_calibration
 import calibrate
 
@@ -41,11 +41,7 @@ class Adjust_Calibration(Calibration_Plugin):
         self.sample_site = (-2,-2)
         self.counter = 0
         self.counter_max = 30
-        self.candidate_ellipses = []
-        self.show_edges = 0
-        self.aperture = 7
-        self.dist_threshold = 10
-        self.area_threshold = 30
+        self.markers = []
         self.world_size = None
 
         self.stop_marker_found = False
@@ -63,9 +59,6 @@ class Adjust_Calibration(Calibration_Plugin):
 
         self.menu = ui.Growing_Menu('Controls')
         self.g_pool.calibration_menu.append(self.menu)
-
-        self.menu.append(ui.Slider('aperture',self,min=3,step=2,max=11,label='filter aperture'))
-        self.menu.append(ui.Switch('show_edges',self,label='show edges'))
 
         self.button = ui.Thumb('active',self,setter=self.toggle,label='Calibrate',hotkey='c')
         self.button.on_color[:] = (.3,.2,1.,.9)
@@ -144,15 +137,11 @@ class Adjust_Calibration(Calibration_Plugin):
             if self.world_size is None:
                 self.world_size = frame.width,frame.height
 
-            self.candidate_ellipses = get_candidate_ellipses(gray_img,
-                                                            area_threshold=self.area_threshold,
-                                                            dist_threshold=self.dist_threshold,
-                                                            min_ring_count=5,
-                                                            visual_debug=self.show_edges)
+            self.markers = find_concetric_circles(gray_img,min_ring_count=3)
 
-            if len(self.candidate_ellipses) > 0:
+            if len(self.markers) > 0:
                 self.detected = True
-                marker_pos = self.candidate_ellipses[0][0]
+                marker_pos = self.markers[0][0][0] #first marker, innermost ellipse, center
                 self.pos = normalize(marker_pos,(frame.width,frame.height),flip_y=True)
 
 
@@ -253,20 +242,12 @@ class Adjust_Calibration(Calibration_Plugin):
             draw_points_norm([self.smooth_pos],size=15,color=RGBA(1.,1.,0.,.5))
 
         if self.active and self.detected:
-            for e in self.candidate_ellipses:
+            for marker in self.markers:
+                e = marker[-1]
                 pts = cv2.ellipse2Poly( (int(e[0][0]),int(e[0][1])),
                                     (int(e[1][0]/2),int(e[1][1]/2)),
                                     int(e[-1]),0,360,15)
                 draw_polyline(pts,color=RGBA(0.,1.,0,1.))
-
-
-            # lets draw an indicator on the autostop count
-            e = self.candidate_ellipses[3]
-            pts = cv2.ellipse2Poly( (int(e[0][0]),int(e[0][1])),
-                                (int(e[1][0]/2),int(e[1][1]/2)),
-                                int(e[-1]),0,360,360/self.auto_stop_max)
-            indicator = [e[0]] + pts[self.auto_stop:].tolist() + [e[0]]
-            draw_polyline(indicator,color=RGBA(8.,0.1,0.1,.8),line_type=GL_POLYGON)
         else:
             pass
 

--- a/pupil_src/shared_modules/circle_detector.py
+++ b/pupil_src/shared_modules/circle_detector.py
@@ -10,65 +10,90 @@
 
 import numpy as np
 import cv2
+from methods import dist_pts_ellipse
 
-def get_candidate_ellipses(gray_img,area_threshold,dist_threshold,min_ring_count, visual_debug):
 
-    # get threshold image used to get crisp-clean edges
-    edges = cv2.adaptiveThreshold(gray_img, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 5, -3)
-    # cv2.flip(edges,1 ,dst = edges,)
-    # display the image for debugging purpuses
-    # img[:] = cv2.cvtColor(edges,cv2.COLOR_GRAY2BGR)
-    # from edges to contours to ellipses CV_RETR_CCsOMP ls fr hole
+def find_concetric_circles(gray_img,min_ring_count=3, visual_debug=False):
+
+    # get threshold image used to get crisp-clean edges using blur to remove small features
+    edges = cv2.adaptiveThreshold(cv2.blur(gray_img,(3,3)), 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 5, 11)
     contours, hierarchy = cv2.findContours(edges,
                                     mode=cv2.RETR_TREE,
                                     method=cv2.CHAIN_APPROX_NONE,offset=(0,0)) #TC89_KCOS
-
-    # remove extra encapsulation
+    if visual_debug is not False:
+        cv2.drawContours(visual_debug,contours,-1,(200,0,0))
     if contours is None or hierarchy is None:
         return []
-
-    hierarchy = hierarchy[0]
-    # turn outmost list into array
-    contours =  np.array(contours)
-    # keep only contours                        with parents     and      children
-    contained_contours = contours[np.logical_and(hierarchy[:,3]>=0, hierarchy[:,2]>=0)]
-    # turn on to debug contours
-    if visual_debug:
-        cv2.drawContours(gray_img, contained_contours,-1, (0,0,255))
-
-    # need at least 5 points to fit ellipse
-    contained_contours =  [c for c in contained_contours if len(c) >= 5]
-
-    ellipses = [cv2.fitEllipse(c) for c in contained_contours]
-    candidate_ellipses = []
-    # filter for ellipses that have similar area as the source contour
-    for e,c in zip(ellipses,contained_contours):
-        a,b = e[1][0]/2.,e[1][1]/2.
-        if abs(cv2.contourArea(c)-np.pi*a*b) <area_threshold:
-            candidate_ellipses.append(e)
+    clusters = get_nested_clusters(contours,hierarchy[0],min_nested_count=min_ring_count)
+    concentric_cirlce_clusters = []
 
 
+    # for each cluster fit ellipses and cull members that dont have good ellipse fit
+    for cluster in clusters:
+        if visual_debug is not False:
+            cv2.drawContours(visual_debug, cluster,-1, (0,0,255))
+        candidate_ellipses = []
+        for c in cluster:
+            if len(c)>5:
+                e = cv2.fitEllipse(c)
+                a,b = e[1][0]/2.,e[1][1]/2.
+                if max(dist_pts_ellipse(e,c))<max(2,max(e[1])/20):
+                    candidate_ellipses.append(e)
+                    if visual_debug is not False:
+                        cv2.ellipse(visual_debug, e, (0,255,0),1)
+
+        if candidate_ellipses:
+            cluster_center = np.mean(np.array([e[0] for e in candidate_ellipses]),axis=0)
+            candidate_ellipses = [e for e in candidate_ellipses if np.linalg.norm(e[0]-cluster_center)<max(3,min(e[1])/20) ]
+            if len(candidate_ellipses) >= min_ring_count:
+                concentric_cirlce_clusters.append(candidate_ellipses)
+                if visual_debug is not False:
+                    cv2.ellipse(visual_debug, candidate_ellipses[-1], (0,255,255),4)
+
+    #return clusters sorted by size of outmost cirlce biggest first.
+    return sorted(concentric_cirlce_clusters,key=lambda e:-max(e[-1][1]))
+
+def add_parents(child,graph,family):
+    family.append(child)
+    parent = graph[child,-1]
+    if parent !=-1:
+        family = add_parents(parent,graph,family)
+    return family
 
 
-    candidate_ellipses = get_cluster(candidate_ellipses,dist_threshold = dist_threshold,min_ring_count=min_ring_count)
-
-    return candidate_ellipses
-
-
-def man_dist(e,other):
-    return abs(e[0][0]-other[0][0])+abs(e[0][1]-other[0][1])
-
-def get_cluster(ellipses,dist_threshold,min_ring_count):
-    for e in ellipses:
-        close_ones = []
-        for other in ellipses:
-            # distance to other ellipse is smaller than min dist threshold and minor of both ellipses
-            if man_dist(e,other)<dist_threshold and man_dist(e,other) < min(min(*e[1]),min(other[1])) :
-                close_ones.append(other)
-        if len(close_ones)>=min_ring_count:
-            # sort by major axis to return smallest ellipse first
-            close_ones.sort(key=lambda e: max(e[1]))
-            return close_ones
-    return []
+def get_nested_clusters(contours,hierarchy,min_nested_count):
+    clusters = {}
+    # nesting of countours where many children are grouping in a sigle parent happens a lot (your screen with stuff in it. A page with text...)
+    # we create a cluster for each of these children.
+    # to reduce CPU load we onle keep the biggest cluster for clusters where the innermost parent is the same.
+    for i in np.where(hierarchy[:,2]==-1)[0]: #contours with no children
+        if len(contours[i])>=5: #we assume that valid markers innermost contour is longer than 5px
+            cluster = add_parents(i,hierarchy,[])
+            # is this cluster bigger that the current contender in the innermost parent group if if already exsists?
+            if min_nested_count < len(cluster) > len(clusters.get(cluster[1],[])):
+                clusters[cluster[1]] = [contours[m] for m in cluster]
+    return clusters.values()
 
 
+if __name__ == '__main__':
+    def bench():
+        import cv2
+        cap = cv2.VideoCapture(0)
+        cap.set(3,1280)
+        cap.set(4,720)
+        for x in range(100):
+            sts,img = cap.read()
+            # img = cv2.imread('/Users/mkassner/Desktop/manual_calibration_marker-01.png')
+            gray  = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
+            print len(find_concetric_circles(gray,visual_debug=img))
+            cv2.imshow('img',img)
+            cv2.waitKey(1)
+            # return
+
+
+    import cProfile,subprocess,os
+    cProfile.runctx("bench()",{},locals(),"world.pstats")
+    loc = os.path.abspath(__file__).rsplit('pupil_src', 1)
+    gprof2dot_loc = os.path.join(loc[0], 'pupil_src', 'shared_modules','gprof2dot.py')
+    subprocess.call("python "+gprof2dot_loc+" -f pstats world.pstats | dot -Tpng -o world_cpu_time.png", shell=True)
+    print "created  time graph for  process. Please check out the png next to this file"


### PR DESCRIPTION
This PR improves the circle marker detector we use for calibration:

- The detector now analyses the contour hierarchy to find clusters of nested contours.
- The detected clusters are filtered for ellipse contour fit. 
- The detected clusters are filtered against eccentricity.

With these changes the detector is more discriminative and allows us to use smaller and simpler markers like the one below:

![screen shot 2016-04-29 at 11 39 52](https://cloud.githubusercontent.com/assets/1433767/14912831/1e608d40-0dff-11e6-9e2f-ffa5232151a3.png)

The simple marker above printed with a diameter of 40mm can be used at distances of 2m with current Pupil hardware. The old marker is still supported and will continue working.
