### PR TITLE
Handle version strings in `os_utils` 

### DIFF
--- a/pupil_src/shared_modules/os_utils.py
+++ b/pupil_src/shared_modules/os_utils.py
@@ -8,7 +8,7 @@
 ----------------------------------------------------------------------------------~(*)
 '''
 
-import platform, sys, os, time
+import platform, sys, os, time, re
 import subprocess as sp
 
 import logging
@@ -16,8 +16,20 @@ logger = logging.getLogger(__name__)
 
 os_name = platform.system()
 if os_name == "Darwin":
+    # version regex from - http://svn.python.org/projects/python/tags/r32rc1/Lib/distutils/version.py
+    version_re = re.compile(r'^(\d+) \. (\d+) (\. (\d+))? ([ab](\d+))?$', re.VERBOSE)
     mac_version = platform.mac_ver()
-    mac_major,mac_minor,mac_patch = map(int,mac_version[0].split('.'))
+    mac_version_str = mac_version[0]
+
+    match = version_re.match(mac_version_str)
+    if not match:
+        logger.error("Invalid version string. Valid semantic versioning follows the MAJOR.MINOR.PATCH pattern with optional pre-release and pre-release build numbers.")
+
+    try:
+        (mac_major,mac_minor,mac_patch,mac_prerelease,mac_prerelease_num) = match.group(1,2,4,5,6) 
+    except Exception as e:
+        logger.error(e)
+
 
 if os_name == "Darwin" and mac_minor >=11:
 


### PR DESCRIPTION
This PR responds to #477 
  - Added regex to match semantic version patterns
  - added simplistic error handling

todo 
  - better error handling
  - improve logger error messages