### PR TITLE
zmq_tools extentions

### DIFF
--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -98,21 +98,8 @@ class Msg_Dispatcher(Msg_Streamer):
     Send messages on a push port.
     Not threadsave. Make a new one for each thread
     '''
-<<<<<<< HEAD
-    def __init__(self,ctx,url):
-        self.socket = zmq.Socket(ctx,zmq.PUSH)
-        self.socket.connect(url)
-
-    def send(self,topic,payload):
-        '''
-        send a generic message with topic, payload
-        '''
-        self.socket.send(str(topic),flags=zmq.SNDMORE)
-        self.socket.send(json.dumps(payload))
-=======
     def __init__(self,ctx,url,block_unitl_connected=True):
         super(Msg_Dispatcher, self).__init__(ctx,url,zmq.PUSH,block_unitl_connected)
->>>>>>> 65fae6f... Revision of zmq_tools
 
     def notify(self,notification):
         '''


### PR DESCRIPTION
These are changes I made during rewriting `Pupil Interface`.

Introduces `ZMQ_Actor` which unifies actor initialization and shutdown. Each actor has its own zmq socket. All actors inherit `ZMQ_Actor`. `Msg_Dispatcher` inherits `Msg_Streamer` but uses a `PUSH` instead of a `PUB` socket.

`Requester` acts as `Pupil Remote` client.

@mkassner Please review.