### PR TITLE
update license header - happy new year 2017

### DIFF
--- a/deployment/deploy_capture/finalize_bundle.py
+++ b/deployment/deploy_capture/finalize_bundle.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import platform

--- a/deployment/deploy_capture/finalize_bundle.py
+++ b/deployment/deploy_capture/finalize_bundle.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/deployment/deploy_capture/version.py
+++ b/deployment/deploy_capture/version.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import sys,os

--- a/deployment/deploy_capture/version.py
+++ b/deployment/deploy_capture/version.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import sys,os
 sys.path.append(os.path.join('../../', 'pupil_src', 'shared_modules'))

--- a/deployment/deploy_player/finalize_bundle.py
+++ b/deployment/deploy_player/finalize_bundle.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import platform

--- a/deployment/deploy_player/finalize_bundle.py
+++ b/deployment/deploy_player/finalize_bundle.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import platform
 import sys, os

--- a/deployment/deploy_player/version.py
+++ b/deployment/deploy_player/version.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import sys,os

--- a/deployment/deploy_player/version.py
+++ b/deployment/deploy_player/version.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import sys,os
 sys.path.append(os.path.join('../../', 'pupil_src', 'shared_modules'))

--- a/deployment/deploy_service/finalize_bundle.py
+++ b/deployment/deploy_service/finalize_bundle.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import platform

--- a/deployment/deploy_service/finalize_bundle.py
+++ b/deployment/deploy_service/finalize_bundle.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/deployment/deploy_service/version.py
+++ b/deployment/deploy_service/version.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import sys,os

--- a/deployment/deploy_service/version.py
+++ b/deployment/deploy_service/version.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import sys,os
 sys.path.append(os.path.join('../../', 'pupil_src', 'shared_modules'))

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform
 

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/main.py
+++ b/pupil_src/capture/main.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os, sys, platform

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/CircleGoodnessTest.pyx
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/CircleGoodnessTest.pyx
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 cimport typ_defs
 from typ_defs cimport *

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/build_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/build_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 if __name__ == '__main__':
     import subprocess as sp

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/build_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/build_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 if __name__ == '__main__':
     import subprocess as sp
     sp.call("python setup_test.py build_ext --inplace",shell=True)

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/setup_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/setup_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 # monkey-patch for parallel compilation
 def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=None, debug=0, extra_preargs=None, extra_postargs=None, depends=None):

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/setup_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/setup_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 # monkey-patch for parallel compilation

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/CircleGoodnessTest/test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/DetectorTests/test_detectors.py
+++ b/pupil_src/capture/pupil_detectors/Tests/DetectorTests/test_detectors.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/DetectorTests/test_detectors.py
+++ b/pupil_src/capture/pupil_detectors/Tests/DetectorTests/test_detectors.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/DistancePointLineTest/test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/DistancePointLineTest/test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 
 import numpy as np

--- a/pupil_src/capture/pupil_detectors/Tests/DistancePointLineTest/test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/DistancePointLineTest/test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/build_and_run_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/build_and_run_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 if __name__ == '__main__':
     import subprocess as sp

--- a/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/build_and_run_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/build_and_run_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 if __name__ == '__main__':

--- a/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/projectionTest.cpp
+++ b/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/projectionTest.cpp
@@ -1,4 +1,12 @@
+/*
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
 
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+*/
 
 #include <iostream>
 #include "../../singleeyefitter/projection.h"

--- a/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/projectionTest.cpp
+++ b/pupil_src/capture/pupil_detectors/Tests/ProjectionTest/projectionTest.cpp
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 #include <iostream>

--- a/pupil_src/capture/pupil_detectors/Tests/SolveNPNTest/solveTest.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SolveNPNTest/solveTest.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 
 import numpy as np

--- a/pupil_src/capture/pupil_detectors/Tests/SolveNPNTest/solveTest.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SolveNPNTest/solveTest.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/SphereCircleTest.pyx
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/SphereCircleTest.pyx
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 cimport typ_defs
 from typ_defs cimport *

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import sys , os

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 import sys , os
  # Make all pupil shared_modules available to this Python session.

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/build_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/build_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 if __name__ == '__main__':
     import subprocess as sp

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/build_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/build_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 if __name__ == '__main__':
     import subprocess as sp
     sp.call("python setup_test.py build_ext --inplace",shell=True)

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/setup_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/setup_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 # monkey-patch for parallel compilation
 def parallelCCompile(self, sources, output_dir=None, macros=None, include_dirs=None, debug=0, extra_preargs=None, extra_postargs=None, depends=None):

--- a/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/setup_test.py
+++ b/pupil_src/capture/pupil_detectors/Tests/SphereCircleTests/setup_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 # monkey-patch for parallel compilation

--- a/pupil_src/capture/pupil_detectors/Tests/TestUtils.h
+++ b/pupil_src/capture/pupil_detectors/Tests/TestUtils.h
@@ -1,4 +1,12 @@
+/*
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
 
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+*/
 
 
 #include "../singleeyefitter/utils.h" // random

--- a/pupil_src/capture/pupil_detectors/Tests/TestUtils.h
+++ b/pupil_src/capture/pupil_detectors/Tests/TestUtils.h
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 

--- a/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
+++ b/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from libcpp.memory cimport shared_ptr

--- a/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
+++ b/pupil_src/capture/pupil_detectors/Tests/typ_defs.pxd
@@ -1,3 +1,13 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
+
 from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from libcpp.deque cimport deque

--- a/pupil_src/capture/pupil_detectors/__init__.py
+++ b/pupil_src/capture/pupil_detectors/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/__init__.py
+++ b/pupil_src/capture/pupil_detectors/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/capture/pupil_detectors/build.py
+++ b/pupil_src/capture/pupil_detectors/build.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 def build_cpp_extension():

--- a/pupil_src/capture/pupil_detectors/build.py
+++ b/pupil_src/capture/pupil_detectors/build.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/coarse_pupil.pxd
+++ b/pupil_src/capture/pupil_detectors/coarse_pupil.pxd
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 cimport cython

--- a/pupil_src/capture/pupil_detectors/coarse_pupil.pxd
+++ b/pupil_src/capture/pupil_detectors/coarse_pupil.pxd
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the CC BY-NC-SA License.
- License details are in the file license.txt, distributed as part of this software.
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/detect_2d.hpp
+++ b/pupil_src/capture/pupil_detectors/detect_2d.hpp
@@ -1,10 +1,10 @@
 /*
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 */
 

--- a/pupil_src/capture/pupil_detectors/detect_2d.hpp
+++ b/pupil_src/capture/pupil_detectors/detect_2d.hpp
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 #include <opencv2/core/core.hpp>

--- a/pupil_src/capture/pupil_detectors/detector.pxd
+++ b/pupil_src/capture/pupil_detectors/detector.pxd
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from libcpp.memory cimport shared_ptr

--- a/pupil_src/capture/pupil_detectors/detector.pxd
+++ b/pupil_src/capture/pupil_detectors/detector.pxd
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/detector_2d.pyx
+++ b/pupil_src/capture/pupil_detectors/detector_2d.pyx
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/detector_3d.pyx
+++ b/pupil_src/capture/pupil_detectors/detector_3d.pyx
@@ -1,11 +1,10 @@
-
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/detector_utils.pxd
+++ b/pupil_src/capture/pupil_detectors/detector_utils.pxd
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 # cython: profile=False

--- a/pupil_src/capture/pupil_detectors/detector_utils.pxd
+++ b/pupil_src/capture/pupil_detectors/detector_utils.pxd
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/setup.py
+++ b/pupil_src/capture/pupil_detectors/setup.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 # # monkey-patch for parallel compilation

--- a/pupil_src/capture/pupil_detectors/setup.py
+++ b/pupil_src/capture/pupil_detectors/setup.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/visualizer_3d.py
+++ b/pupil_src/capture/pupil_detectors/visualizer_3d.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/pupil_detectors/visualizer_3d.py
+++ b/pupil_src/capture/pupil_detectors/visualizer_3d.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from visualizer import Visualizer

--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/capture/recorder.py
+++ b/pupil_src/capture/recorder.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os, sys, platform, errno, getpass

--- a/pupil_src/capture/service.py
+++ b/pupil_src/capture/service.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform

--- a/pupil_src/capture/service.py
+++ b/pupil_src/capture/service.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform
 

--- a/pupil_src/capture/ui_roi.py
+++ b/pupil_src/capture/ui_roi.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 from methods import Roi
 from pyglui.cygl.utils import draw_points as cygl_draw_points

--- a/pupil_src/capture/ui_roi.py
+++ b/pupil_src/capture/ui_roi.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from methods import Roi

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform
 

--- a/pupil_src/player/batch_exporter.py
+++ b/pupil_src/player/batch_exporter.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/batch_exporter.py
+++ b/pupil_src/player/batch_exporter.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import numpy as np

--- a/pupil_src/player/exporter.py
+++ b/pupil_src/player/exporter.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/exporter.py
+++ b/pupil_src/player/exporter.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 if __name__ == '__main__':

--- a/pupil_src/player/eye_video_overlay.py
+++ b/pupil_src/player/eye_video_overlay.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/eye_video_overlay.py
+++ b/pupil_src/player/eye_video_overlay.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import sys, os,platform

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import sys, os,platform,errno

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/manual_gaze_correction.py
+++ b/pupil_src/player/manual_gaze_correction.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import cv2

--- a/pupil_src/player/manual_gaze_correction.py
+++ b/pupil_src/player/manual_gaze_correction.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/player_methods.py
+++ b/pupil_src/player/player_methods.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/player_methods.py
+++ b/pupil_src/player/player_methods.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os, cv2, csv_utils, shutil

--- a/pupil_src/player/raw_data_exporter.py
+++ b/pupil_src/player/raw_data_exporter.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/player/raw_data_exporter.py
+++ b/pupil_src/player/raw_data_exporter.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/scan_path.py
+++ b/pupil_src/player/scan_path.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import cv2

--- a/pupil_src/player/scan_path.py
+++ b/pupil_src/player/scan_path.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/seek_bar.py
+++ b/pupil_src/player/seek_bar.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from pyglui.cygl.utils import draw_polyline,draw_points,RGBA

--- a/pupil_src/player/seek_bar.py
+++ b/pupil_src/player/seek_bar.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/trim_marks.py
+++ b/pupil_src/player/trim_marks.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from OpenGL.GL import *

--- a/pupil_src/player/trim_marks.py
+++ b/pupil_src/player/trim_marks.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/video_export_launcher.py
+++ b/pupil_src/player/video_export_launcher.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/player/video_export_launcher.py
+++ b/pupil_src/player/video_export_launcher.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_circle.py
+++ b/pupil_src/player/vis_circle.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from player_methods import transparent_circle

--- a/pupil_src/player/vis_circle.py
+++ b/pupil_src/player/vis_circle.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_cross.py
+++ b/pupil_src/player/vis_cross.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/player/vis_cross.py
+++ b/pupil_src/player/vis_cross.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_fixation.py
+++ b/pupil_src/player/vis_fixation.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from player_methods import transparent_circle

--- a/pupil_src/player/vis_fixation.py
+++ b/pupil_src/player/vis_fixation.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_light_points.py
+++ b/pupil_src/player/vis_light_points.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import cv2

--- a/pupil_src/player/vis_light_points.py
+++ b/pupil_src/player/vis_light_points.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_polyline.py
+++ b/pupil_src/player/vis_polyline.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/player/vis_polyline.py
+++ b/pupil_src/player/vis_polyline.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_watermark.py
+++ b/pupil_src/player/vis_watermark.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/player/vis_watermark.py
+++ b/pupil_src/player/vis_watermark.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from player_methods import transparent_image_overlay

--- a/pupil_src/shared_cpp/include/logger/pycpplogger.h
+++ b/pupil_src/shared_cpp/include/logger/pycpplogger.h
@@ -1,10 +1,10 @@
 /*
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 */
 

--- a/pupil_src/shared_cpp/include/math/distance.h
+++ b/pupil_src/shared_cpp/include/math/distance.h
@@ -1,3 +1,13 @@
+/*
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+*/
+
 #ifndef distance_h__
 #define distance_h__
 

--- a/pupil_src/shared_cpp/include/math/intersect.h
+++ b/pupil_src/shared_cpp/include/math/intersect.h
@@ -1,3 +1,13 @@
+/*
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+*/
+
 #ifndef __INTERSECT_H__
 #define __INTERSECT_H__
 

--- a/pupil_src/shared_modules/annotations.py
+++ b/pupil_src/shared_modules/annotations.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os
 import csv

--- a/pupil_src/shared_modules/annotations.py
+++ b/pupil_src/shared_modules/annotations.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os

--- a/pupil_src/shared_modules/audio/__init__.py
+++ b/pupil_src/shared_modules/audio/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/audio/__init__.py
+++ b/pupil_src/shared_modules/audio/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import platform,sys,os

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 """

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/cache_list.py
+++ b/pupil_src/shared_modules/cache_list.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/cache_list.py
+++ b/pupil_src/shared_modules/cache_list.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import logging

--- a/pupil_src/shared_modules/calibration_routines/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/shared_modules/calibration_routines/accuracy_test.py
+++ b/pupil_src/shared_modules/calibration_routines/accuracy_test.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/accuracy_test.py
+++ b/pupil_src/shared_modules/calibration_routines/accuracy_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/adjust_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/calibrate.py
+++ b/pupil_src/shared_modules/calibration_routines/calibrate.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/calibrate.py
+++ b/pupil_src/shared_modules/calibration_routines/calibrate.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import numpy as np

--- a/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
+++ b/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 from plugin import Plugin
 import logging

--- a/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
+++ b/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 from plugin import Plugin
 import logging
 logger = logging.getLogger(__name__)

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/finish_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/finish_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/finish_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/finish_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 #when running from source compile cpp extension if nessesary.

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/build.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/build.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 def build_cpp_extension():

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/build.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/build.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/bundleCalibration.h
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/bundleCalibration.h
@@ -1,10 +1,10 @@
 /*
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 */
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/bundleCalibration.h
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/bundleCalibration.h
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pxd
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pxd
@@ -1,12 +1,13 @@
 
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 from libcpp.vector cimport vector
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pxd
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pxd
@@ -2,10 +2,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 from libcpp.vector cimport vector

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pyx
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/calibration_methods.pyx
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/common.h
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/common.h
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 #ifndef COMMON_H__

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/common.h
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/common.h
@@ -1,10 +1,10 @@
 /*
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 */
 

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 # # monkey-patch for parallel compilation

--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from visualizer import Visualizer

--- a/pupil_src/shared_modules/circle_detector.py
+++ b/pupil_src/shared_modules/circle_detector.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/circle_detector.py
+++ b/pupil_src/shared_modules/circle_detector.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import numpy as np

--- a/pupil_src/shared_modules/csv_utils.py
+++ b/pupil_src/shared_modules/csv_utils.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/csv_utils.py
+++ b/pupil_src/shared_modules/csv_utils.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import csv

--- a/pupil_src/shared_modules/cv2_writer.py
+++ b/pupil_src/shared_modules/cv2_writer.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/cv2_writer.py
+++ b/pupil_src/shared_modules/cv2_writer.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from cv2 import VideoWriter

--- a/pupil_src/shared_modules/display_recent_gaze.py
+++ b/pupil_src/shared_modules/display_recent_gaze.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/shared_modules/display_recent_gaze.py
+++ b/pupil_src/shared_modules/display_recent_gaze.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/file_methods.py
+++ b/pupil_src/shared_modules/file_methods.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/file_methods.py
+++ b/pupil_src/shared_modules/file_methods.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import cPickle as pickle

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -1,13 +1,12 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
-
 import os, time
 import csv
 import numpy as np

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -1,4 +1,14 @@
 '''
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+'''
+'''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
  Copyright (C) 2012-2017  Pupil Labs

--- a/pupil_src/shared_modules/frame_publisher.py
+++ b/pupil_src/shared_modules/frame_publisher.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 from plugin import Plugin
 from pyglui import ui

--- a/pupil_src/shared_modules/frame_publisher.py
+++ b/pupil_src/shared_modules/frame_publisher.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 from plugin import Plugin
 from pyglui import ui
 import numpy as np

--- a/pupil_src/shared_modules/gl_utils/__init__.py
+++ b/pupil_src/shared_modules/gl_utils/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/gl_utils/__init__.py
+++ b/pupil_src/shared_modules/gl_utils/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from utils import *

--- a/pupil_src/shared_modules/gl_utils/trackball.py
+++ b/pupil_src/shared_modules/gl_utils/trackball.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from OpenGL.GL import *

--- a/pupil_src/shared_modules/gl_utils/trackball.py
+++ b/pupil_src/shared_modules/gl_utils/trackball.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import OpenGL

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 from plugin import Plugin

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 from plugin import Plugin
 from pyglui.cygl.utils import Render_Target,push_ortho,pop_ortho

--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os

--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os
 from pyglui import ui

--- a/pupil_src/shared_modules/marker_auto_trim_marks.py
+++ b/pupil_src/shared_modules/marker_auto_trim_marks.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/marker_auto_trim_marks.py
+++ b/pupil_src/shared_modules/marker_auto_trim_marks.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import logging

--- a/pupil_src/shared_modules/marker_detector_cacher.py
+++ b/pupil_src/shared_modules/marker_detector_cacher.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/marker_detector_cacher.py
+++ b/pupil_src/shared_modules/marker_detector_cacher.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 class Global_Container(object):

--- a/pupil_src/shared_modules/math_helper/__init__.py
+++ b/pupil_src/shared_modules/math_helper/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from intersections import *

--- a/pupil_src/shared_modules/math_helper/__init__.py
+++ b/pupil_src/shared_modules/math_helper/__init__.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/math_helper/intersections.py
+++ b/pupil_src/shared_modules/math_helper/intersections.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/math_helper/intersections.py
+++ b/pupil_src/shared_modules/math_helper/intersections.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os, sys, platform, getpass

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/network_time_sync.py
+++ b/pupil_src/shared_modules/network_time_sync.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 from time import sleep
 from uvc import get_time_monotonic

--- a/pupil_src/shared_modules/network_time_sync.py
+++ b/pupil_src/shared_modules/network_time_sync.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 from time import sleep

--- a/pupil_src/shared_modules/offline_reference_surface.py
+++ b/pupil_src/shared_modules/offline_reference_surface.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/offline_reference_surface.py
+++ b/pupil_src/shared_modules/offline_reference_surface.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import numpy as np

--- a/pupil_src/shared_modules/offline_surface_tracker.py
+++ b/pupil_src/shared_modules/offline_surface_tracker.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/offline_surface_tracker.py
+++ b/pupil_src/shared_modules/offline_surface_tracker.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import sys, os,platform

--- a/pupil_src/shared_modules/os_utils.py
+++ b/pupil_src/shared_modules/os_utils.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import platform, sys, os, time

--- a/pupil_src/shared_modules/os_utils.py
+++ b/pupil_src/shared_modules/os_utils.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 import os,sys

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os,sys
 import logging

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import zmq, time, uuid

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from time import sleep

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the CC BY-NC-SA License.
- License details are in the file license.txt, distributed as part of this software.
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import numpy as np

--- a/pupil_src/shared_modules/show_calibration.py
+++ b/pupil_src/shared_modules/show_calibration.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os

--- a/pupil_src/shared_modules/show_calibration.py
+++ b/pupil_src/shared_modules/show_calibration.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/square_marker_detect.py
+++ b/pupil_src/shared_modules/square_marker_detect.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import cv2

--- a/pupil_src/shared_modules/square_marker_detect.py
+++ b/pupil_src/shared_modules/square_marker_detect.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/surface_tracker.py
+++ b/pupil_src/shared_modules/surface_tracker.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/surface_tracker.py
+++ b/pupil_src/shared_modules/surface_tracker.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import sys, os,platform

--- a/pupil_src/shared_modules/time_sync.py
+++ b/pupil_src/shared_modules/time_sync.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/time_sync.py
+++ b/pupil_src/shared_modules/time_sync.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -8,15 +8,8 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 '''
+
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
-
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
-
 Video Capture provides the interface to get frames from diffferent backends.
 Backends consist of a manager and at least one source class. The manager
 is a Pupil plugin that provides an GUI that lists all available sources. The

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 '''
 (*)~----------------------------------------------------------------------------------

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -1,6 +1,15 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
  Copyright (C) 2012-2016  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).

--- a/pupil_src/shared_modules/video_capture/base_backend.py
+++ b/pupil_src/shared_modules/video_capture/base_backend.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from plugin import Plugin

--- a/pupil_src/shared_modules/video_capture/base_backend.py
+++ b/pupil_src/shared_modules/video_capture/base_backend.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/video_capture/fake_backend.py
+++ b/pupil_src/shared_modules/video_capture/fake_backend.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from .base_backend import Base_Source, Base_Manager

--- a/pupil_src/shared_modules/video_capture/fake_backend.py
+++ b/pupil_src/shared_modules/video_capture/fake_backend.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 import os,sys

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from .base_backend import InitialisationError, StreamError, Base_Source, Base_Manager

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from .base_backend import InitialisationError, StreamError, Base_Source, Base_Manager

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -1,10 +1,10 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
 '''
 

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 from glfw import *

--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 '''

--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -1,12 +1,14 @@
 '''
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
+'''
 
+'''
 This file contains convenience classes for communication with
 the Pupil IPC Backbone.
 '''

--- a/pupil_src/tests/LoggerTest/build_and_run_test.py
+++ b/pupil_src/tests/LoggerTest/build_and_run_test.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 
 if __name__ == '__main__':
     import subprocess as sp

--- a/pupil_src/tests/LoggerTest/build_and_run_test.py
+++ b/pupil_src/tests/LoggerTest/build_and_run_test.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 
 if __name__ == '__main__':

--- a/pupil_src/tests/LoggerTest/loggerTest.cpp
+++ b/pupil_src/tests/LoggerTest/loggerTest.cpp
@@ -1,11 +1,12 @@
 /*
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 */
 
 #include <string>

--- a/pupil_src/tests/LoggerTest/loggerTest.cpp
+++ b/pupil_src/tests/LoggerTest/loggerTest.cpp
@@ -1,4 +1,12 @@
+/*
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
 
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+*/
 
 #include <string>
 #include <iostream>

--- a/pupil_src/tests/OptimizationCalibrationTest/lineLineTest.py
+++ b/pupil_src/tests/OptimizationCalibrationTest/lineLineTest.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 import os, sys, platform
 loc = os.path.abspath(__file__).rsplit('pupil_src', 1)
 sys.path.append(os.path.join(loc[0], 'pupil_src', 'shared_modules'))

--- a/pupil_src/tests/OptimizationCalibrationTest/lineLineTest.py
+++ b/pupil_src/tests/OptimizationCalibrationTest/lineLineTest.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform
 loc = os.path.abspath(__file__).rsplit('pupil_src', 1)

--- a/pupil_src/tests/OptimizationCalibrationTest/pointLineTest.py
+++ b/pupil_src/tests/OptimizationCalibrationTest/pointLineTest.py
@@ -1,3 +1,12 @@
+'''
+(*)~----------------------------------------------------------------------------------
+ Pupil - eye tracking platform
+ Copyright (C) 2012-2017  Pupil Labs
+
+ Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
+----------------------------------------------------------------------------------~(*)
+'''
 import os, sys, platform
 loc = os.path.abspath(__file__).rsplit('pupil_src', 1)
 sys.path.append(os.path.join(loc[0], 'pupil_src', 'shared_modules'))

--- a/pupil_src/tests/OptimizationCalibrationTest/pointLineTest.py
+++ b/pupil_src/tests/OptimizationCalibrationTest/pointLineTest.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import os, sys, platform
 loc = os.path.abspath(__file__).rsplit('pupil_src', 1)

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -29,10 +29,10 @@ pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re
 # choose files types to include
 # choose directories to exclude from search
 includes = ['*.py', '*.c','*.cpp','*.hpp','*.h','*.pxd','*.pxy','*.pxi']
-excludes = [ 'src_video', 'recordings', 'shader.py','singleeyefitter',
+excludes = [ 'recordings*', 'shader.py','singleeyefitter*',
             'vertex_buffer.py', 'gprof2dot.py','git_version.py',
             'transformations.py','libuvcc*', '.gitignore','glfw.py',
-            'version_utils.py','update_license_header.py']
+            'version_utils.py','update_license_header.py','shared_cpp*']
 
 # transform glob patterns to regular expressions
 includes = r'|'.join([fnmatch.translate(x) for x in includes])
@@ -46,6 +46,9 @@ def get_files(start_dir, includes, excludes):
             files = [f for f in files if re.search(includes, f) and not re.search(excludes, f)]
             files = [os.path.join(root, f) for f in files]
             match_files += files
+        else:
+            print("Excluding '%s'"%root)
+
     return match_files
 
 def write_header(file_name, license_txt):

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -28,10 +28,11 @@ pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re
 
 # choose files types to include
 # choose directories to exclude from search
-includes = ['*.py', '*.c']
-excludes = ['.git', '*.md', 'src_video', 'recordings', 'License', 'shader.py', 'vertex_buffer.py',
-             'gprof2dot.py','git_version.py','transformations.py','libuvcc*', '*.pstats', '*.png',
-             '*.svg', '*.ico', '*.sh', '*.icns', '*.spec', '.gitignore','glfw.py', 'version_utils.py']
+includes = ['*.py', '*.c','*.cpp','*.hpp','*.h','*.pxd','*.pxy','*.pxi']
+excludes = [ 'src_video', 'recordings', 'shader.py',
+            'vertex_buffer.py', 'gprof2dot.py','git_version.py',
+            'transformations.py','libuvcc*', '.gitignore','glfw.py',
+            'version_utils.py','update_license_header.py']
 
 # transform glob patterns to regular expressions
 includes = r'|'.join([fnmatch.translate(x) for x in includes])
@@ -54,10 +55,12 @@ def write_header(file_name, license_txt):
     py_comment = ["'''\n","\n'''\n"]
     file_type = os.path.splitext(file_name)[-1]
 
-    if file_type == '.py':
+    if file_type in ('.py','.pxd','.pxy','.pxi'):
         license_txt = py_comment[0] + license_txt + py_comment[1]
-    if file_type == '.c':
+    elif file_type in ('.c','.cpp','.hpp','.h'):
         license_txt = c_comment[0] + license_txt + c_comment[1]
+    else:
+        raise Excection("Dont know how to deal with this filetype")
 
     with file(file_name, 'r') as original:
         data = original.read()

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -12,15 +12,15 @@ import os
 import re
 
 license_txt = """\
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2017  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)\
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)\
 """
-
 
 # find out the cwd and change to the top level Pupil folder
 cwd = os.getcwd()

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -14,10 +14,10 @@ import re
 license_txt = """\
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+ Copyright (C) 2012-2017  Pupil Labs
 
  Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
+ License details are in the files COPYING and COPYING.LESSER, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)\
 """
 
@@ -32,7 +32,7 @@ pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re
 # choose directories to exclude from search
 includes = ['*.py', '*.c']
 excludes = ['.git', '*.md', 'src_video', 'recordings', 'License', 'shader.py', 'vertex_buffer.py',
- 			 'gprof2dot.py','git_version.py','libuvcc*', '*.pstats', '*.png',
+ 			 'gprof2dot.py','git_version.py','transformations.py','libuvcc*', '*.pstats', '*.png',
  			 '*.svg', '*.ico', '*.sh', '*.icns', '*.spec', '.gitignore','glfw.py', 'version_utils.py']
 
 # transform glob patterns to regular expressions

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -29,7 +29,7 @@ pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re
 # choose files types to include
 # choose directories to exclude from search
 includes = ['*.py', '*.c','*.cpp','*.hpp','*.h','*.pxd','*.pxy','*.pxi']
-excludes = [ 'src_video', 'recordings', 'shader.py',
+excludes = [ 'src_video', 'recordings', 'shader.py','singleeyefitter',
             'vertex_buffer.py', 'gprof2dot.py','git_version.py',
             'transformations.py','libuvcc*', '.gitignore','glfw.py',
             'version_utils.py','update_license_header.py']

--- a/update_license_header.py
+++ b/update_license_header.py
@@ -1,11 +1,12 @@
 '''
-(*)~----------------------------------------------------------------------------------
- Pupil - eye tracking platform
- Copyright (C) 2012-2016  Pupil Labs
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
 
- Distributed under the terms of the GNU Lesser General Public License (LGPL v3.0).
- License details are in the file license.txt, distributed as part of this software.
-----------------------------------------------------------------------------------~(*)
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
 '''
 import fnmatch
 import os
@@ -22,9 +23,6 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)\
 """
 
-# find out the cwd and change to the top level Pupil folder
-cwd = os.getcwd()
-pupil_dir = os.path.join(cwd,'pupil_src')
 
 pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re.DOTALL|re.MULTILINE)
 
@@ -32,56 +30,57 @@ pattern = re.compile('(\'{3}|[/][*])\n\([*]\)~(.+?)~\([*]\)\n(\'{3}|[*][/])', re
 # choose directories to exclude from search
 includes = ['*.py', '*.c']
 excludes = ['.git', '*.md', 'src_video', 'recordings', 'License', 'shader.py', 'vertex_buffer.py',
- 			 'gprof2dot.py','git_version.py','transformations.py','libuvcc*', '*.pstats', '*.png',
- 			 '*.svg', '*.ico', '*.sh', '*.icns', '*.spec', '.gitignore','glfw.py', 'version_utils.py']
+             'gprof2dot.py','git_version.py','transformations.py','libuvcc*', '*.pstats', '*.png',
+             '*.svg', '*.ico', '*.sh', '*.icns', '*.spec', '.gitignore','glfw.py', 'version_utils.py']
 
 # transform glob patterns to regular expressions
 includes = r'|'.join([fnmatch.translate(x) for x in includes])
 excludes = r'|'.join([fnmatch.translate(x) for x in excludes]) or r'$.'
 
 def get_files(start_dir, includes, excludes):
-	# use os.walk to recursively dig down into the Pupil directory
-	match_files = []
-	for root, dirs, files in os.walk(start_dir):
-		if not re.search(excludes, root):
-			files = [f for f in files if re.search(includes, f) and not re.search(excludes, f)]
-			files = [os.path.join(root, f) for f in files]
-			match_files += files
-	return match_files
+    # use os.walk to recursively dig down into the Pupil directory
+    match_files = []
+    for root, dirs, files in os.walk(start_dir):
+        if not re.search(excludes, root):
+            files = [f for f in files if re.search(includes, f) and not re.search(excludes, f)]
+            files = [os.path.join(root, f) for f in files]
+            match_files += files
+    return match_files
 
 def write_header(file_name, license_txt):
-	# find and replace license header
-	# or add new header if not existing
-	c_comment = ['/*\n', '\n*/\n']
-	py_comment = ["'''\n","\n'''\n"]
-	file_type = os.path.splitext(file_name)[-1]
+    # find and replace license header
+    # or add new header if not existing
+    c_comment = ['/*\n', '\n*/\n']
+    py_comment = ["'''\n","\n'''\n"]
+    file_type = os.path.splitext(file_name)[-1]
 
-	if file_type == '.py':
-		license_txt = py_comment[0] + license_txt + py_comment[1]
-	if file_type == '.c':
-		license_txt = c_comment[0] + license_txt + c_comment[1]
+    if file_type == '.py':
+        license_txt = py_comment[0] + license_txt + py_comment[1]
+    if file_type == '.c':
+        license_txt = c_comment[0] + license_txt + c_comment[1]
 
-	with file(file_name, 'r') as original:
-		data = original.read()
+    with file(file_name, 'r') as original:
+        data = original.read()
 
-	with file(file_name, 'w') as modified:
-		if re.findall(pattern, data):
-			# if header already exists, then update, but dont add the last newline.
-			modified.write(re.sub(pattern, license_txt[:-1], data))
-			modified.close()
-		else:
-			# else write the license header
-			modified.write(license_txt + data)
-			modified.close()
-
-def update_header():
-	# Add a license/docstring header to selected files
-	match_files = get_files(pupil_dir, includes, excludes)
-	print match_files
-
-	for f in match_files:
-		write_header(f, license_txt)
+    with file(file_name, 'w') as modified:
+        if re.findall(pattern, data):
+            # if header already exists, then update, but dont add the last newline.
+            modified.write(re.sub(pattern, license_txt[:-1], data))
+            modified.close()
+        else:
+            # else write the license header
+            modified.write(license_txt + data)
+            modified.close()
 
 if __name__ == '__main__':
-	# run update_header() to add headers to find files
-	update_header()
+
+    # find out the cwd and change to the top level Pupil folder
+    cwd = os.getcwd()
+    pupil_dir = cwd
+
+    # Add a license/docstring header to selected files
+    match_files = get_files(pupil_dir, includes, excludes)
+    print len(match_files)
+
+    for f in match_files:
+        write_header(f, license_txt)


### PR DESCRIPTION
Updating license headers for 🎆  2017 🎆 , and added license headers to cython files that previously did not have headers. 

Todo
  - check to make sure that no files are left out of this update and test build.
 - The update license header script could also use some improvements to include `.pyx`, `.pyd`, `.h`, and `.hpp`, and relevant `.cpp` files. 