### PR TITLE
[pupil_remote] Return more precise float representation of timestamp

### DIFF
--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -145,7 +145,7 @@ class Pupil_Remote(Plugin):
                 self.g_pool.timebase.value = raw_time-target
                 response = 'Timesync successful.'
         elif msg[0] == 't':
-            response = str(self.g_pool.capture.get_timestamp())
+            response = '%.5f' % self.g_pool.capture.get_timestamp()
         else:
             response = 'Unknown command.'
         socket.send(response)


### PR DESCRIPTION
Hi,
I noticed that the timestamp returned by `pupil_remote` is cut off after 2 decimal points due to the conversion to `string`. Using this change, 5 decimal points are used instead.