### PR TITLE
Fix broken Audio Modes in Capture 0.9.1 linux bundle

### DIFF
--- a/pupil_src/shared_modules/audio/__init__.py
+++ b/pupil_src/shared_modules/audio/__init__.py
@@ -44,7 +44,7 @@ if os_name == "Linux":
     ffmpeg_bin = "avconv"
     arecord_bin = 'arecord'
 
-    if 'Ubuntu' in platform.linux_distribution():
+    if platform.linux_distribution()[0] in ('Ubuntu', 'debian'):
         def beep():
             if 'sound' in audio_mode:
                 try:


### PR DESCRIPTION
Fixes #651

platform.linux_distribution() returns different values when running from bundle