### PR TITLE
Opencv3 rebase

### DIFF
--- a/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
+++ b/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
@@ -3,32 +3,32 @@ from libcpp.vector cimport vector
 from libcpp.deque cimport deque
 from libc.stdint cimport int32_t
 
-cdef extern from '<opencv2/core/types_c.h>':
+cdef extern from '<opencv2/core.hpp>':
 
   int CV_8UC1
   int CV_8UC3
 
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv::Mat':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv::Mat':
 
   cdef cppclass Mat :
       Mat() except +
       Mat( int height, int width, int type, void* data  ) except+
       Mat( int height, int width, int type ) except+
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv::Rect':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv::Rect':
 
   cdef cppclass Rect_[T]:
     Rect_() except +
     Rect_( T x, T y, T width, T height ) except +
     T x, y, width, height
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv::Point':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv::Point':
 
   cdef cppclass Point_[T]:
     Point_() except +
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv::Scalar':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv::Scalar':
 
   cdef cppclass Scalar_[T]:
     Scalar_() except +

--- a/pupil_src/capture/pupil_detectors/detect_2d.hpp
+++ b/pupil_src/capture/pupil_detectors/detect_2d.hpp
@@ -8,9 +8,9 @@
 ----------------------------------------------------------------------------------~(*)
 */
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 #include <iostream>
 
 #include "common/types.h"

--- a/pupil_src/capture/pupil_detectors/detector.pxd
+++ b/pupil_src/capture/pupil_detectors/detector.pxd
@@ -13,32 +13,32 @@ from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libc.stdint cimport int32_t
 
-cdef extern from '<opencv2/core/types_c.h>':
+cdef extern from '<opencv2/core.hpp>':
 
   int CV_8UC1
   int CV_8UC3
 
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv':
 
   cdef cppclass Mat :
       Mat() except +
       Mat( int height, int width, int type, void* data  ) except+
       Mat( int height, int width, int type ) except+
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv':
 
   cdef cppclass Rect_[T]:
     Rect_() except +
     Rect_( T x, T y, T width, T height ) except +
     T x, y, width, height
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv':
 
   cdef cppclass Point_[T]:
     Point_() except +
 
-cdef extern from '<opencv2/core/core.hpp>' namespace 'cv':
+cdef extern from '<opencv2/core.hpp>' namespace 'cv':
 
   cdef cppclass Scalar_[T]:
     Scalar_() except +

--- a/pupil_src/capture/pupil_detectors/setup.py
+++ b/pupil_src/capture/pupil_detectors/setup.py
@@ -43,13 +43,28 @@ for dirpath, dirnames, filenames in os.walk("singleeyefitter"):
 shared_cpp_include_path = '../../shared_cpp/include'
 singleeyefitter_include_path = 'singleeyefitter/'
 
+# opencv3 - highgui module has been split into parts: imgcodecs, videoio, and highgui itself
+opencv_libraries = ['opencv_core', 'opencv_highgui', 'opencv_videoio', 'opencv_imgcodecs', 'opencv_imgproc', 'opencv_video']
+opencv_library_dir = '/usr/local/opt/opencv3/lib'
+opencv_include_dir = '/usr/local/opt/opencv3/include'
+
+if(not os.path.isfile(opencv_library_dir+'/libopencv_core.so')):
+    ros_dists = ['kinetic', 'jade', 'indigo']
+    for ros_dist in ros_dists:
+        ros_candidate_path = '/opt/ros/'+ros_dist+'/lib'
+        if(os.path.isfile(ros_candidate_path+'/libopencv_core3.so')):
+            opencv_library_dir = ros_candidate_path
+            opencv_include_dir = '/opt/ros/'+ros_dist+'/include/opencv-3.1.0-dev'
+            opencv_libraries = [lib + '3' for lib in opencv_libraries]
+            break
+
 extensions = [
     Extension(
         name="detector_2d",
         sources=['detector_2d.pyx','singleeyefitter/ImageProcessing/cvx.cpp','singleeyefitter/utils.cpp','singleeyefitter/detectorUtils.cpp' ],
-        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path],
-        libraries = ['opencv_highgui','opencv_core','opencv_imgproc' , 'boost_python'],
-        #library_dirs = ['/usr/local/lib'],
+        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, opencv_include_dir ],
+        libraries = ['boost_python']+opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,
@@ -57,9 +72,9 @@ extensions = [
      Extension(
         name="detector_3d",
         sources=['detector_3d.pyx','singleeyefitter/ImageProcessing/cvx.cpp','singleeyefitter/utils.cpp','singleeyefitter/detectorUtils.cpp', 'singleeyefitter/EyeModelFitter.cpp','singleeyefitter/EyeModel.cpp'],
-        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path],
-        libraries = ['opencv_highgui','opencv_core','opencv_imgproc', 'opencv_video', 'ceres', 'boost_python' ],
-        # library_dirs = ['/usr/local/lib'],
+        include_dirs = [ np.get_include() , '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path , singleeyefitter_include_path, opencv_include_dir ],
+        libraries = ['ceres', 'boost_python']+opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,
@@ -75,4 +90,5 @@ setup(
     license='GNU',
     ext_modules=cythonize(extensions)
 )
+
 

--- a/pupil_src/capture/pupil_detectors/setup.py
+++ b/pupil_src/capture/pupil_detectors/setup.py
@@ -91,4 +91,3 @@ setup(
     ext_modules=cythonize(extensions)
 )
 
-

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/GuoHallThinner.h
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/GuoHallThinner.h
@@ -33,7 +33,7 @@ and contains the fast Guo Hall thinner algorithm
 
 
 #include <deque>
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 #include "ImageContour.h"
 #include "cvx.h"
 

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/ImageContour.h
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/ImageContour.h
@@ -27,7 +27,7 @@ From https://github.com/arnaud-ramey/voronoi
 #include <stdio.h>
 #include <vector>
 #include <numeric>      // std::accumulate
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/cvx.h
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/ImageProcessing/cvx.h
@@ -1,9 +1,8 @@
 #ifndef __SINGLEEYEFITTER_CVX_H__
 #define __SINGLEEYEFITTER_CVX_H__
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/core/core_c.h>
-#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
 
 namespace singleeyefitter {
 

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/detectorUtils.cpp
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/detectorUtils.cpp
@@ -5,7 +5,7 @@
 #include "fun.h"
 #include "EllipseDistanceApproxCalculator.h"
 
-#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgproc.hpp>
 #include <vector>
 
 namespace singleeyefitter {

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/detectorUtils.h
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/detectorUtils.h
@@ -2,7 +2,7 @@
 #define __DETECTORUTILS_H__
 
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 #include "common/types.h"
 #include "EllipseEvaluation2D.h"
 

--- a/pupil_src/capture/pupil_detectors/singleeyefitter/utils.h
+++ b/pupil_src/capture/pupil_detectors/singleeyefitter/utils.h
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <Eigen/Core>
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 
 namespace singleeyefitter {
 

--- a/pupil_src/player/player_methods.py
+++ b/pupil_src/player/player_methods.py
@@ -258,11 +258,11 @@ def transparent_circle(img,center,radius,color,thickness):
 
     try:
         overlay = img[roi].copy()
-        cv2.circle(overlay,(pad,pad), radius=radius, color=rgb, thickness=thickness, lineType=cv2.cv.CV_AA)
+        cv2.circle(img,center,radius,rgb, thickness=thickness, lineType=cv2.LINE_AA)        
         opacity = alpha
-        cv2.addWeighted(overlay, opacity, img[roi], 1. - opacity, 0, img[roi])
+        cv2.addWeighted(src1=img[roi], alpha=opacity, src2=overlay, beta=1. - opacity, gamma=0, dst=img[roi])
     except:
-        logger.debug("transparent_circle would have been partially outsize of img. Did not draw it.")
+        logger.debug("transparent_circle would have been partially outside of img. Did not draw it.")
 
 
 def transparent_image_overlay(pos,overlay_img,img,alpha):

--- a/pupil_src/player/scan_path.py
+++ b/pupil_src/player/scan_path.py
@@ -55,7 +55,7 @@ class Scan_Path(Plugin):
         #lets update past gaze using optical flow: this is like sticking the gaze points onto the pixels of the img.
         if self.past_gaze_positions and succeeding_frame:
             past_screen_gaze = np.array([denormalize(ng['norm_pos'] ,img_shape,flip_y=True) for ng in self.past_gaze_positions],dtype=np.float32)
-            new_pts, status, err = cv2.calcOpticalFlowPyrLK(self.prev_gray, gray_img,past_screen_gaze,minEigThreshold=0.005,**lk_params)
+            new_pts, status, err = cv2.calcOpticalFlowPyrLK(self.prev_gray,gray_img,past_screen_gaze,None,minEigThreshold=0.005,**lk_params)
             for gaze,new_gaze_pt,s,e in zip(self.past_gaze_positions,new_pts,status,err):
                 if s:
                     # print "norm,updated",gaze['norm_gaze'], normalize(new_gaze_pt,img_shape[:-1],flip_y=True)

--- a/pupil_src/player/vis_circle.py
+++ b/pupil_src/player/vis_circle.py
@@ -11,7 +11,6 @@
 from player_methods import transparent_circle
 from plugin import Plugin
 import numpy as np
-import cv2
 
 # TODO: Import pyglui
 from pyglui import ui

--- a/pupil_src/player/vis_cross.py
+++ b/pupil_src/player/vis_cross.py
@@ -36,7 +36,7 @@ class Vis_Cross(Plugin):
         bgra = (self.b*255,self.g*255,self.r*255,self.a*255)
         for pt in pts:
             lines =  np.array( [((pt[0]-self.inner,pt[1]),(pt[0]-self.outer,pt[1])),((pt[0]+self.inner,pt[1]),(pt[0]+self.outer,pt[1])) , ((pt[0],pt[1]-self.inner),(pt[0],pt[1]-self.outer)) , ((pt[0],pt[1]+self.inner),(pt[0],pt[1]+self.outer))],dtype=np.int32 )
-            cv2.polylines(frame.img, lines, isClosed=False, color=bgra, thickness=self.thickness, lineType=cv2.cv.CV_AA)
+            cv2.polylines(frame.img, lines, isClosed=False, color=bgra, thickness=self.thickness, lineType=cv2.LINE_AA)
 
     def init_gui(self):
         # initialize the menu

--- a/pupil_src/player/vis_light_points.py
+++ b/pupil_src/player/vis_light_points.py
@@ -46,7 +46,7 @@ class Vis_Light_Points(Plugin):
             except:
                 pass
 
-        out = cv2.distanceTransform(overlay,cv2.cv.CV_DIST_L2, 5)
+        out = cv2.distanceTransform(overlay,cv2.DIST_L2, 5)
 
         # fix for opencv binding inconsitency
         if type(out)==tuple:
@@ -54,7 +54,8 @@ class Vis_Light_Points(Plugin):
 
         overlay =  1/(out/falloff+1)
 
-        img = np.multiply(img, cv2.cvtColor(overlay,cv2.COLOR_GRAY2RGB), casting="unsafe")
+        img_float = img.astype(np.float32) * cv2.cvtColor(overlay,cv2.COLOR_GRAY2RGB)
+        img.data = img_float.round().astype(np.uint8).data
 
     def init_gui(self):
         # initialize the menu

--- a/pupil_src/player/vis_polyline.py
+++ b/pupil_src/player/vis_polyline.py
@@ -34,7 +34,7 @@ class Vis_Polyline(Plugin):
         bgra = (self.b*255,self.g*255,self.r*255,self.a*255)
         if pts:
             pts = np.array([pts],dtype=np.int32)
-            cv2.polylines(frame.img, pts, isClosed=False, color=bgra, thickness=self.thickness, lineType=cv2.cv.CV_AA)
+            cv2.polylines(frame.img, pts, isClosed=False, color=bgra, thickness=self.thickness, lineType=cv2.LINE_AA)
 
     def init_gui(self):
         # initialize the menu

--- a/pupil_src/shared_cpp/include/common/colors.h
+++ b/pupil_src/shared_cpp/include/common/colors.h
@@ -1,7 +1,7 @@
 #ifndef singleeyefitter_colors_h__
 #define singleeyefitter_colors_h__
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 
 
 namespace singleeyefitter {

--- a/pupil_src/shared_cpp/include/common/types.h
+++ b/pupil_src/shared_cpp/include/common/types.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <chrono>
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/core.hpp>
 
 
 namespace singleeyefitter {

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
@@ -43,14 +43,27 @@ for dirpath, dirnames, filenames in os.walk("."):
 shared_cpp_include_path = '../../../shared_cpp/include'
 singleeyefitter_include_path = '../../../capture/pupil_detectors/singleeyefitter'
 
+opencv_libraries = ['opencv_core']
+opencv_library_dir = '/usr/local/opt/opencv3/lib'
+opencv_include_dir = '/usr/local/opt/opencv3/include'
+
+if(not os.path.isfile(opencv_library_dir+'/libopencv_core.so')):
+    ros_dists = ['kinetic', 'jade', 'indigo']
+    for ros_dist in ros_dists:
+        ros_candidate_path = '/opt/ros/'+ros_dist+'/lib'
+        if(os.path.isfile(ros_candidate_path+'/libopencv_core3.so')):
+            opencv_library_dir = ros_candidate_path
+            opencv_include_dir = '/opt/ros/'+ros_dist+'/include/opencv-3.1.0-dev'
+            opencv_libraries = [lib + '3' for lib in opencv_libraries]
+            break
 
 extensions = [
      Extension(
         name="calibration_methods",
         sources=['calibration_methods.pyx'],
-        include_dirs = [ np.get_include() , singleeyefitter_include_path, shared_cpp_include_path , '/usr/local/include/eigen3','/usr/include/eigen3'],
-        libraries = [ 'ceres' ],
-        # library_dirs = ['/usr/local/lib'],
+        include_dirs = [ np.get_include() , singleeyefitter_include_path, shared_cpp_include_path , '/usr/local/include/eigen3','/usr/include/eigen3',opencv_include_dir],
+        libraries = [ 'ceres' ] + opencv_libraries,
+        library_dirs = [opencv_library_dir],
         extra_link_args=[], #'-WL,-R/usr/local/lib'
         extra_compile_args=["-std=c++11",'-w','-O2'], #-w hides warnings
         depends= dependencies,

--- a/pupil_src/shared_modules/circle_detector.py
+++ b/pupil_src/shared_modules/circle_detector.py
@@ -17,7 +17,7 @@ def find_concetric_circles(gray_img,min_ring_count=3, visual_debug=False):
 
     # get threshold image used to get crisp-clean edges using blur to remove small features
     edges = cv2.adaptiveThreshold(cv2.blur(gray_img,(3,3)), 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 5, 11)
-    contours, hierarchy = cv2.findContours(edges,
+    _, contours, hierarchy = cv2.findContours(edges,
                                     mode=cv2.RETR_TREE,
                                     method=cv2.CHAIN_APPROX_NONE,offset=(0,0)) #TC89_KCOS
     if visual_debug is not False:

--- a/pupil_src/shared_modules/cv2_writer.py
+++ b/pupil_src/shared_modules/cv2_writer.py
@@ -9,13 +9,12 @@
 '''
 
 from cv2 import VideoWriter
-from cv2.cv import CV_FOURCC
 
 class CV_Writer(object):
     """docstring for CV_Writer"""
     def __init__(self, file_loc,frame_rate,frame_size):
         super(CV_Writer, self).__init__()
-        self.writer = VideoWriter(file_loc, CV_FOURCC(*'DIVX'), float(frame_rate), frame_size)
+        self.writer = VideoWriter(file_loc, VideoWriter_fourcc(*'DIVX'), float(frame_rate), frame_size)
 
     def write_video_frame(self, input_frame):
         self.writer.write(input_frame.img)

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -292,7 +292,7 @@ class Reference_Surface(object):
                 uv3d[:,:-1] = uv
                 xy.shape = -1,1,2
                 # compute pose of object relative to camera center
-                is3dPoseAvailable, rot3d_cam_to_object, translate3d_cam_to_object = cv2.solvePnP(uv3d, xy, K, dist_coef,flags=cv2.CV_EPNP)
+                is3dPoseAvailable, rot3d_cam_to_object, translate3d_cam_to_object = cv2.solvePnP(uv3d, xy, K, dist_coef,flags=cv2.SOLVEPNP_EPNP)
 
                 if is3dPoseAvailable:
 

--- a/pupil_src/shared_modules/square_marker_detect.py
+++ b/pupil_src/shared_modules/square_marker_detect.py
@@ -121,7 +121,7 @@ def correct_gradient(gray_img,r):
 def detect_markers(gray_img,grid_size,min_marker_perimeter=40,aperture=11,visualize=False):
     edges = cv2.adaptiveThreshold(gray_img, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, aperture, 9)
 
-    contours, hierarchy = cv2.findContours(edges,
+    _, contours, hierarchy = cv2.findContours(edges,
                                     mode=cv2.RETR_TREE,
                                     method=cv2.CHAIN_APPROX_SIMPLE,offset=(0,0)) #TC89_KCOS
 
@@ -269,7 +269,7 @@ def detect_markers_robust(gray_img,grid_size,prev_markers,min_marker_perimeter=4
         if not_found:
             prev_pts = np.array([m['centroid'] for m in not_found])
             # new_pts, flow_found, err = cv2.calcOpticalFlowPyrLK(prev_img, gray_img,prev_pts,winSize=(100,100))
-            new_pts, flow_found, err = cv2.calcOpticalFlowPyrLK(prev_img, gray_img,prev_pts,minEigThreshold=0.01,**lk_params)
+            new_pts, flow_found, err = cv2.calcOpticalFlowPyrLK(prev_img, gray_img,prev_pts,None,minEigThreshold=0.01,**lk_params)
             for pt,s,e,m in zip(new_pts,flow_found,err,not_found):
                 if s: #ho do we ensure that this is a good move?
                     m['verts'] += pt-m['centroid'] #uniformly translate verts by optlical flow offset


### PR DESCRIPTION
## Overview

Granular commits ported from the [`opencv3`](https://github.com/pupil-labs/pupil/tree/opencv3) branch and rebased on the current `master`. 

This branch branch integrates work from @Tobias-Fischer's commits to the `opencv3` branch see PRs - #488, #393. 
### Tests
- [x] Pupil Capture - All Cython libs compile on macOS `10.12` with opencv3 (and no other versions of opencv
- [x] Pupil Player - All plugins working with `opencv3`
- [x] Test on Linux (Ubuntu) with ROS (@Tobias-Fischer - you have already done this for ROS so you can probably check this off)
- [ ] Test on Linux with `opencv3` without ROS
### Needs review
- [ ] review changes to [`vis_light_points`](https://github.com/pupil-labs/pupil/commit/5d2643c9c827cb3812c1f2f4a503b1f01b2295c4)
- [ ] review cython `setup.py` files [here](https://github.com/pupil-labs/pupil/commit/fbdb634d7cb60241c6faf56145fe4f03695764e5) and [here](https://github.com/pupil-labs/pupil/commit/fbdb634d7cb60241c6faf56145fe4f03695764e5) -consider changing :
  
  ``` python
  if os.path.isfile(os.path.join(opencv_library_dir,libopencv_core.so)):
    pass
  else:
    ... 
  ```
  
  or changing to `try` `except` instead of `if (not ...` statement? Also use `os.path.join` to avoid future errors. 
### Roadblocks

Wait until the `opencv3` install process is mature for macOS. This will happen when `brew install opecv3` pulls changes from `brew install opencv3 --HEAD --with-contrib`. 
