### PR TITLE
Fix backend script

### DIFF
--- a/pupil_src/shared_modules/video_capture/fake_backend.py
+++ b/pupil_src/shared_modules/video_capture/fake_backend.py
@@ -158,7 +158,7 @@ class Fake_Source(Base_Source):
 
     @property
     def frame_rates(self):
-        return range(30,60,90,120)
+        return (30,60,90,120)
 
     @property
     def frame_sizes(self):


### PR DESCRIPTION
Don't use range(30,60,90,120) to return frame rates.
Instead just return as a list (30,60,90,120)

Error without fix on startup:


> Traceback (most recent call last):
>   File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
>     self.run()
>   File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
>     self._target(*self._args, **self._kwargs)
>   File "/home/pupil/pupil/pupil_src/capture/world.py", line 216, in world
>     cap = Fake_Source(g_pool, **settings)
>   File "/home/pupil/pupil/pupil_src/shared_modules/video_capture/fake_backend.py", line 76, in __init__
>     self.settings = settings
>   File "/home/pupil/pupil/pupil_src/shared_modules/video_capture/fake_backend.py", line 143, in settings
>     self.frame_rate = settings.get('frame_rate', self.frame_rate )
>   File "/home/pupil/pupil/pupil_src/shared_modules/video_capture/fake_backend.py", line 172, in frame_rate
>     rates = [ abs(r-new_rate) for r in self.frame_rates ]
>   File "/home/pupil/pupil/pupil_src/shared_modules/video_capture/fake_backend.py", line 161, in frame_rates
>     return range(30,60,90,120)
> TypeError: range expected at most 3 arguments, got 4