### PR TITLE
Log History - GUI window that displays last 50 logger messages

### DIFF
--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -85,6 +85,7 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
     from log_display import Log_Display
     from annotations import Annotation_Capture
     from pupil_remote import Pupil_Remote
+    from log_history import Log_History
     # create logger for the context of this function
 
 
@@ -117,7 +118,7 @@ def world(pupil_queue,timebase,lauchner_pipe,eye_pipes,eyes_are_alive,user_dir,v
 
     #manage plugins
     runtime_plugins = import_runtime_plugins(os.path.join(g_pool.user_dir,'plugins'))
-    user_launchable_plugins = [Show_Calibration,Pupil_Remote,Pupil_Server,Pupil_Sync,Surface_Tracker,Annotation_Capture]+runtime_plugins
+    user_launchable_plugins = [Show_Calibration,Pupil_Remote,Pupil_Server,Pupil_Sync,Surface_Tracker,Annotation_Capture,Log_History]+runtime_plugins
     system_plugins  = [Log_Display,Display_Recent_Gaze,Recorder]
     plugin_by_index =  system_plugins+user_launchable_plugins+calibration_plugins+gaze_mapping_plugins
     name_by_index = [p.__name__ for p in plugin_by_index]

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -116,9 +116,10 @@ from eye_video_overlay import Eye_Video_Overlay
 from log_display import Log_Display
 from annotations import Annotation_Player
 from raw_data_exporter import Raw_Data_Exporter
+from log_history import Log_History
 
 system_plugins = [Log_Display,Seek_Bar,Trim_Marks]
-user_launchable_plugins = [Video_Export_Launcher,Raw_Data_Exporter, Vis_Circle,Vis_Cross, Vis_Polyline, Vis_Light_Points,Scan_Path,Fixation_Detector_Dispersion_Duration,Vis_Watermark, Manual_Gaze_Correction, Show_Calibration, Offline_Surface_Tracker,Pupil_Server,Batch_Exporter,Eye_Video_Overlay,Annotation_Player] #,Marker_Auto_Trim_Marks
+user_launchable_plugins = [Video_Export_Launcher,Raw_Data_Exporter, Vis_Circle,Vis_Cross, Vis_Polyline, Vis_Light_Points,Scan_Path,Fixation_Detector_Dispersion_Duration,Vis_Watermark, Manual_Gaze_Correction, Show_Calibration, Offline_Surface_Tracker,Pupil_Server,Batch_Exporter,Eye_Video_Overlay,Annotation_Player,Log_History] #,Marker_Auto_Trim_Marks
 user_launchable_plugins += import_runtime_plugins(os.path.join(user_dir,'plugins'))
 available_plugins = system_plugins + user_launchable_plugins
 name_by_index = [p.__name__ for p in available_plugins]

--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -35,7 +35,7 @@ class Log_History(Plugin):
         def close():
             self.alive = False
 
-        help_str = "This menu shows the last %s messages from the logger. See world.log or eye.log files for full logs." %(self.num_messages)
+        help_str = 'A View of the %s most recent log messages. Complete logs are here: "%s"' %(self.num_messages,self.g_pool.user_dir)
         self.menu = ui.Scrolling_Menu('Log')
         self.g_pool.gui.append(self.menu)
         self.menu.append(ui.Button('Close',close))

--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -30,6 +30,15 @@ class Log_History(Plugin):
         self.menu = None
         self.num_messages = 50
 
+        self.formatter = None
+        self.logfile = None
+        for h in logging.getLogger().handlers:
+            if isinstance(h,logging.FileHandler):
+                self.formatter = h.formatter
+                self.logfile = h.stream.name
+        if self.formatter == None:
+            raise Exception("Could not find fh in logging system")
+
     def init_gui(self):
 
         def close():
@@ -41,14 +50,19 @@ class Log_History(Plugin):
         self.menu.append(ui.Button('Close',close))
         self.menu.append(ui.Info_Text(help_str))
 
+        with open(self.logfile,'r') as fh:
+            for l in fh.readlines():
+                self.menu.insert(2,ui.Info_Text(l[:-1]))
+
         self.log_handler = Log_to_Callback(self.on_log)
         logger = logging.getLogger()
         logger.addHandler(self.log_handler)
         self.log_handler.setLevel(logging.INFO)
 
+
     def on_log(self,record):
         self.menu.elements[self.num_messages+2:] = []
-        self.menu.insert(2,ui.Info_Text("%s - %s" %(record.levelname, record.msg)))
+        self.menu.insert(2,ui.Info_Text(self.formatter.format(record)))
 
 
     def deinit_gui(self):

--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -1,0 +1,87 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2016  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the file license.txt, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
+import os
+from pyglui import ui
+from plugin import Plugin
+from file_methods import load_object,save_object
+
+import numpy as np
+from OpenGL.GL import *
+from glfw import glfwGetWindowSize,glfwGetCurrentContext
+from pyglui.cygl.utils import draw_polyline,RGBA
+from pyglui.pyfontstash import fontstash
+from pyglui.ui import get_opensans_font_path
+
+#logging
+import logging
+logger = logging.getLogger(__name__)
+
+class Log_to_Callback(logging.Handler):
+    def __init__(self,cb):
+        super(Log_to_Callback, self).__init__()
+        self.cb = cb
+
+    def emit(self,record):
+        self.cb(record)
+
+class Log_History(Plugin):
+    """Simple logging GUI that displays the last N messages from the logger"""
+    def __init__(self, g_pool):
+        super(Log_History, self).__init__(g_pool)
+        self.log_messages = []
+        self.order = 0.0
+        self.menu = None
+        self.num_messages = 50
+        self.help_str = "This menu shows the last %s messages from the logger. See world.log or eye.log files for full logs." %(self.num_messages)        
+    
+    def init_gui(self):
+        self.menu = ui.Scrolling_Menu('Log')
+        self.g_pool.gui.append(self.menu)
+
+        self.log_handler = Log_to_Callback(self.on_log)
+        logger = logging.getLogger()
+        logger.addHandler(self.log_handler)
+        self.log_handler.setLevel(logging.INFO)
+        self._update_gui()
+
+    def _update_gui(self):
+        self.menu.elements[:] = []
+        self.menu.append(ui.Button('Close',self.close))        
+        self.menu.append(ui.Info_Text(self.help_str))
+        
+        # show most recent log message at the top of the list
+        for record in self.log_messages[-1:-self.num_messages:-1]:
+            self.menu.append(ui.Info_Text("%s - %s" %(record.levelname, record.msg)))
+
+
+    def on_log(self,record):
+        self.log_messages.append(record)
+
+        if self.menu:
+            self._update_gui()
+            
+
+    def deinit_gui(self):
+        if self.menu:
+            self.g_pool.gui.remove(self.menu)
+            self.menu= None
+
+    def close(self):
+        self.alive = False
+
+    def cleanup(self):
+        """ called when the plugin gets terminated.
+        This happens either voluntarily or forced.
+        if you have a GUI or glfw window destroy it here.
+        """
+        self.deinit_gui()
+
+    def get_init_dict(self):
+        return {}


### PR DESCRIPTION
Proposing `log_history` plugin for Pupil Capture motivated by UX testing feedback from @nathakits, @DouglasMackay and conversations with other members in the Pupil community about the brevity of the log messages.

![screen shot 2016-05-06 at 11 12 45](https://cloud.githubusercontent.com/assets/1407224/15064145/84ac667e-137b-11e6-8705-fbc456832b8a.png)

This is a simple (convenience) plugin that shows the last 50 log messages as `Info_Text` within a separate GUI window (`Scrolling_Menu`). The most recent log message appears at the top. This plugin is motivated by feedback from UX tests and provides a way to review log messages in the case that they were not seen when they were rendered by `Log_Display`. Full logs are written to files, so this just provides a glimpse into the past instead of a full record.

Other enhancements to this plugin could include a timestamp for the log messages so that log messages are prepended with the timestamp -- but I was trying to keep this plugin very simple. 

Let me know what you think. 