### PR TITLE
Fixes deprecated camera calibration format #639

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -72,7 +72,7 @@ def load_camera_calibration(g_pool):
             camera_calibration['camera_name']
         except KeyError:
             camera_calibration = None
-            logger.warning('Deprecated camera calibration format. Ignoring {}.'.format(os.path.join(g_pool.user_dir, 'camera_calibration')))
+            logger.warning('Invalid or Deprecated camera calibration found. Please recalibrate camera.')
         except:
             camera_calibration = None
         else:

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -71,6 +71,7 @@ def load_camera_calibration(g_pool):
             camera_calibration = load_object(os.path.join(g_pool.user_dir,'camera_calibration'))
             camera_calibration['camera_name']
         except KeyError:
+            camera_calibration = None
             logger.warning('Deprecated camera calibration format. Ignoring {}.'.format(os.path.join(g_pool.user_dir, 'camera_calibration')))
         except:
             camera_calibration = None

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -69,6 +69,9 @@ def load_camera_calibration(g_pool):
     if g_pool.app == 'capture':
         try:
             camera_calibration = load_object(os.path.join(g_pool.user_dir,'camera_calibration'))
+            camera_calibration['camera_name']
+        except KeyError:
+            logger.warning('Deprecated camera calibration format. Ignoring {}.'.format(os.path.join(g_pool.user_dir, 'camera_calibration')))
         except:
             camera_calibration = None
         else:


### PR DESCRIPTION
To upgrade calibration settings file, load the file content, change the keys to unicode objects, store it back to the file.