### PR TITLE
fix remote_plugin response sending

### DIFF
--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -187,7 +187,7 @@ class Pupil_Remote(Plugin):
             response = repr(self.g_pool.get_timestamp())
         else:
             response = 'Unknown command.'
-        socket.send(response)
+        socket.send_unicode(response)
 
     def on_notify(self,notification):
         """send simple string messages to control application functions.


### PR DESCRIPTION
When you just use socket.send(...) you get an type error.
So use socket.send_unicode(...).

The error:
TypeError: unicode not allowed, use send_string