### PR TITLE
Capture robustification

### DIFF
--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -163,9 +163,10 @@ class Recorder(Plugin):
 
     def toggle(self, _=None):
         if self.running:
-            self.stop()
+            self.notify_all( {'subject':'should_stop_recording','network_propagate':True} )
         else:
-            self.start()
+            self.notify_all( {'subject':'should_start_recording','session_name':self.session_name,'network_propagate':True} )
+
 
     def on_notify(self,notification):
 
@@ -175,17 +176,17 @@ class Recorder(Plugin):
 
 
         # Notificatio to start recording
-        elif notification['subject'] == 'should_start_recording' and notification.get('source','local') != 'local':
+        elif notification['subject'] == 'should_start_recording':
             if self.running:
                 logger.warning('Recording is already running!')
             else:
                 if notification.get("session_name",""):
                     self.set_session_name(notification["session_name"])
-                self.start(instruct_others=False)
+                self.start()
         # Remote has stopped recording, we should stop as well.
-        elif notification['subject'] == 'should_stop_recording' and notification.get('source','local') != 'local':
+        elif notification['subject'] == 'should_stop_recording':
             if self.running:
-                self.stop(instruct_others=False)
+                self.stop()
             else:
                 logger.warning('Recording is already stopped!')
 
@@ -194,7 +195,7 @@ class Recorder(Plugin):
         rec_time = gmtime(time()-self.start_time)
         return strftime("%H:%M:%S", rec_time)
 
-    def start(self,instruct_others=True):
+    def start(self):
         self.timestamps = []
         self.data = {'pupil_positions':[],'gaze_positions':[],'notifications':[]}
         self.frame_count = 0
@@ -253,8 +254,6 @@ class Recorder(Plugin):
             self.open_info_menu()
 
         self.notify_all( {'subject':'rec_started','rec_path':self.rec_path,'session_name':self.session_name,'network_propagate':True} )
-        if instruct_others:
-            self.notify_all( {'subject':'should_start_recording','session_name':self.session_name,'network_propagate':True} )
 
     def open_info_menu(self):
         self.info_menu = ui.Growing_Menu('additional Recording Info',size=(300,300),pos=(300,300))
@@ -298,7 +297,7 @@ class Recorder(Plugin):
 
             self.button.status_text = self.get_rec_time_str()
 
-    def stop(self,instruct_others=True):
+    def stop(self):
         #explicit release of VideoWriter
         self.writer.release()
         self.writer = None
@@ -377,9 +376,6 @@ class Recorder(Plugin):
 
 
         self.notify_all( {'subject':'rec_stopped','rec_path':self.rec_path,'network_propagate':True} )
-        if instruct_others:
-            self.notify_all( {'subject':'should_stop_recording','network_propagate':True} )
-
 
     def cleanup(self):
         """gets called when the plugin get terminated.

--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -178,7 +178,7 @@ class Recorder(Plugin):
         # Notificatio to start recording
         elif notification['subject'] == 'should_start_recording':
             if self.running:
-                logger.warning('Recording is already running!')
+                logger.info('Recording already running!')
             else:
                 if notification.get("session_name",""):
                     self.set_session_name(notification["session_name"])
@@ -188,7 +188,7 @@ class Recorder(Plugin):
             if self.running:
                 self.stop()
             else:
-                logger.warning('Recording is already stopped!')
+                logger.info('Recording already stopped!')
 
 
     def get_rec_time_str(self):

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -351,10 +351,16 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
 
         # Get an image from the grabber
         try:
-            frame = cap.get_frame()
+            frame = g_pool.capture.get_frame()
         except CameraCaptureError:
-            logger.error("Capture from camera failed. Stopping.")
-            break
+            logger.error("Capture from camera failed. Starting Fake Capture.")
+            settings = g_pool.capture.settings
+            g_pool.capture.close()
+            g_pool.capture = autoCreateCapture(None, timebase=g_pool.timebase)
+            g_pool.capture.init_gui(g_pool.sidebar)
+            g_pool.capture.settings = settings
+            g_pool.notifications.append({'subject':'should_stop_recording'})
+            continue
         except EndofVideoFileError:
             logger.warning("Video file is done. Stopping")
             break
@@ -450,7 +456,7 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     g_pool.gui.terminate()
     glfw.glfwDestroyWindow(main_window)
     glfw.glfwTerminate()
-    cap.close()
+    g_pool.capture.close()
 
     #shut down eye processes:
     stop_eye_process(0)


### PR DESCRIPTION
The PR improves capture robustness and failed capture feedback.

- The pupil video_backend now tries to restart the capture device after all attempts to read from the device have failed.
- The world process with fall back to a `fake capture` if all attempts to restart and recover communications with the camera have failed. This behaviour is better feedback to the user than a shutdown of the capture program.
- The world process will stop recording when the fallback to `fake capture` happens.

This PR requires an updated of [pyuvc](https://github.com/pupil-labs/pyuvc) to v0.6

