### PR TITLE
Fixes for OpenCV3 using ROS

### DIFF
--- a/pupil_src/capture/pupil_detectors/setup.py
+++ b/pupil_src/capture/pupil_detectors/setup.py
@@ -43,14 +43,28 @@ for dirpath, dirnames, filenames in os.walk("singleeyefitter"):
 shared_cpp_include_path = '../../shared_cpp/include'
 singleeyefitter_include_path = 'singleeyefitter/'
 
+# opencv3 - highgui module has been split into parts: imgcodecs, videoio, and highgui itself
+opencv_libraries = ['opencv_core', 'opencv_highgui', 'opencv_videoio', 'opencv_imgcodecs', 'opencv_imgproc', 'opencv_video']
+opencv_library_dir = '/usr/local/opt/opencv3/lib'
+opencv_include_dir = '/usr/local/opt/opencv3/include'
+
+if(not os.path.isfile(opencv_library_dir+'/libopencv_core.so')):
+    ros_dists = ['kinetic', 'jade', 'indigo']
+    for ros_dist in ros_dists:
+        ros_candidate_path = '/opt/ros/'+ros_dist+'/lib'
+        if(os.path.isfile(ros_candidate_path+'/libopencv_core3.so')):
+            opencv_library_dir = ros_candidate_path
+            opencv_include_dir = '/opt/ros/'+ros_dist+'/include/opencv-3.1.0-dev'
+            opencv_libraries = [lib + '3' for lib in opencv_libraries]
+            break
+
 extensions = [
-    # opencv3 - highgui module has been split into parts: imgcodecs, videoio, and highgui itself
     Extension(
         name="detector_2d",
         sources=['detector_2d.pyx','singleeyefitter/ImageProcessing/cvx.cpp','singleeyefitter/utils.cpp','singleeyefitter/detectorUtils.cpp' ],
-        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, '/usr/local/opt/opencv3/include'],
-        libraries = ['opencv_core','opencv_highgui', 'opencv_videoio', 'opencv_imgcodecs', 'opencv_imgproc', 'boost_python'],
-        library_dirs = ['/usr/local/opt/opencv3/lib'],
+        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, opencv_include_dir ],
+        libraries = ['boost_python']+opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,
@@ -58,9 +72,9 @@ extensions = [
      Extension(
         name="detector_3d",
         sources=['detector_3d.pyx','singleeyefitter/ImageProcessing/cvx.cpp','singleeyefitter/utils.cpp','singleeyefitter/detectorUtils.cpp', 'singleeyefitter/EyeModelFitter.cpp','singleeyefitter/EyeModel.cpp'],
-        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, '/usr/local/opt/opencv3/include'],
-        libraries = ['opencv_core','opencv_highgui','opencv_videoio', 'opencv_imgcodecs','opencv_imgproc', 'opencv_video', 'ceres', 'boost_python' ],
-        library_dirs = ['/usr/local/opt/opencv3/lib'],
+        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, opencv_include_dir ],
+        libraries = ['ceres', 'boost_python']+opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
@@ -43,14 +43,27 @@ for dirpath, dirnames, filenames in os.walk("."):
 shared_cpp_include_path = '../../../shared_cpp/include'
 singleeyefitter_include_path = '../../../capture/pupil_detectors/singleeyefitter'
 
+opencv_libraries = ['opencv_core']
+opencv_library_dir = '/usr/local/opt/opencv3/lib'
+opencv_include_dir = '/usr/local/opt/opencv3/include'
+
+if(not os.path.isfile(opencv_library_dir+'/libopencv_core.so')):
+    ros_dists = ['kinetic', 'jade', 'indigo']
+    for ros_dist in ros_dists:
+        ros_candidate_path = '/opt/ros/'+ros_dist+'/lib'
+        if(os.path.isfile(ros_candidate_path+'/libopencv_core3.so')):
+            opencv_library_dir = ros_candidate_path
+            opencv_include_dir = '/opt/ros/'+ros_dist+'/include/opencv-3.1.0-dev'
+            opencv_libraries = [lib + '3' for lib in opencv_libraries]
+            break
 
 extensions = [
      Extension(
         name="calibration_methods",
         sources=['calibration_methods.pyx'],
-        include_dirs = [ np.get_include() , singleeyefitter_include_path, shared_cpp_include_path , '/usr/local/include/eigen3','/usr/include/eigen3','/usr/local/opt/opencv3/include'],
-        libraries = ['opencv_core', 'ceres' ],
-        library_dirs = ['/usr/local/opt/opencv3/lib'],
+        include_dirs = [ np.get_include() , singleeyefitter_include_path, shared_cpp_include_path , '/usr/local/include/eigen3','/usr/include/eigen3',opencv_include_dir],
+        libraries = [ 'ceres' ] + opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,


### PR DESCRIPTION
Hi,
This is (re-)introducing the ability to use OpenCV3 provided by ROS. This is only used if OpenCV3 is not found in the default path. I've extended it a little so is searches through all ROS distributions which provide OpenCV3. It will also be easy to extend this for other operating systems etc.

Best,
Tobias