### PR TITLE
Add Pupil Capture version and user system info to `world.log`

### DIFF
--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -17,6 +17,7 @@ from time import strftime,localtime,time,gmtime
 from shutil import copy2
 from audio import Audio_Input_Dict
 from file_methods import save_object
+from methods import get_system_info
 from av_writer import JPEG_Writer, AV_Writer, Audio_Capture
 from calibration_routines.camera_intrinsics_estimation import load_camera_calibration
 #logging
@@ -335,20 +336,7 @@ class Recorder(Plugin):
                 f.write("World Camera Frames\t"+ str(self.frame_count)+ "\n")
                 f.write("World Camera Resolution\t"+ str(self.g_pool.capture.frame_size[0])+"x"+str(self.g_pool.capture.frame_size[1])+"\n")
                 f.write("Capture Software Version\t%s\n"%self.g_pool.version)
-                if platform.system() == "Windows":
-                    username = os.environ["USERNAME"]
-                    sysname, nodename, release, version, machine, _ = platform.uname()
-                else:
-                    username = getpass.getuser()
-                    try:
-                        sysname, nodename, release, version, machine = os.uname()
-                    except:
-                        sysname, nodename, release, version, machine = sys.platform,None,None,None,None
-                f.write("User\t"+username+"\n")
-                f.write("Platform\t"+sysname+"\n")
-                f.write("Machine\t"+nodename+"\n")
-                f.write("Release\t"+release+"\n")
-                f.write("Version\t"+version+"\n")
+                f.write("System Info\t%s"%get_system_info())
         except Exception:
             logger.exception("Could not save metadata. Please report this bug!")
 

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -7,7 +7,7 @@
  License details are in the file license.txt, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
-import os, sys, platform, getpass
+import os, sys, platform
 
 
 class Global_Container(object):
@@ -68,7 +68,7 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
 
     # helpers/utils
     from file_methods import Persistent_Dict
-    from methods import normalize, denormalize, delta_t
+    from methods import normalize, denormalize, delta_t, log_system_info
     from video_capture import autoCreateCapture, FileCaptureError, EndofVideoFileError, CameraCaptureError
     from version_utils import VersionFormat
     import audio
@@ -124,24 +124,8 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     plugin_by_name = dict(zip(name_by_index,plugin_by_index))
     default_plugins = [('Log_Display',{}),('Dummy_Gaze_Mapper',{}),('Display_Recent_Gaze',{}), ('Screen_Marker_Calibration',{}),('Recorder',{})]
 
-    def log_system_info():
-        try:
-            if platform.system() == "Windows":
-                username = os.environ["USERNAME"]
-                sysname, nodename, release, version, machine, _ = platform.uname()
-            else:
-                username = getpass.getuser()
-                try:
-                    sysname, nodename, release, version, machine = os.uname()
-                except:
-                    sysname, nodename, release, version, machine = sys.platform,None,None,None,None
-            logger.info("Pupil Capture Version: %s"%g_pool.version)
-            logger.info("System Info - User: %s, Platform: %s, Machine: %s, Release: %s, Version: %s" %(username,sysname,nodename,release,version))
-        except Exception:
-            logger.exception("Could log system info to world.log. Please report this bug!")
-
     # log info about Pupil Capture and Platform in world.log
-    log_system_info()
+    log_system_info(g_pool.version,g_pool.app)
 
     # Callback functions
     def on_resize(window,w, h):

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -68,7 +68,7 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
 
     # helpers/utils
     from file_methods import Persistent_Dict
-    from methods import normalize, denormalize, delta_t, log_system_info
+    from methods import normalize, denormalize, delta_t, get_system_info
     from video_capture import autoCreateCapture, FileCaptureError, EndofVideoFileError, CameraCaptureError
     from version_utils import VersionFormat
     import audio
@@ -85,8 +85,9 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     from log_display import Log_Display
     from annotations import Annotation_Capture
     from pupil_remote import Pupil_Remote
-    # create logger for the context of this function
 
+    logger.info('Application Version: %s'%version)
+    logger.info('System Info: %s'%get_system_info())
 
     #UI Platform tweaks
     if platform.system() == 'Linux':
@@ -124,8 +125,6 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     plugin_by_name = dict(zip(name_by_index,plugin_by_index))
     default_plugins = [('Log_Display',{}),('Dummy_Gaze_Mapper',{}),('Display_Recent_Gaze',{}), ('Screen_Marker_Calibration',{}),('Recorder',{})]
 
-    # log info about Pupil Capture and Platform in world.log
-    log_system_info(g_pool.version,g_pool.app)
 
     # Callback functions
     def on_resize(window,w, h):

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -7,7 +7,7 @@
  License details are in the file license.txt, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
-import os, sys, platform
+import os, sys, platform, getpass
 
 
 class Global_Container(object):
@@ -124,7 +124,24 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     plugin_by_name = dict(zip(name_by_index,plugin_by_index))
     default_plugins = [('Log_Display',{}),('Dummy_Gaze_Mapper',{}),('Display_Recent_Gaze',{}), ('Screen_Marker_Calibration',{}),('Recorder',{})]
 
+    def log_system_info():
+        try:
+            if platform.system() == "Windows":
+                username = os.environ["USERNAME"]
+                sysname, nodename, release, version, machine, _ = platform.uname()
+            else:
+                username = getpass.getuser()
+                try:
+                    sysname, nodename, release, version, machine = os.uname()
+                except:
+                    sysname, nodename, release, version, machine = sys.platform,None,None,None,None
+            logger.info("Pupil Capture Version: %s"%g_pool.version)
+            logger.info("System Info - User: %s, Platform: %s, Machine: %s, Release: %s, Version: %s" %(username,sysname,nodename,release,version))
+        except Exception:
+            logger.exception("Could log system info to world.log. Please report this bug!")
 
+    # log info about Pupil Capture and Platform in world.log
+    log_system_info()
 
     # Callback functions
     def on_resize(window,w, h):

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -88,7 +88,7 @@ from video_capture import File_Capture,EndofVideoFileError,FileSeekError
 
 # helpers/utils
 from version_utils import VersionFormat, read_rec_version, get_version
-from methods import normalize, denormalize, delta_t
+from methods import normalize, denormalize, delta_t,log_system_info
 from player_methods import correlate_data, is_pupil_rec_dir,update_recording_0v4_to_current,update_recording_0v3_to_current,update_recording_0v5_to_current,update_recording_0v73_to_current
 
 #monitoring
@@ -130,6 +130,7 @@ class Global_Container(object):
 
 def session(rec_dir):
 
+    
     # Callback functions
     def on_resize(window,w, h):
         g_pool.gui.update_window(w,h)
@@ -190,6 +191,11 @@ def session(rec_dir):
         meta_info = dict( ((line.strip().split('\t')) for line in info.readlines() ) )
 
     rec_version = read_rec_version(meta_info)
+    app_version = get_version(version_file)
+
+    # log info about Pupil Platform and Platform in player.log
+    log_system_info(app_version,app='player')
+
     if rec_version >= VersionFormat('0.7.4'):
         pass
     if rec_version >= VersionFormat('0.7.3'):
@@ -232,7 +238,7 @@ def session(rec_dir):
     g_pool = Global_Container()
     g_pool.app = 'player'
     g_pool.binocular = meta_info.get('Eye Mode','monocular') == 'binocular'
-    g_pool.version = get_version(version_file)
+    g_pool.version = app_version
     g_pool.capture = cap
     g_pool.timestamps = timestamps
     g_pool.play = False

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -88,7 +88,7 @@ from video_capture import File_Capture,EndofVideoFileError,FileSeekError
 
 # helpers/utils
 from version_utils import VersionFormat, read_rec_version, get_version
-from methods import normalize, denormalize, delta_t,log_system_info
+from methods import normalize, denormalize, delta_t,get_system_info
 from player_methods import correlate_data, is_pupil_rec_dir,update_recording_0v4_to_current,update_recording_0v3_to_current,update_recording_0v5_to_current,update_recording_0v73_to_current
 
 #monitoring
@@ -130,7 +130,7 @@ class Global_Container(object):
 
 def session(rec_dir):
 
-    
+
     # Callback functions
     def on_resize(window,w, h):
         g_pool.gui.update_window(w,h)
@@ -194,7 +194,8 @@ def session(rec_dir):
     app_version = get_version(version_file)
 
     # log info about Pupil Platform and Platform in player.log
-    log_system_info(app_version,app='player')
+    logger.info('Application Version: %s'%app_version)
+    logger.info('System Info: %s'%get_system_info())
 
     if rec_version >= VersionFormat('0.7.4'):
         pass

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -8,6 +8,8 @@
 ----------------------------------------------------------------------------------~(*)
 '''
 
+import os, sys, platform, getpass
+from time import time
 import numpy as np
 try:
     import numexpr as ne
@@ -17,7 +19,7 @@ import cv2
 import logging
 logger = logging.getLogger(__name__)
 
-from time import time
+
 def timer(dt):
     '''
     a generator used to time window refreshs
@@ -676,28 +678,20 @@ def filter_subsets(l):
 
 
 
-def log_system_info(pupil_version,app=None):
-    import os, sys, platform, getpass
-
+def get_system_info():
     try:
         if platform.system() == "Windows":
             username = os.environ["USERNAME"]
             sysname, nodename, release, version, machine, _ = platform.uname()
         else:
             username = getpass.getuser()
-            try:
-                sysname, nodename, release, version, machine = os.uname()
-            except:
-                sysname, nodename, release, version, machine = sys.platform,None,None,None,None
-        
-        if app is 'player':
-            logger.info("Pupil Player Version: %s"%pupil_version)
-        else:
-            logger.info("Pupil Capture Version: %s"%pupil_version)
+            sysname, nodename, release, version, machine = os.uname()
+    except Exception as e:
+        logger.error(e)
+        username = 'unknown'
+        sysname, nodename, release, version, machine = sys.platform,'unknown','unknown','unknown','unknown'
 
-        logger.info("System Info - User: %s, Platform: %s, Machine: %s, Release: %s, Version: %s" %(username,sysname,nodename,release,version))
-    except Exception:
-        logger.exception("Could log system info to world.log. Please report this bug!")
+    return "User: %s, Platform: %s, Machine: %s, Release: %s, Version: %s" %(username,sysname,nodename,release,version)
 
 
 if __name__ == '__main__':

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -676,6 +676,30 @@ def filter_subsets(l):
 
 
 
+def log_system_info(pupil_version,app=None):
+    import os, sys, platform, getpass
+
+    try:
+        if platform.system() == "Windows":
+            username = os.environ["USERNAME"]
+            sysname, nodename, release, version, machine, _ = platform.uname()
+        else:
+            username = getpass.getuser()
+            try:
+                sysname, nodename, release, version, machine = os.uname()
+            except:
+                sysname, nodename, release, version, machine = sys.platform,None,None,None,None
+        
+        if app is 'player':
+            logger.info("Pupil Player Version: %s"%pupil_version)
+        else:
+            logger.info("Pupil Capture Version: %s"%pupil_version)
+
+        logger.info("System Info - User: %s, Platform: %s, Machine: %s, Release: %s, Version: %s" %(username,sysname,nodename,release,version))
+    except Exception:
+        logger.exception("Could log system info to world.log. Please report this bug!")
+
+
 if __name__ == '__main__':
     # tst = []
     # for x in range(10):


### PR DESCRIPTION
Log information about Pupil Capture version and user system in `world.log`

This information is essential for bug reporting and will save time for debugging community member issues if system information and pupil capture version can be communicated by simply sharing the world.log file.

This change will add two log messages in the `world.log`. See example output below:

```
World Process: 2016-05-05 14:46:53,931 - world - INFO - Pupil Capture Version: 0.7.5.18
World Process: 2016-05-05 14:46:53,932 - world - INFO - System Info - User: wrp, Platform: Darwin, Machine: Wills-MacBook-Air.local, Release: 15.4.0, Version: Darwin Kernel Version 15.4.0: Fri Feb 26 22:08:05 PST 2016; root:xnu-3248.40.184~3/RELEASE_X86_64
```

@mkasser - please have a look at this.