### PR TITLE
Switch from `json` to `msgpack` message serialisation

### DIFF
--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -125,7 +125,7 @@ class Plugin(object):
             adding 'delay':3.2 will delay the notification for 3.2s.
             If a new delayed notification of same subject is sent before 3.2s have passed we will discard the former notification
 
-            All notifications but be json serializable
+            All notifications must be serializable
 
             You may add more fields as you like.
 

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -36,7 +36,7 @@ class Pupil_Remote(Plugin):
         'SUB_PORT' return the current sub port of the IPC Backbone
 
     Mulitpart messages conforming to pattern:
-        part1: 'notify.' part2: serialized dict with at least  key 'subject':'my_notification_subject'
+        part1: 'notify.' part2: a msgpack serialized dict with at least key 'subject':'my_notification_subject'
         will be forwared to the Pupil IPC Backbone.
 
 

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -36,7 +36,7 @@ class Pupil_Remote(Plugin):
         'SUB_PORT' return the current sub port of the IPC Backbone
 
     Mulitpart messages conforming to pattern:
-        part1: 'notify.' part2: json encoded dict with at least  key 'subject':'my_notification_subject'
+        part1: 'notify.' part2: serialized dict with at least  key 'subject':'my_notification_subject'
         will be forwared to the Pupil IPC Backbone.
 
 
@@ -148,7 +148,7 @@ class Pupil_Remote(Plugin):
         msg = socket.recv()
         if msg.startswith('notify'):
             try:
-                payload = zmq_tools.json.loads(socket.recv(flags=zmq.NOBLOCK))
+                payload = zmq_tools.serializer.loads(socket.recv(flags=zmq.NOBLOCK))
                 payload['subject']
             except Exception as e:
                 response = 'Notification mal-formatted or missing: %s'%e

--- a/pupil_src/shared_modules/pupil_server.py
+++ b/pupil_src/shared_modules/pupil_server.py
@@ -13,7 +13,7 @@ from plugin import Plugin
 import numpy as np
 from pyglui import ui
 import zmq
-import json
+from zmq_tools import serializer
 
 
 import logging
@@ -75,7 +75,7 @@ class Pupil_Server(Plugin):
     def update(self,frame,events):
         for topic,data in events.iteritems():
             for d in data:
-                self.socket.send_multipart((topic, json.dumps(d)))
+                self.socket.send_multipart((topic, serializer.dumps(d)))
 
     def close(self):
         self.alive = False


### PR DESCRIPTION
Use `zmq_tools.serializer.dumps()` to encode and `.loads()` to decode messages. `zmq_tools.py` will be the central place to configure the serialization method.

@mkassner Please review.