### PR TITLE
Fix negative time difference in fixation detector 

### DIFF
--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -642,7 +642,7 @@ class Detection_Window(object):
         counter = 1
         newest = self.gaze_data[-1]['timestamp']
         for idx, datum in enumerate(self.gaze_data):
-            if newest - datum['timestamp'] > time_constraint:
+            if abs(newest - datum['timestamp']) > time_constraint:
                 counter += 1
             else:
                 # do not remove datum that breaks the constraint

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -436,7 +436,7 @@ class Sliding_Window(object):
         ts0 = self.timestamps[start_idx]
         for j in range(start_idx+1, len(self.timestamps)):
             ts1 = self.timestamps[j]
-            if ts1 - ts0 > self.min_duration:
+            if abs(ts1 - ts0) > self.min_duration:
                 return start_idx, j
         raise EOFError('Could not find a sliding window with minimal lenght of %.2fs'%self.min_duration)
 


### PR DESCRIPTION
Problem: If the newer timestamp would be smaller than the old one the fixation detector would not free data and distance calculation would slow down everything over time.