### PR TITLE
Problem: Pupil Sync is too complex

### DIFF
--- a/deployment/bundle.sh
+++ b/deployment/bundle.sh
@@ -1,0 +1,15 @@
+rm *.dmg
+rm *.deb
+cd deploy_capture
+./bundle.sh
+mv *.deb ../
+mv *.dmg ../
+cd ../deploy_service
+./bundle.sh
+mv *.deb ../
+mv *.dmg ../
+cd ../deploy_player
+./bundle.sh
+mv *.deb ../
+mv *.dmg ../
+cd ../

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -36,10 +36,11 @@ class Is_Alive_Manager(object):
 
 
 def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url,ipc_push_url, user_dir, version, eye_id, cap_src):
-    """
+    """reads eye video and detects the pupil.
+
     Creates a window, gl context.
     Grabs images from a capture.
-    Streams Pupil coordinates into g_pool.pupil_queue
+    Streams Pupil coordinates.
 
     Reacts to notifications:
        ``set_detection_mapping_mode``: Sets detection method

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -352,9 +352,9 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url,ipc_push_url, user_dir
                         writer = None
                         np.save(timestamps_path,np.asarray(timestamps))
                         del timestamps
-                elif subject.startswith('notification.should_doc'):
+                elif subject.startswith('meta.should_doc'):
                     ipc_socket.notify({
-                        'subject':'notification.doc',
+                        'subject':'meta.doc',
                         'actor':'eye%i'%eye_id,
                         'doc':eye.__doc__
                         })

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -76,12 +76,14 @@ eye1_src = ["Pupil Cam1 ID1","HD-6000","Integrated Camera"]
 
 video_sources = {'world':world_src,'eye0':eye0_src,'eye1':eye1_src}
 
-def main():
-    """
+def launcher():
+    """Starts eye processes. Hosts the IPC Backbone and Logging functions.
+
     Reacts to notifications:
        ``launcher_process.should_stop``: Stops the launcher process
        ``eye_process.should_start``: Starts the eye process
     """
+
     ## IPC
     #shared values
     timebase = Value(c_double,0)
@@ -246,11 +248,11 @@ def main():
         elif "notify.notification.should_doc" in topic:
             cmd_push.notify({
                 'subject':'notification.doc',
-                'actor':'main',
-                'doc':main.__doc__})
+                'actor':'launcher',
+                'doc':launcher.__doc__})
 
     for p in active_children(): p.join()
 
 if __name__ == '__main__':
     freeze_support()
-    main()
+    launcher()

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -85,68 +85,43 @@ def launcher():
     """
 
 
-    #We use a zmq forwarder and the zmq PUBSUB pattern to do all our IPC.
-    def ipc_backbone(ipc_urls):
+    #Reliable msg dispatch to the IPC via push bridge.
+    def pull_pub(ipc_pub_url,pull):
         ctx = zmq.Context.instance()
-        xsub = ctx.socket(zmq.XSUB)
-        xsub.bind(ipc_urls['pub'])
-        url = xsub.last_endpoint.decode('ascii', 'replace')
-        ipc_urls['pub'] = url.replace("0.0.0.0","127.0.0.1")
-
-        xpub = ctx.socket(zmq.XPUB)
-        xpub.bind(ipc_urls['sub'])
-        url = xpub.last_endpoint.decode('ascii', 'replace')
-        ipc_urls['sub'] = url.replace("0.0.0.0","127.0.0.1")
-
-        try:
-            zmq.proxy(xsub, xpub)
-        except zmq.ContextTerminated:
-            xsub.close()
-            xpub.close()
-
-    #reliable msg dispatch to the IPC via push bridge
-    def pull_pub(ipc_urls):
-        ctx = zmq.Context.instance()
-        pull = ctx.socket(zmq.PULL)
-        pull.bind(ipc_urls['push'])
-        url = pull.last_endpoint.decode('ascii', 'replace')
-        ipc_urls['push'] = url.replace("0.0.0.0","127.0.0.1")
-
         pub = ctx.socket(zmq.PUB)
-        pub.connect(ipc_urls['pub'])
+        pub.connect(ipc_pub_url)
 
         while True:
             m = pull.recv_multipart()
             pub.send_multipart(m)
 
+
     #The delay proxy handles delayed notififications.
-    def delay_proxy(ipc_urls):
+    def delay_proxy(ipc_pub_url,ipc_sub_url):
         ctx = zmq.Context.instance()
-        sub = zmq_tools.Msg_Receiver(ctx,ipc_urls['sub'],('delayed_notify',))
-        pub = zmq_tools.Msg_Dispatcher(ctx,ipc_urls['push'])
+        sub = zmq_tools.Msg_Receiver(ctx,ipc_sub_url,('delayed_notify',))
+        pub = zmq_tools.Msg_Dispatcher(ctx,ipc_pub_url)
         poller = zmq.Poller()
         poller.register(sub.socket, zmq.POLLIN)
         waiting_notifications = {}
-        try:
-            while True:
-                if poller.poll(timeout=250):
-                    #Recv new delayed notification and store it.
-                    topic,n = sub.recv()
-                    n['_notify_time_'] = time()+n['delay']
-                    waiting_notifications[n['subject']] = n
-                #When a notifications time has come, pop from dict and send it as notification
-                for n in waiting_notifications.values():
-                    if n['_notify_time_'] < time():
-                        del n['_notify_time_']
-                        del n['delay']
-                        del waiting_notifications[n['subject']]
-                        pub.notify(n)
-        except zmq.ContextTerminated:
-            sub.close()
-            pub.close()
 
-    #recv log records from other processes.
-    def log_loop(ipc_urls,log_level_debug):
+        while True:
+            if poller.poll(timeout=250):
+                #Recv new delayed notification and store it.
+                topic,n = sub.recv()
+                n['_notify_time_'] = time()+n['delay']
+                waiting_notifications[n['subject']] = n
+            #When a notifications time has come, pop from dict and send it as notification
+            for n in waiting_notifications.values():
+                if n['_notify_time_'] < time():
+                    del n['_notify_time_']
+                    del n['delay']
+                    del waiting_notifications[n['subject']]
+                    pub.notify(n)
+
+
+    #Recv log records from other processes.
+    def log_loop(ipc_sub_url,log_level_debug):
         import logging
         #Get the root logger
         logger = logging.getLogger()
@@ -164,7 +139,7 @@ def launcher():
         ch.setFormatter(logging.Formatter('%(processName)s - [%(levelname)s] %(name)s: %(message)s'))
         logger.addHandler(ch)
         # IPC setup to receive log messages. Use zmq_tools.ZMQ_handler to send messages to here.
-        sub = zmq_tools.Msg_Receiver(zmq_ctx,ipc_urls['sub'],topics=("logging",))
+        sub = zmq_tools.Msg_Receiver(zmq_ctx,ipc_sub_url,topics=("logging",))
         while True:
             topic,msg = sub.recv()
             record = logging.makeLogRecord(msg)
@@ -174,36 +149,51 @@ def launcher():
     ## IPC
     timebase = Value(c_double,0)
     eyes_are_alive = Value(c_bool,0),Value(c_bool,0)
+
     zmq_ctx = zmq.Context()
 
-    #ipc urls are assinged by the OS`
-    ipc_urls = {'pub':'tcp://*:*','sub':'tcp://*:*','push':'tcp://*:*'}
+    #Let the OS choose the IP and PORT
+    ipc_pub_url = 'tcp://*:*'
+    ipc_sub_url = 'tcp://*:*'
+    ipc_push_url = 'tcp://*:*'
 
-    ipc_backbone_thread = Thread(target=ipc_backbone, args=(ipc_urls,))
+    # Binding IPC Backbone Sockets to URLs.
+    # They are only used in the threads started below.
+    xsub_socket = zmq_ctx.socket(zmq.XSUB)
+    xsub_socket.bind(ipc_pub_url)
+    url = xsub_socket.last_endpoint.decode('ascii', 'replace')
+    ipc_pub_url = url.replace("0.0.0.0","127.0.0.1")
+
+    xpub_socket = zmq_ctx.socket(zmq.XPUB)
+    xpub_socket.bind(ipc_sub_url)
+    url = xpub_socket.last_endpoint.decode('ascii', 'replace')
+    ipc_sub_url = url.replace("0.0.0.0","127.0.0.1")
+
+    pull_socket = zmq_ctx.socket(zmq.PULL)
+    pull_socket.bind(ipc_push_url)
+    url = pull_socket.last_endpoint.decode('ascii', 'replace')
+    ipc_push_url = url.replace("0.0.0.0","127.0.0.1")
+
+
+    # Starting communication threads:
+    # A ZMQ Proxy Device serves as our IPC Backbone
+    ipc_backbone_thread = Thread(target=zmq.proxy, args=(xsub_socket,xpub_socket))
     ipc_backbone_thread.setDaemon(True)
     ipc_backbone_thread.start()
-    while ipc_urls['sub'][-1] == '*':
-        print 'waiting for pub and sub port to bind'
-        sleep(0.01)
 
-    pull_pub = Thread(target=pull_pub, args=(ipc_urls,))
+    pull_pub = Thread(target=pull_pub, args=(ipc_pub_url,pull_socket))
     pull_pub.setDaemon(True)
     pull_pub.start()
-    while ipc_urls['push'][-1] == '*':
-        print 'waiting for push port to bind'
-        sleep(0.01)
 
-    log_thread = Thread(target=log_loop, args=(ipc_urls,'debug'in sys.argv))
+    log_thread = Thread(target=log_loop, args=(ipc_sub_url,'debug'in sys.argv))
     log_thread.setDaemon(True)
     log_thread.start()
 
-    delay_thread = Thread(target=delay_proxy, args=(ipc_urls,))
+    delay_thread = Thread(target=delay_proxy, args=(ipc_push_url,ipc_sub_url))
     delay_thread.setDaemon(True)
     delay_thread.start()
 
-    ipc_pub_url = ipc_urls['pub']
-    ipc_sub_url = ipc_urls['sub']
-    ipc_push_url = ipc_urls['push']
+    del xsub_socket,xpub_socket,pull_socket
 
 
     topics = (  'notify.eye_process.',
@@ -234,7 +224,6 @@ def launcher():
                             user_dir,
                             app_version,
                             video_sources['world'] )).start()
-
 
 
     while True:

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -8,7 +8,7 @@
 ----------------------------------------------------------------------------------~(*)
 '''
 
-import os, sys, platform
+import os, sys, platform, time
 
 # sys.argv.append('profiled')
 # sys.argv.append('debug')
@@ -87,7 +87,6 @@ def launcher():
 
     #We use a zmq forwarder and the zmq PUBSUB pattern to do all our IPC.
     def ipc_backbone(ipc_urls):
-
         ctx = zmq.Context.instance()
         xsub = ctx.socket(zmq.XSUB)
         xsub.bind(ipc_urls['pub'])
@@ -173,7 +172,6 @@ def launcher():
 
 
     ## IPC
-
     timebase = Value(c_double,0)
     eyes_are_alive = Value(c_bool,0),Value(c_bool,0)
     zmq_ctx = zmq.Context()
@@ -186,13 +184,14 @@ def launcher():
     ipc_backbone_thread.start()
     while ipc_urls['sub'][-1] == '*':
         print 'waiting for pub and sub port to bind'
-
+        time.sleep(0.01)
 
     pull_pub = Thread(target=pull_pub, args=(ipc_urls,))
     pull_pub.setDaemon(True)
     pull_pub.start()
     while ipc_urls['push'][-1] == '*':
         print 'waiting for push port to bind'
+        time.sleep(0.01)
 
     log_thread = Thread(target=log_loop, args=(ipc_urls,'debug'in sys.argv))
     log_thread.setDaemon(True)

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -8,7 +8,7 @@
 ----------------------------------------------------------------------------------~(*)
 '''
 
-import os, sys, platform, time
+import os, sys, platform
 
 # sys.argv.append('profiled')
 # sys.argv.append('debug')
@@ -49,7 +49,7 @@ import zmq
 import zmq_tools
 
 #time
-from time import time
+from time import time,sleep
 
 #functions to run in seperate processes
 if 'profiled' in sys.argv:
@@ -184,14 +184,14 @@ def launcher():
     ipc_backbone_thread.start()
     while ipc_urls['sub'][-1] == '*':
         print 'waiting for pub and sub port to bind'
-        time.sleep(0.01)
+        sleep(0.01)
 
     pull_pub = Thread(target=pull_pub, args=(ipc_urls,))
     pull_pub.setDaemon(True)
     pull_pub.start()
     while ipc_urls['push'][-1] == '*':
         print 'waiting for push port to bind'
-        time.sleep(0.01)
+        sleep(0.01)
 
     log_thread = Thread(target=log_loop, args=(ipc_urls,'debug'in sys.argv))
     log_thread.setDaemon(True)

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -197,7 +197,7 @@ def launcher():
 
     topics = (  'notify.eye_process.',
                 'notify.launcher_process.',
-                'notify.notification.should_doc')
+                'notify.meta.should_doc')
     cmd_sub = zmq_tools.Msg_Receiver(zmq_ctx,ipc_sub_url,topics=topics )
     cmd_push = zmq_tools.Msg_Dispatcher(zmq_ctx,ipc_push_url)
 
@@ -245,9 +245,9 @@ def launcher():
                                 video_sources['eye%s'%eye_id] )).start()
         elif "notify.launcher_process.should_stop" in topic:
             break
-        elif "notify.notification.should_doc" in topic:
+        elif "notify.meta.should_doc" in topic:
             cmd_push.notify({
-                'subject':'notification.doc',
+                'subject':'meta.doc',
                 'actor':'launcher',
                 'doc':launcher.__doc__})
 

--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -188,10 +188,16 @@ class Recorder(Plugin):
             self.data['notifications'].append(notification)
 
 
+<<<<<<< b2e1149320a7cfca8b0466d6762848a8a59b5d61
         elif notification['subject'] == 'recording.should_start':
+=======
+        # Remote has started recording, we should start as well.
+        elif notification['subject'] == 'rec_should_start':
+>>>>>>> Implement 'rec_should_start'/'rec_should_stop' notifications
             if self.running:
                 logger.info('Recording already running!')
             else:
+<<<<<<< b2e1149320a7cfca8b0466d6762848a8a59b5d61
                 if notification.get("session_name",""):
                     self.set_session_name(notification["session_name"])
                 self.start()
@@ -199,6 +205,14 @@ class Recorder(Plugin):
         elif notification['subject'] == 'recording.should_stop':
             if self.running:
                 self.stop()
+=======
+                self.set_session_name(notification["session_name"])
+                self.start(network_propagate=True)
+        # Remote has stopped recording, we should stop as well.
+        elif notification['subject'] == 'rec_should_stop':
+            if self.running:
+                self.stop(network_propagate=True)
+>>>>>>> Implement 'rec_should_start'/'rec_should_stop' notifications
             else:
                 logger.info('Recording already stopped!')
 

--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -188,16 +188,10 @@ class Recorder(Plugin):
             self.data['notifications'].append(notification)
 
 
-<<<<<<< b2e1149320a7cfca8b0466d6762848a8a59b5d61
         elif notification['subject'] == 'recording.should_start':
-=======
-        # Remote has started recording, we should start as well.
-        elif notification['subject'] == 'rec_should_start':
->>>>>>> Implement 'rec_should_start'/'rec_should_stop' notifications
             if self.running:
                 logger.info('Recording already running!')
             else:
-<<<<<<< b2e1149320a7cfca8b0466d6762848a8a59b5d61
                 if notification.get("session_name",""):
                     self.set_session_name(notification["session_name"])
                 self.start()
@@ -205,14 +199,6 @@ class Recorder(Plugin):
         elif notification['subject'] == 'recording.should_stop':
             if self.running:
                 self.stop()
-=======
-                self.set_session_name(notification["session_name"])
-                self.start(network_propagate=True)
-        # Remote has stopped recording, we should stop as well.
-        elif notification['subject'] == 'rec_should_stop':
-            if self.running:
-                self.stop(network_propagate=True)
->>>>>>> Implement 'rec_should_start'/'rec_should_stop' notifications
             else:
                 logger.info('Recording already stopped!')
 

--- a/pupil_src/capture/service.py
+++ b/pupil_src/capture/service.py
@@ -158,15 +158,15 @@ def service(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_di
             ipc_pub.notify(n)
         elif subject == 'service_process.should_stop':
             g_pool.service_should_run = False
-        elif subject.startswith('notification.should_doc'):
+        elif subject.startswith('meta.should_doc'):
             ipc_pub.notify({
-                'subject':'notification.doc',
+                'subject':'meta.doc',
                 'actor':g_pool.app,
                 'doc':service.__doc__})
             for p in g_pool.plugins:
                 if p.on_notify.__doc__ and p.__class__.on_notify != Plugin.on_notify:
                     ipc_pub.notify({
-                        'subject':'notification.doc',
+                        'subject':'meta.doc',
                         'actor': p.class_name,
                         'doc':p.on_notify.__doc__})
 

--- a/pupil_src/capture/service.py
+++ b/pupil_src/capture/service.py
@@ -83,6 +83,7 @@ def service(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_di
     from calibration_routines import calibration_plugins, gaze_mapping_plugins
     from pupil_sync import Pupil_Sync
     from pupil_remote import Pupil_Remote
+    from discovery import Discovery
 
     logger.info('Application Version: %s'%version)
     logger.info('System Info: %s'%get_system_info())
@@ -107,11 +108,11 @@ def service(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_di
 
     #manage plugins
     runtime_plugins = import_runtime_plugins(os.path.join(g_pool.user_dir,'plugins'))
-    user_launchable_plugins = [Pupil_Remote,Pupil_Sync]+runtime_plugins
+    user_launchable_plugins = [Discovery,Pupil_Remote,Pupil_Sync]+runtime_plugins
     plugin_by_index =  runtime_plugins+calibration_plugins+gaze_mapping_plugins+user_launchable_plugins
     name_by_index = [p.__name__ for p in plugin_by_index]
     plugin_by_name = dict(zip(name_by_index,plugin_by_index))
-    default_plugins = [('Dummy_Gaze_Mapper',{}),('HMD_Calibration',{}),('Pupil_Remote',{})]
+    default_plugins = [('Dummy_Gaze_Mapper',{}),('HMD_Calibration',{}),('Pupil_Remote',{}),('Discovery',{})]
 
 
     tick = delta_t()

--- a/pupil_src/capture/service.py
+++ b/pupil_src/capture/service.py
@@ -13,9 +13,7 @@ class Global_Container(object):
     pass
 
 def service(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,cap_src):
-    """service
-    Maps pupil to gaze data
-    Can run various plug-ins.
+    """Maps pupil to gaze data, can run various plug-ins.
 
     Reacts to notifications:
        ``set_detection_mapping_mode``: Sets detection method

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -14,7 +14,8 @@ class Global_Container(object):
     pass
 
 def world(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,cap_src):
-    """world
+    """Reads world video and runs plugins.
+
     Creates a window, gl context.
     Grabs images from a capture.
     Maps pupil to gaze data

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -252,15 +252,15 @@ def world(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,
         elif subject == 'eye_process.started':
             n = {'subject':'set_detection_mapping_mode','mode':g_pool.detection_mapping_mode}
             ipc_pub.notify(n)
-        elif subject.startswith('notification.should_doc'):
+        elif subject.startswith('meta.should_doc'):
             ipc_pub.notify({
-                'subject':'notification.doc',
+                'subject':'meta.doc',
                 'actor':g_pool.app,
                 'doc':world.__doc__})
             for p in g_pool.plugins:
                 if p.on_notify.__doc__ and p.__class__.on_notify != Plugin.on_notify:
                     ipc_pub.notify({
-                        'subject':'notification.doc',
+                        'subject':'meta.doc',
                         'actor': p.class_name,
                         'doc':p.on_notify.__doc__})
 

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -98,6 +98,7 @@ def world(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,
     from display_recent_gaze import Display_Recent_Gaze
     from pupil_sync import Pupil_Sync
     from pupil_remote import Pupil_Remote
+    from discovery import Discovery
     from surface_tracker import Surface_Tracker
     from log_display import Log_Display
     from annotations import Annotation_Capture
@@ -138,12 +139,12 @@ def world(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,
 
     #manage plugins
     runtime_plugins = import_runtime_plugins(os.path.join(g_pool.user_dir,'plugins'))
-    user_launchable_plugins = [Show_Calibration,Pupil_Remote,Pupil_Sync,Surface_Tracker,Annotation_Capture,Log_History]+runtime_plugins
+    user_launchable_plugins = [Show_Calibration,Discovery, Pupil_Remote,Pupil_Sync,Surface_Tracker,Annotation_Capture,Log_History]+runtime_plugins
     system_plugins  = [Log_Display,Display_Recent_Gaze,Recorder]
     plugin_by_index =  system_plugins+user_launchable_plugins+calibration_plugins+gaze_mapping_plugins
     name_by_index = [p.__name__ for p in plugin_by_index]
     plugin_by_name = dict(zip(name_by_index,plugin_by_index))
-    default_plugins = [('Log_Display',{}),('Dummy_Gaze_Mapper',{}),('Display_Recent_Gaze',{}), ('Screen_Marker_Calibration',{}),('Recorder',{}),('Pupil_Remote',{})]
+    default_plugins = [('Log_Display',{}),('Dummy_Gaze_Mapper',{}),('Display_Recent_Gaze',{}), ('Screen_Marker_Calibration',{}),('Recorder',{}),('Pupil_Remote',{}),('Discovery',{})]
 
 
     # Callback functions

--- a/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
+++ b/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
@@ -12,7 +12,8 @@ class Calibration_Plugin(Plugin):
         self.active = False
 
     def on_notify(self,notification):
-        '''
+        '''Handles calibration notifications
+
         Reacts to notifications:
            ``calibration.should_start``: Starts the calibration procedure
            ``calibration.should_stop``: Stops the calibration procedure

--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -45,7 +45,8 @@ class HMD_Calibration(Calibration_Plugin):
 
 
     def on_notify(self,notification):
-        '''
+        '''Calibrates user gaze for HMDs
+
         Reacts to notifications:
            ``calibration.should_start``: Starts the calibration procedure
            ``calibration.should_stop``:  Stops the calibration procedure

--- a/pupil_src/shared_modules/discovery.py
+++ b/pupil_src/shared_modules/discovery.py
@@ -1,0 +1,164 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2016  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the file license.txt, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
+
+import zmq, time
+from pyre import Pyre, PyreEvent, zhelper
+from plugin import Plugin
+from zmq_tools import Msg_Dispatcher, Msg_Receiver
+import msgpack as serializer
+
+import logging
+logger = logging.getLogger(__name__)
+
+class Discovery(Plugin):
+    """Plugin for local network discovery
+
+    Uses Pyre for local service discovery.
+    """
+    def __init__(self, g_pool, name=None, groups=["pupil-discovery"]):
+        super(Discovery, self).__init__(g_pool)
+        self._name = name
+        self._groups = groups
+        self.thread_pipe = None
+        self.start_discovery()
+
+
+    def start_discovery(self):
+        if self.thread_pipe:
+            self.stop_discovery()
+        logger.debug('Starting discovery...')
+        self.thread_pipe = zhelper.zthread_fork(self.g_pool.zmq_ctx, self._thread_loop)
+
+    def stop_discovery(self):
+        logging.debug('Stopping discovery...')
+        self.thread_pipe.send('$TERM')
+        while self.thread_pipe:
+            time.sleep(.1)
+        logger.info('Discovery stopped.')
+
+    def get_init_dict(self):
+        return {}
+
+    def cleanup(self):
+        self.stop_discovery()
+
+    @property
+    def default_headers(self):
+        # TODO: look up request port
+        return [
+            ('sub_address', self.g_pool.ipc_sub_url),
+            ('pub_address', self.g_pool.ipc_pub_url),
+            ('app_type', self.g_pool.app)
+        ]
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def groups(self):
+        return self._groups
+
+    # @groups.setter
+    # def groups(self,group_list):
+    #     self._groups
+
+    # ---------------------------------------------------------------
+    # Background functions
+
+    def _thread_loop(self,context,pipe):
+        # setup sockets
+        local_in  = Msg_Receiver(context, self.g_pool.ipc_sub_url, topics=('notify.',))
+        local_out = Msg_Dispatcher(context, self.g_pool.ipc_sub_url)
+        discovery = self._setup_discovery_node()
+        discovery.start()
+
+        # register sockets for polling
+        poller = zmq.Poller()
+        poller.register(pipe,zmq.POLLIN)
+        poller.register(local_in.socket,zmq.POLLIN)
+        poller.register(discovery.socket(),zmq.POLLIN)
+
+        logger.info('Discovery started.')
+
+        # Poll loop
+        while True:
+            # Wait for next readable item
+            readable = dict(poller.poll())
+
+            # shout or whisper marked notifications
+            if local_in in readable:
+                topic, notification = local_in.recv()
+
+                # check if notification should be shouted
+                shout_key = 'discovery.shout'
+                if shout_key in notification:
+                    group = notification[shout_key]
+                    del notification[shout_key]
+                    serialized = serializer.dumps(notification)
+                    discovery.shout(group,serialized)
+
+                # check if notification should be whispered
+                whisper_key = 'discovery.whisper'
+                if whisper_key in notification:
+                    peer_uuid = notification[whisper_key]
+                    del notification[whisper_key]
+                    serialized = serializer.dumps(notification)
+                    discovery.whisper(peer_uuid,serialized)
+
+            if discovery.socket() in readable:
+                event = PyreEvent(discovery)
+                if event.msg:
+                    for msg in event.msg:
+                        try:
+                            # try to unpack data
+                            notification = serializer.loads(msg)
+                            # test if dictionary and if `subject` key is present
+                            notification['subject']
+                            # add peer information
+                            notification['discovery.peer'] = {
+                                'uuid': event.peer_uuid,
+                                'name': event.peer_name,
+                                'arrival_timestamp': time.time(),
+                                'type': event.type
+                            }
+                            # add group name if notification was shouted
+                            if event.type == 'SHOUT':
+                                notification['discovery.peer'].update({'group': event.group})
+                            local_out.notify(notification)
+                        except Exception:
+                            logger.info('Dropped garbage data by peer %s (%s)'%(event.peer_name, event.peer_uuid))
+                            pass
+
+            if pipe in readable:
+                command = pipe.recv()
+                if command == '$TERM':
+                    break
+
+        del local_in
+        del local_out
+        self._shutdown_discovery_node(discovery)
+        self.thread_pipe = None
+
+
+    def _setup_discovery_node(self):
+        node = Pyre(self.name)
+        # set headers
+        for header in self.default_headers:
+            node.set_header(*header)
+        # join groups
+        for group in self.groups:
+            node.join(group)
+        return node
+
+    def _shutdown_discovery_node(self,node):
+        for group in self.groups:
+            node.leave(group)
+        node.stop()

--- a/pupil_src/shared_modules/discovery.py
+++ b/pupil_src/shared_modules/discovery.py
@@ -8,8 +8,9 @@
 ----------------------------------------------------------------------------------~(*)
 '''
 
-import zmq, time
+import zmq, time, uuid
 from pyre import Pyre, PyreEvent, zhelper
+from pyglui import ui
 from plugin import Plugin
 from zmq_tools import Msg_Dispatcher, Msg_Receiver
 import msgpack as serializer
@@ -22,12 +23,22 @@ class Discovery(Plugin):
 
     Uses Pyre for local service discovery.
     """
-    def __init__(self, g_pool, name=None, groups=["pupil-discovery"]):
+    def __init__(self, g_pool, name="Unnamed Discovery Node", active_group="pupil-discovery"):
         super(Discovery, self).__init__(g_pool)
         self._name = name
-        self._groups = groups
+        self._active_group = active_group
         self.thread_pipe = None
         self.start_discovery()
+
+    def init_gui(self):
+        help_str = "Uses the ZeroMQ Realtime Exchange Protocol to discover other local network members."
+        self.menu = ui.Growing_Menu('Discovery')
+        self.menu.append(ui.Button('Close',self.close))
+        self.menu.append(ui.Button('Test',self.test))
+        self.menu.append(ui.Info_Text(help_str))
+        self.menu.append(ui.Text_Input('name',self,label='Name:'))
+        self.menu.append(ui.Text_Input('active_group',self,label='Group:'))
+        self.g_pool.sidebar.append(self.menu)
 
 
     def start_discovery(self):
@@ -43,28 +54,77 @@ class Discovery(Plugin):
             time.sleep(.1)
         logger.info('Discovery stopped.')
 
+    def on_notify(self,notification):
+        if notification['subject'].startswith('discovery.name_should_change'):
+            self.name = notification['name']
+        elif notification['subject'].startswith('discovery.active_group_should_change'):
+            self.active_group = notification['name']
+        elif notification['subject'].startswith('discovery.ping') and 'discovery.peer' in notification:
+            peer = notification['discovery.peer']
+            self.notify_all({
+                'subject': 'discovery.pong',
+                't1': notification['t1'],
+                't2': self.g_pool.get_timestamp(),
+                'remote_notify': peer['uuid']
+            })
+        elif notification['subject'].startswith('discovery.pong') and 'discovery.peer' in notification:
+            peer = notification['discovery.peer']
+            logger.debug(
+                '%s took %s seconds to answer.'%(
+                    peer['name'],
+                    float(notification['t2'])-
+                    float(notification['t1']))
+            )
+
+
+    def close(self):
+        self.alive = False
+
     def get_init_dict(self):
-        return {}
+        return {'name':self.name, 'active_group': self.active_group}
 
     def cleanup(self):
+        if self.menu:
+            self.g_pool.sidebar.remove(self.menu)
+            self.menu = None
         self.stop_discovery()
 
     @property
     def default_headers(self):
-        # TODO: look up request port
         return [
             ('sub_address', self.g_pool.ipc_sub_url),
             ('pub_address', self.g_pool.ipc_pub_url),
             ('app_type', self.g_pool.app)
         ]
 
+    def test(self):
+        self.notify_all({
+            'subject': 'discovery.ping',
+            't1': self.g_pool.get_timestamp(),
+            'remote_notify': 'all'
+        })
+
     @property
     def name(self):
         return self._name
 
+    @name.setter
+    def name(self,value):
+        self.thread_pipe.send('$NAME')
+        self.thread_pipe.send(value)
+        self._name = value
+
     @property
-    def groups(self):
-        return self._groups
+    def active_group(self):
+        return self._active_group
+
+    @active_group.setter
+    def active_group(self,value):
+        self.thread_pipe.send('$GROUP')
+        self.thread_pipe.send(self._active_group)
+        self.thread_pipe.send(value)
+        self._active_group = value
+
 
     # @groups.setter
     # def groups(self,group_list):
@@ -75,10 +135,9 @@ class Discovery(Plugin):
 
     def _thread_loop(self,context,pipe):
         # setup sockets
-        local_in  = Msg_Receiver(context, self.g_pool.ipc_sub_url, topics=('notify.',))
+        local_in  = Msg_Receiver(context, self.g_pool.ipc_sub_url, topics=('remote_notify.',))
         local_out = Msg_Dispatcher(context, self.g_pool.ipc_sub_url)
         discovery = self._setup_discovery_node()
-        discovery.start()
 
         # register sockets for polling
         poller = zmq.Poller()
@@ -97,18 +156,13 @@ class Discovery(Plugin):
             if local_in in readable:
                 topic, notification = local_in.recv()
 
-                # check if notification should be shouted
-                shout_key = 'discovery.shout'
-                if shout_key in notification:
-                    group = notification[shout_key]
-                    del notification[shout_key]
+                remote_key = 'remote_notify'
+                if notification[remote_key] == 'all':
+                    del notification[remote_key]
                     serialized = serializer.dumps(notification)
-                    discovery.shout(group,serialized)
-
-                # check if notification should be whispered
-                whisper_key = 'discovery.whisper'
-                if whisper_key in notification:
-                    peer_uuid = notification[whisper_key]
+                    discovery.shout(self.active_group,serialized)
+                else:
+                    peer_uuid = notification[remote_key]
                     del notification[whisper_key]
                     serialized = serializer.dumps(notification)
                     discovery.whisper(peer_uuid,serialized)
@@ -126,12 +180,9 @@ class Discovery(Plugin):
                             notification['discovery.peer'] = {
                                 'uuid': event.peer_uuid,
                                 'name': event.peer_name,
-                                'arrival_timestamp': time.time(),
+                                'arrival_timestamp': self.g_pool.get_timestamp(),
                                 'type': event.type
                             }
-                            # add group name if notification was shouted
-                            if event.type == 'SHOUT':
-                                notification['discovery.peer'].update({'group': event.group})
                             local_out.notify(notification)
                         except Exception:
                             logger.info('Dropped garbage data by peer %s (%s)'%(event.peer_name, event.peer_uuid))
@@ -139,7 +190,19 @@ class Discovery(Plugin):
 
             if pipe in readable:
                 command = pipe.recv()
-                if command == '$TERM':
+                if command == '$NAME':
+                    # Restart discovery node to change name
+                    poller.unregister(discovery.socket())
+                    self._shutdown_discovery_node(discovery)
+                    discovery = self._setup_discovery_node()
+                    poller.register(discovery.socket(),zmq.POLLIN)
+                elif command == '$GROUP':
+                    # Leave old group. Join new group.
+                    old_group = pipe.recv()
+                    new_group = pipe.recv()
+                    discovery.leave(old_group)
+                    discovery.join(new_group)
+                elif command == '$TERM':
                     break
 
         del local_in
@@ -148,17 +211,19 @@ class Discovery(Plugin):
         self.thread_pipe = None
 
 
-    def _setup_discovery_node(self):
+    def _setup_discovery_node(self,start_node=True):
         node = Pyre(self.name)
         # set headers
         for header in self.default_headers:
             node.set_header(*header)
-        # join groups
-        for group in self.groups:
-            node.join(group)
+        # join active group
+        node.join(self.active_group)
+
+        # start node
+        if start_node:
+            node.start()
         return node
 
     def _shutdown_discovery_node(self,node):
-        for group in self.groups:
-            node.leave(group)
+        node.leave(self.active_group)
         node.stop()

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -190,27 +190,14 @@ class Pupil_Remote(Plugin):
         socket.send(response)
 
     def on_notify(self,notification):
-        """
-        Send simple string messages to control Pupil Capture functions:
-            'R' start recording with auto generated session name
-            'R rec_name' start recording and name new session name: rec_name
-            'r' stop recording
-            'C' start currently selected calibration
-            'c' stop currently selected calibration
-            'T 1234.56' Timesync: make timestamps count form 1234.56 from now on.
-            't' get pupil capture timestamp returns a float as string.
-
-
-            #IPC Backbone communication
-            'PUB_PORT' return the current pub port of the IPC Backbone
-            'SUB_PORT' return the current sub port of the IPC Backbone
+        """send simple string messages to control application functions.
 
         Emits notifications:
             ``recording.should_start``
             ``recording.should_stop``
             ``calibration.should_start``
             ``calibration.should_stop``
-            Any other notification received
+            Any other notification received though the reqrepl port.
         """
         pass
 

--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     print requester.recv()
     requester.send_multipart(('notify.service_process.should_stop',serializer.dumps({'subject':'service_process.should_stop'})))
     print requester.recv()
-    requester.send_multipart(('notify.notification.should_doc',serializer.dumps({'subject':'notification.should_doc'})))
+    requester.send_multipart(('notify.meta.should_doc',serializer.dumps({'subject':'meta.should_doc'})))
     print requester.recv()
     # listen to all notifications.
     while True:

--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
     # gaze_monitor = Msg_Receiver(ctx,'tcp://localhost:%s'%ipc_sub_port,topics=('gaze.',))
 
     #you can also publish to the IPC Backbone directly.
-    publisher = Msg_Dispatcher(ctx,'tcp://localhost:%s'%ipc_pub_port)
+    publisher = Msg_Streamer(ctx,'tcp://localhost:%s'%ipc_pub_port)
 
     def roundtrip_latency_reqrep():
         ts = []
@@ -177,10 +177,14 @@ if __name__ == '__main__':
     # now lets get the current pupil time.
     requester.send('t')
     print requester.recv()
-
+    requester.send_multipart(('notify.service_process.should_stop',serializer.dumps({'subject':'service_process.should_stop'})))
+    print requester.recv()
+    requester.send_multipart(('notify.notification.should_doc',serializer.dumps({'subject':'notification.should_doc'})))
+    print requester.recv()
     # listen to all notifications.
     while True:
-        print notification_monitor.recv()
+        topic,msg = notification_monitor.recv()
+        print '%s: %s' %(msg.get('actor'), msg.get('doc'))
 
     # # listen to all log messages.
     # while True:


### PR DESCRIPTION
Solution: Split discovery and time sync features into different plugins.

- [x] Discovery implementation
- [ ] Discovery UI
- [ ] Time Sync implementation
- [ ] Time Sync UI

**`discovery.py` documentation:**
- Creates `Pyre` node with following headers:
    - "pub_address"
    - "sub_address"
    - "app_type"
- Joins "pupil-discovery" group by default.
- Shouts all notifications with the key "discovery.shout"
    - Notifications will be serialized with msgpack
- Whispers all notifications with the key "discovery.whisper"
    - Notifications will be serialized with msgpack
- Publishes all discovered notifications to the IPC backbone
    - Drops notifications which cannot be unpacked with msgpack
        or do not have "subject" key
    - Adds "discovery.peer" key with dictionary containing information:
        - "uuid": peer uuid
        - "name": peer name
        - "arrival_timestamp": time of arrival
        - "type": "SHOUT" or "WHISPER"
        - ["group": source group] if "type" equals "SHOUT"