### PR TITLE
Require pyndsi version 0.3.0 and higher

### DIFF
--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -16,7 +16,11 @@ import ndsi
 
 from .base_backend import Base_Source, Base_Manager
 
-assert ndsi.NDS_PROTOCOL_VERSION >= '0.2.16'
+try:
+    from ndsi import __version__
+    assert __version__ >= '0.3.0'
+except (ImportError, AssertionError):
+    raise Exception("pyndsi version is to old. Please upgrade")
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
To be merged when Pupil Mobile has implemented Time Sync.