### PR TITLE
Add new gaze_mapper for hmd

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/__init__.py
@@ -17,7 +17,7 @@ from camera_intrinsics_estimation import Camera_Intrinsics_Estimation
 from adjust_calibration import Adjust_Calibration
 from accuracy_test import Accuracy_Test
 from hmd_calibration import HMD_Calibration
-from gaze_mappers import Dummy_Gaze_Mapper, Monocular_Gaze_Mapper, Binocular_Gaze_Mapper,Vector_Gaze_Mapper,Binocular_Vector_Gaze_Mapper,Dual_Monocular_Gaze_Mapper
+from gaze_mappers import Dummy_Gaze_Mapper, Monocular_Gaze_Mapper, Binocular_Gaze_Mapper,Vector_Gaze_Mapper,Binocular_Vector_Gaze_Mapper,Dual_Monocular_Gaze_Mapper, Binocular_HMD_Scored_Gaze_Mapper
 
 calibration_plugins =  [Screen_Marker_Calibration,
                         Manual_Marker_Calibration,
@@ -32,4 +32,5 @@ gaze_mapping_plugins = [Dummy_Gaze_Mapper,
                         Vector_Gaze_Mapper,
                         Binocular_Gaze_Mapper,
                         Binocular_Vector_Gaze_Mapper,
-                        Dual_Monocular_Gaze_Mapper]
+                        Dual_Monocular_Gaze_Mapper,
+                        Binocular_HMD_Scored_Gaze_Mapper]

--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -188,7 +188,31 @@ class Binocular_Gaze_Mapper(Binocular_Gaze_Mapper_Base):
     def get_init_dict(self):
         return {'params':self.params, 'params_eye0':self.params_eye0, 'params_eye1':self.params_eye1}
 
+class Binocular_HMD_Scored_Gaze_Mapper(Binocular_Gaze_Mapper_Base):
+    """A gaze mapper that maps two eyes individually"""
+    def __init__(self, g_pool,params0,params1):
+        super(Binocular_HMD_Scored_Gaze_Mapper, self).__init__(g_pool)
+        self.params0 = params0
+        self.params1 = params1
+        self.map_fns = (make_map_function(*self.params0),make_map_function(*self.params1))
 
+    def _map_monocular(self,p):
+        gaze_point = self.map_fns[p['id']](p['norm_pos'])
+        return {'norm_pos':gaze_point,'confidence':p['confidence'],'id':p['id'],'timestamp':p['timestamp'],'base':[p]}
+
+    def _map_binocular(self, p0, p1):
+        gaze_point_eye0 = self.map_fns[p0['id']](p0['norm_pos'])
+        score_eye0 = p0['confidence']
+        gaze_point_eye1 = self.map_fns[p1['id']](p1['norm_pos'])
+        score_eye1 = p1['confidence']
+        score_total = score_eye0 + score_eye1
+        gaze_point = (gaze_point_eye0[0] * score_eye0 + gaze_point_eye1[0] * score_eye1)/score_total , (gaze_point_eye0[1] * score_eye0 + gaze_point_eye1[1] * score_eye1)/score_total
+        confidence = (p0['confidence'] * score_eye0 + p1['confidence'] * score_eye1)/score_total
+        ts = (p0['timestamp'] * score_eye0 + p1['timestamp'] * score_eye1)/score_total
+        return {'norm_pos':gaze_point,'confidence':confidence,'timestamp':ts,'base':[p0, p1]}
+
+    def get_init_dict(self):
+        return {'params0':self.params0,'params1':self.params1}
 
 class Vector_Gaze_Mapper(Monocular_Gaze_Mapper_Base):
     """docstring for Vector_Gaze_Mapper"""

--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -16,7 +16,7 @@ from pyglui import ui
 from calibration_plugin_base import Calibration_Plugin
 from finish_calibration import not_enough_data_error_msg,solver_failed_to_converge_error_msg
 import calibrate
-from gaze_mappers import Monocular_Gaze_Mapper,Dual_Monocular_Gaze_Mapper
+from gaze_mappers import Monocular_Gaze_Mapper,Dual_Monocular_Gaze_Mapper, Binocular_HMD_Scored_Gaze_Mapper
 
 #logging
 import logging
@@ -144,7 +144,7 @@ class HMD_Calibration(Calibration_Plugin):
             params1 = None
 
         if params0 and params1:
-            g_pool.plugins.add(Dual_Monocular_Gaze_Mapper,args={'params0':params0,'params1':params1})
+            g_pool.plugins.add(Binocular_HMD_Scored_Gaze_Mapper,args={'params0':params0,'params1':params1})
             method = 'dual monocular polynomial regression'
         elif params0:
             g_pool.plugins.add(Monocular_Gaze_Mapper,args={'params':params0})


### PR DESCRIPTION
The standard gaze_mapper hmd calibration is using is not that exact.
The gaze point jumps around.

To solve this the new gaze_mapper uses the confidence as an score for both eyes and then calculates weighted average for x,y of the gaze.
