### PR TITLE
Consistent ui scaling across different monitor pixel densities

### DIFF
--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -149,10 +149,11 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         # Callback functions
         def on_resize(window, w, h):
             if is_window_visible(window):
+                hdpi_factor = glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0]
                 active_window = glfw.glfwGetCurrentContext()
                 glfw.glfwMakeContextCurrent(window)
                 g_pool.gui.update_window(w, h)
-                graph.adjust_size(w, h)
+                graph.adjust_size(w*hdpi_factor, h*hdpi_factor)
                 adjust_gl_view(w, h)
                 glfw.glfwMakeContextCurrent(active_window)
 

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -297,17 +297,18 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
 
         # setup GUI
         g_pool.gui = ui.UI()
+        g_pool.gui_user_scale = session_settings.get('gui_scale', 1.)
         g_pool.sidebar = ui.Scrolling_Menu("Settings",
                                            pos=(-300, 0),
                                            size=(0, 0),
                                            header_pos='left')
         general_settings = ui.Growing_Menu('General')
-        general_settings.append(ui.Slider(  'scale',g_pool.gui,
-                                            setter=set_scale,
-                                            step = .05,
-                                            min=1.,
-                                            max=2.5,
-                                            label='Interface Size'))
+        general_settings.append(ui.Slider('gui_user_scale', g_pool,
+                                          setter=set_scale,
+                                          step=.05,
+                                          min=.5,
+                                          max=1.5,
+                                          label='Interface Size'))
         general_settings.append(ui.Button('Reset window size',lambda: glfw.glfwSetWindowSize(main_window,*g_pool.capture.frame_size)) )
         general_settings.append(ui.Switch('flip',g_pool,label='Flip image display'))
         general_settings.append(ui.Selector('display_mode',
@@ -382,8 +383,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         glfw.glfwSetScrollCallback(main_window, on_scroll)
 
         # set the last saved window size
-        # on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
-        set_scale(session_settings.get('gui_scale', 1))
+        on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
 
         # load last gui configuration
         g_pool.gui.configuration = session_settings.get('ui_config', {})

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -149,11 +149,11 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         # Callback functions
         def on_resize(window, w, h):
             if is_window_visible(window):
-                hdpi_factor = glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0]
+                print('>eye>', w,h)
                 active_window = glfw.glfwGetCurrentContext()
                 glfw.glfwMakeContextCurrent(window)
                 g_pool.gui.update_window(w, h)
-                graph.adjust_size(w*hdpi_factor, h*hdpi_factor)
+                graph.adjust_size(w, h)
                 adjust_gl_view(w, h)
                 glfw.glfwMakeContextCurrent(active_window)
 

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -381,7 +381,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         glfw.glfwSetScrollCallback(main_window, on_scroll)
 
         # set the last saved window size
-        on_resize(main_window, *glfw.glfwGetWindowSize(main_window))
+        on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
 
         # load last gui configuration
         g_pool.gui.configuration = session_settings.get('ui_config', {})

--- a/pupil_src/capture/eye.py
+++ b/pupil_src/capture/eye.py
@@ -282,6 +282,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         width, height = session_settings.get(
             'window_size', g_pool.capture.frame_size)
         main_window = glfw.glfwCreateWindow(width, height, title, None, None)
+        hdpi_factor = float(glfw.glfwGetFramebufferSize(main_window)[0] / glfw.glfwGetWindowSize(main_window)[0])
         window_pos = session_settings.get(
             'window_position', window_position_default)
         glfw.glfwSetWindowPos(main_window, window_pos[0], window_pos[1])
@@ -295,7 +296,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
 
         # setup GUI
         g_pool.gui = ui.UI()
-        g_pool.gui.scale = session_settings.get('gui_scale', 1)
+        g_pool.gui.scale = session_settings.get('gui_scale', hdpi_factor)
         g_pool.sidebar = ui.Scrolling_Menu("Settings",
                                            pos=(-300, 0),
                                            size=(0, 0),

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -297,9 +297,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
 
     # setup GUI
     g_pool.gui = ui.UI()
+    g_pool.gui_user_scale = session_settings.get('gui_scale', 1.)
     g_pool.sidebar = ui.Scrolling_Menu("Settings", pos=(-350, 0), size=(0, 0), header_pos='left')
     general_settings = ui.Growing_Menu('General')
-    general_settings.append(ui.Slider('scale',g_pool.gui, setter=set_scale,step = .05,min=1.,max=2.5,label='Interface size'))
+    general_settings.append(ui.Slider('gui_user_scale', g_pool, setter=set_scale, step=.05, min=.5, max=1.5, label='Interface size'))
     general_settings.append(ui.Button('Reset window size',lambda: glfw.glfwSetWindowSize(main_window,g_pool.capture.frame_size[0],g_pool.capture.frame_size[1])) )
     general_settings.append(ui.Selector('audio_mode',audio,selection=audio.audio_modes))
     general_settings.append(ui.Selector('detection_mapping_mode',
@@ -383,8 +384,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     g_pool.image_tex = Named_Texture()
 
     # trigger setup of window and gl sizes
-    # on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
-    set_scale(session_settings.get('gui_scale', 1))
+    on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
 
     # now the we have  aproper window we can load the last gui configuration
     g_pool.gui.configuration = session_settings.get('ui_config', {})

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -288,6 +288,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     glfw.glfwInit()
     width, height = session_settings.get('window_size', (1280, 720))
     main_window = glfw.glfwCreateWindow(width, height, "Pupil Capture - World")
+    hdpi_factor = float(glfw.glfwGetFramebufferSize(main_window)[0] / glfw.glfwGetWindowSize(main_window)[0])
     window_pos = session_settings.get('window_position', window_position_default)
     glfw.glfwSetWindowPos(main_window, window_pos[0], window_pos[1])
     glfw.glfwMakeContextCurrent(main_window)
@@ -296,7 +297,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
 
     # setup GUI
     g_pool.gui = ui.UI()
-    g_pool.gui.scale = session_settings.get('gui_scale', 1)
+    g_pool.gui.scale = session_settings.get('gui_scale', hdpi_factor)
     g_pool.sidebar = ui.Scrolling_Menu("Settings", pos=(-350, 0), size=(0, 0), header_pos='left')
     general_settings = ui.Growing_Menu('General')
     general_settings.append(ui.Slider('scale',g_pool.gui, setter=set_scale,step = .05,min=1.,max=2.5,label='Interface size'))

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -175,10 +175,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # Callback functions
     def on_resize(window, w, h):
         if gl_utils.is_window_visible(window):
-            hdpi_factor = glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0]
+            print('>wld>', w,h)
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()
-            graph.adjust_size(w*hdpi_factor, h*hdpi_factor)
+            graph.adjust_size(w, h)
             gl_utils.adjust_gl_view(w, h)
             for p in g_pool.plugins:
                 p.on_window_resize(window, w, h)

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -175,9 +175,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # Callback functions
     def on_resize(window, w, h):
         if gl_utils.is_window_visible(window):
+            hdpi_factor = glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0]
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()
-            graph.adjust_size(w, h)
+            graph.adjust_size(w*hdpi_factor, h*hdpi_factor)
             gl_utils.adjust_gl_view(w, h)
             for p in g_pool.plugins:
                 p.on_window_resize(window, w, h)

--- a/pupil_src/capture/world.py
+++ b/pupil_src/capture/world.py
@@ -73,7 +73,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # display
     import glfw
     from pyglui import ui, graph, cygl, __version__ as pyglui_version
-    assert pyglui_version >= '1.2'
+    assert pyglui_version >= '1.3'
     from pyglui.cygl.utils import Named_Texture
     import gl_utils
 
@@ -179,7 +179,9 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()
-            graph.adjust_size(w, h)
+            for g in g_pool.graphs:
+                g.scale = hdpi_factor
+                g.adjust_size(w, h)
             gl_utils.adjust_gl_view(w, h)
             for p in g_pool.plugins:
                 p.on_window_resize(window, w, h)
@@ -300,7 +302,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     g_pool.gui_user_scale = session_settings.get('gui_scale', 1.)
     g_pool.sidebar = ui.Scrolling_Menu("Settings", pos=(-350, 0), size=(0, 0), header_pos='left')
     general_settings = ui.Growing_Menu('General')
-    general_settings.append(ui.Slider('gui_user_scale', g_pool, setter=set_scale, step=.05, min=.5, max=1.5, label='Interface size'))
+    general_settings.append(ui.Selector('gui_user_scale', g_pool, setter=set_scale, selection=[0.5, 0.75, 1., 1.5, 2.], label='Interface size'))
     general_settings.append(ui.Button('Reset window size',lambda: glfw.glfwSetWindowSize(main_window,g_pool.capture.frame_size[0],g_pool.capture.frame_size[1])) )
     general_settings.append(ui.Selector('audio_mode',audio,selection=audio.audio_modes))
     general_settings.append(ui.Selector('detection_mapping_mode',
@@ -383,12 +385,8 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     gl_utils.basic_gl_setup()
     g_pool.image_tex = Named_Texture()
 
-    # trigger setup of window and gl sizes
-    on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
-
     # now the we have  aproper window we can load the last gui configuration
     g_pool.gui.configuration = session_settings.get('ui_config', {})
-
 
     # create a timer to control window update frequency
     window_update_timer = timer(1 / 60)
@@ -420,6 +418,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     pupil1_graph.update_rate = 5
     pupil1_graph.label = "id1 conf: %0.2f"
     pupil_graphs = pupil0_graph, pupil1_graph
+    g_pool.graphs = [cpu_graph, fps_graph, pupil0_graph, pupil1_graph]
+
+    # trigger setup of window and gl sizes
+    on_resize(main_window, *glfw.glfwGetFramebufferSize(main_window))
 
     if session_settings.get('eye1_process_alive', False):
         launch_eye_process(1, delay=0.6)
@@ -486,12 +488,12 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             g_pool.capture.gl_display()
             for p in g_pool.plugins:
                 p.gl_display()
-            graph.push_view()
-            fps_graph.draw()
-            cpu_graph.draw()
-            pupil0_graph.draw()
-            pupil1_graph.draw()
+
+            graph.push_view(*glfw.glfwGetFramebufferSize(main_window))
+            for g in g_pool.graphs:
+                g.draw()
             graph.pop_view()
+
             g_pool.gui.update()
             glfw.glfwSwapBuffers(main_window)
         glfw.glfwPollEvents()

--- a/pupil_src/player/main.py
+++ b/pupil_src/player/main.py
@@ -95,7 +95,7 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-assert pyglui_version >= '1.0'
+assert pyglui_version >= '1.3'
 
 # since we are not using OS.fork on MacOS we need to do a few extra things to log our exports correctly.
 if platform.system() == 'Darwin':
@@ -156,12 +156,17 @@ def session(rec_dir):
 
     # Callback functions
     def on_resize(window, w, h):
-        g_pool.gui.update_window(w, h)
-        g_pool.gui.collect_menus()
-        graph.adjust_size(w, h)
-        gl_utils.adjust_gl_view(w, h)
-        for p in g_pool.plugins:
-            p.on_window_resize(window, w, h)
+        if gl_utils.is_window_visible(window):
+            hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
+            g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
+            g_pool.gui.update_window(w, h)
+            g_pool.gui.collect_menus()
+            for g in g_pool.graphs:
+                g.scale = hdpi_factor
+                g.adjust_size(w, h)
+            gl_utils.adjust_gl_view(w, h)
+            for p in g_pool.plugins:
+                p.on_window_resize(window, w, h)
 
     def on_key(window, key, scancode, action, mods):
         g_pool.gui.update_key(key, scancode, action, mods)
@@ -236,6 +241,10 @@ def session(rec_dir):
     glfwMakeContextCurrent(main_window)
     cygl.utils.init()
 
+    def set_scale(new_scale):
+        g_pool.gui_user_scale = new_scale
+        on_resize(main_window, *glfwGetFramebufferSize(main_window))
+
     # load pupil_positions, gaze_positions
     pupil_data = load_object(pupil_data_path)
     pupil_list = pupil_data['pupil_positions']
@@ -276,10 +285,6 @@ def session(rec_dir):
             logger.warning("End of video - restart at beginning.")
         g_pool.play = new_state
 
-    def set_scale(new_scale):
-        g_pool.gui.scale = new_scale
-        g_pool.gui.collect_menus()
-
     def set_data_confidence(new_confidence):
         g_pool.min_data_confidence = new_confidence
         notification = {'subject': 'min_data_confidence_changed'}
@@ -316,10 +321,10 @@ def session(rec_dir):
         g_pool.notifications.append(notification)
 
     g_pool.gui = ui.UI()
-    g_pool.gui.scale = session_settings.get('gui_scale', 1)
+    g_pool.gui_user_scale = session_settings.get('gui_scale', 1.)
     g_pool.main_menu = ui.Scrolling_Menu("Settings", pos=(-350, 20), size=(300, 500))
     g_pool.main_menu.append(ui.Button("Close Pupil Player", lambda: glfwSetWindowShouldClose(main_window, True)))
-    g_pool.main_menu.append(ui.Slider('scale', g_pool.gui, setter=set_scale, step=.05, min=0.75, max=2.5, label='Interface Size'))
+    g_pool.main_menu.append(ui.Selector('gui_user_scale', g_pool, setter=set_scale, selection=[.5, .75, 1., 1.5, 2.], label='Interface Size'))
     g_pool.main_menu.append(ui.Info_Text('Player Version: {}'.format(g_pool.version)))
     g_pool.main_menu.append(ui.Info_Text('Capture Version: {}'.format(meta_info['Capture Software Version'])))
     g_pool.main_menu.append(ui.Info_Text('Data Format Version: {}'.format(meta_info['Data Format Version'])))
@@ -406,8 +411,6 @@ def session(rec_dir):
     glfwSetCursorPosCallback(main_window, on_pos)
     glfwSetScrollCallback(main_window, on_scroll)
     glfwSetDropCallback(main_window, on_drop)
-    # trigger on_resize
-    on_resize(main_window, *glfwGetFramebufferSize(main_window))
 
     g_pool.gui.configuration = session_settings.get('ui_config', {})
 
@@ -435,6 +438,10 @@ def session(rec_dir):
     pupil_graph.pos = (260, 110)
     pupil_graph.update_rate = 5
     pupil_graph.label = "Confidence: %0.2f"
+    g_pool.graphs = [cpu_graph, fps_graph, pupil_graph]
+
+    # trigger on_resize
+    on_resize(main_window, *glfwGetFramebufferSize(main_window))
 
     while not glfwWindowShouldClose(main_window):
         # grab new frame
@@ -505,7 +512,7 @@ def session(rec_dir):
         for p in g_pool.plugins:
             p.gl_display()
 
-        graph.push_view()
+        graph.push_view(*glfwGetFramebufferSize(main_window))
         fps_graph.draw()
         cpu_graph.draw()
         pupil_graph.draw()
@@ -520,7 +527,7 @@ def session(rec_dir):
 
     session_settings['loaded_plugins'] = g_pool.plugins.get_initializers()
     session_settings['min_data_confidence'] = g_pool.min_data_confidence
-    session_settings['gui_scale'] = g_pool.gui.scale
+    session_settings['gui_scale'] = g_pool.gui_user_scale
     session_settings['ui_config'] = g_pool.gui.configuration
     session_settings['window_size'] = glfwGetWindowSize(main_window)
     session_settings['window_position'] = glfwGetWindowPos(main_window)
@@ -569,7 +576,6 @@ def show_no_rec_window():
     glfwSetWindowPos(window, window_pos[0], window_pos[1])
     glfwSetDropCallback(window, on_drop)
 
-    gl_utils.adjust_gl_view(w, h)
     glfont = fontstash.Context()
     glfont.add_font('roboto', get_roboto_font_path())
     glfont.set_align_string(v_align="center", h_align="middle")
@@ -580,19 +586,24 @@ def show_no_rec_window():
     tip = '(Tip: You can drop a recording directory onto the app icon.)'
     # text = "Please supply a Pupil recording directory as first arg when calling Pupil Player."
     while not glfwWindowShouldClose(window):
+
+        fb_size = glfwGetFramebufferSize(window)
+        hdpi_factor = float(fb_size[0] / glfwGetWindowSize(window)[0])
+        gl_utils.adjust_gl_view(*fb_size)
+
         gl_utils.clear_gl_screen()
         glfont.set_blur(10.5)
         glfont.set_color_float((0.0, 0.0, 0.0, 1.))
-        glfont.set_size(w/25.)
-        glfont.draw_text(w/2, .3*h, text)
-        glfont.set_size(w/30.)
-        glfont.draw_text(w/2, .4*h, tip)
+        glfont.set_size(w/25.*hdpi_factor)
+        glfont.draw_text(w/2*hdpi_factor, .3*h*hdpi_factor, text)
+        glfont.set_size(w/30.*hdpi_factor)
+        glfont.draw_text(w/2*hdpi_factor, .4*h*hdpi_factor, tip)
         glfont.set_blur(0.96)
         glfont.set_color_float((1., 1., 1., 1.))
-        glfont.set_size(w/25.)
-        glfont.draw_text(w/2, .3*h, text)
-        glfont.set_size(w/30.)
-        glfont.draw_text(w/2, .4*h, tip)
+        glfont.set_size(w/25.*hdpi_factor)
+        glfont.draw_text(w/2*hdpi_factor, .3*h*hdpi_factor, text)
+        glfont.set_size(w/30.*hdpi_factor)
+        glfont.draw_text(w/2*hdpi_factor, .4*h*hdpi_factor, tip)
         glfwSwapBuffers(window)
         glfwPollEvents()
 

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -170,26 +170,26 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         self.clicks_to_close = 5
         self.open_window("Calibration")
 
-    def open_window(self,title='new_window'):
+    def open_window(self, title='new_window'):
         if not self._window:
             if self.fullscreen:
                 monitor = glfwGetMonitors()[self.monitor_idx]
-                width,height,redBits,blueBits,greenBits,refreshRate = glfwGetVideoMode(monitor)
+                width, height, redBits, blueBits, greenBits, refreshRate = glfwGetVideoMode(monitor)
             else:
                 monitor = None
                 width,height= 640,360
 
             self._window = glfwCreateWindow(width, height, title, monitor=monitor, share=glfwGetCurrentContext())
             if not self.fullscreen:
-                glfwSetWindowPos(self._window,self.window_position_default[0],self.window_position_default[1])
+                glfwSetWindowPos(self._window, self.window_position_default[0], self.window_position_default[1])
 
-            glfwSetInputMode(self._window,GLFW_CURSOR,GLFW_CURSOR_HIDDEN)
+            glfwSetInputMode(self._window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN)
 
-            #Register callbacks
-            glfwSetFramebufferSizeCallback(self._window,on_resize)
-            glfwSetKeyCallback(self._window,self.on_key)
-            glfwSetMouseButtonCallback(self._window,self.on_button)
-            on_resize(self._window,*glfwGetFramebufferSize(self._window))
+            # Register callbacks
+            glfwSetFramebufferSizeCallback(self._window, on_resize)
+            glfwSetKeyCallback(self._window, self.on_key)
+            glfwSetMouseButtonCallback(self._window, self.on_button)
+            on_resize(self._window, *glfwGetFramebufferSize(self._window))
 
             # gl_state settings
             active_window = glfwGetCurrentContext()
@@ -228,8 +228,8 @@ class Screen_Marker_Calibration(Calibration_Plugin):
     def close_window(self):
         if self._window:
             # enable mouse display
-            active_window = glfwGetCurrentContext();
-            glfwSetInputMode(self._window,GLFW_CURSOR,GLFW_CURSOR_NORMAL)
+            active_window = glfwGetCurrentContext()
+            glfwSetInputMode(self._window, GLFW_CURSOR, GLFW_CURSOR_NORMAL)
             glfwDestroyWindow(self._window)
             self._window = None
             glfwMakeContextCurrent(active_window)
@@ -305,11 +305,11 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         # debug mode within world will show green ellipses around detected ellipses
         if self.active and self.detected:
             for marker in self.markers:
-                e = marker[-1] #outermost ellipse
-                pts = cv2.ellipse2Poly( (int(e[0][0]),int(e[0][1])),
-                                    (int(e[1][0]/2),int(e[1][1]/2)),
-                                    int(e[-1]),0,360,15)
-                draw_polyline(pts,1,RGBA(0.,1.,0.,1.))
+                e = marker[-1]  # outermost ellipse
+                pts = cv2.ellipse2Poly((int(e[0][0]), int(e[0][1])),
+                                       (int(e[1][0]/2), int(e[1][1]/2)),
+                                       int(e[-1]), 0, 360, 15)
+                draw_polyline(pts, 1, RGBA(0.,1.,0.,1.))
 
         else:
             pass
@@ -331,8 +331,8 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         r = 110*self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()
-        p_window_size = glfwGetWindowSize(self._window)
-        gl.glOrtho(0,p_window_size[0],p_window_size[1],0 ,-1,1)
+        p_window_size = glfwGetFramebufferSize(self._window)
+        gl.glOrtho(0, p_window_size[0], p_window_size[1], 0, -1, 1)
         # Switch back to Model View Matrix
         gl.glMatrixMode(gl.GL_MODELVIEW)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -15,6 +15,7 @@ from glfw import glfwGetFramebufferSize,glfwGetCurrentContext
 import zmq_tools
 from pyglui.pyfontstash import fontstash
 from pyglui.ui import get_opensans_font_path
+import glfw
 
 from time import time
 
@@ -70,11 +71,14 @@ class Log_Display(Plugin):
         self.rendered_log.append(record)
         self.alpha += duration_from_level(record.levelname) + len(str(record.msg))/100.
         self.rendered_log = self.rendered_log[-10:]
-        self.alpha = min(self.alpha,6.)
+        self.alpha = min(self.alpha, 6.)
 
-    def on_window_resize(self,window,w,h):
-        self.window_size = w,h
+    def on_window_resize(self, window, w, h):
+        self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+        self.glfont.set_size(32*self.window_scale)
+        self.window_size = w, h
         self.tex.resize(*self.window_size)
+        self.should_redraw = True
 
     def recent_events(self,events):
         if self._socket and self._socket.new_data:
@@ -96,7 +100,7 @@ class Log_Display(Plugin):
                 self.glfont.set_blur(0.96)
                 self.glfont.set_color_float(color_from_level(record.levelname))
                 self.glfont.draw_limited_text(self.window_size[0]/2.,y,str(record.processName.upper())+': '+str(record.msg),self.window_size[0]*0.8)
-                y +=lineh
+                y += lineh
             pop_ortho()
             self.tex.pop()
             self.should_redraw = False


### PR DESCRIPTION
`glfw` differentiates between _frame buffer size_ and _window size_ -- the former referring to the size in pixels and the lather to the size in screen coordinates (see [docs](http://www.glfw.org/docs/latest/group__window.html#ga0e2637a4161afb283f5300c7f94785c9)). Usually, these sizes are the same but they differ on screens with higher pixel densities (e.g. Retina displays).

This can lead to unexpected behavior of the ui. This pull request reacts appropriately to changes in pixel densities and fixes unexpected behavior.

Requires `pyglui` `v1.3` or higher (https://github.com/pupil-labs/pyglui/pull/45)