### PR TITLE
Add version requirement for pyre >= 0.3.1

### DIFF
--- a/pupil_src/shared_modules/time_sync.py
+++ b/pupil_src/shared_modules/time_sync.py
@@ -23,10 +23,19 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+pyre_requirement = 'Pyre >= 0.3.1 is required for Time Sync to work'
+try:
+    from pyre import __version__
+except ImportError:
+    logger.error(pyre_requirement)
+else:
+    if __version__ < '0.3.1':
+        logger.error(pyre_requirement)
+
 
 class Clock_Service(object):
     """Represents a remote clock service and is sortable by rank."""
-    def __init__(self, uuid,name, rank, port):
+    def __init__(self, uuid, name, rank, port):
         super(Clock_Service, self).__init__()
         self.uuid = uuid
         self.rank = rank
@@ -34,7 +43,7 @@ class Clock_Service(object):
         self.name = name
 
     def __repr__(self):
-        return '{:.2f}:{}'.format(self.rank,self.name)
+        return '{:.2f}:{}'.format(self.rank, self.name)
 
     def __lt__(self, other):
         # "smallest" object has highest rank

--- a/pupil_src/shared_modules/time_sync.py
+++ b/pupil_src/shared_modules/time_sync.py
@@ -23,14 +23,11 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-pyre_requirement = 'Pyre >= 0.3.1 is required for Time Sync to work'
 try:
     from pyre import __version__
-except ImportError:
-    logger.error(pyre_requirement)
-else:
-    if __version__ < '0.3.1':
-        logger.error(pyre_requirement)
+    assert __version__ >= '0.3.1'
+except (ImportError, AssertionError):
+    raise Exception("Pyre version is to old. Please upgrade")
 
 
 class Clock_Service(object):
@@ -119,7 +116,6 @@ class Time_Sync(Plugin):
                 self.evaluate_leaderboard()
             elif evt.type == 'JOIN' and evt.group == self.sync_group:
                 should_announce = True
-                self.announce_clock_master_info()
             elif (evt.type == 'LEAVE' and evt.group == self.sync_group) or evt.type == 'EXIT':
                 self.remove_from_leaderboard(evt.peer_uuid)
                 self.evaluate_leaderboard()

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -293,7 +293,7 @@ class UVC_Source(Base_Source):
             self.frame_size = new_size
 
         if self.uvc_capture is None:
-            ui_elements.append(ui.Info_Text('Capture initialization faild.'))
+            ui_elements.append(ui.Info_Text('Capture initialization failed.'))
             self.g_pool.capture_source_menu.extend(ui_elements)
             return
 


### PR DESCRIPTION
Pyre does not have .version() implemented before 0.3.2,
therefore the relatively complex version test.

+ small typo fixes