### PR TITLE
Add on_unconsumed_key/char events

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -164,10 +164,10 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
                 adjust_gl_view(w, h)
                 glfw.glfwMakeContextCurrent(active_window)
 
-        def on_key(window, key, scancode, action, mods):
+        def on_window_key(window, key, scancode, action, mods):
             g_pool.gui.update_key(key, scancode, action, mods)
 
-        def on_char(window, char):
+        def on_window_char(window, char):
             g_pool.gui.update_char(char)
 
         def on_iconify(window, iconified):
@@ -378,8 +378,8 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         # Register callbacks main_window
         glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)
         glfw.glfwSetWindowIconifyCallback(main_window, on_iconify)
-        glfw.glfwSetKeyCallback(main_window, on_key)
-        glfw.glfwSetCharCallback(main_window, on_char)
+        glfw.glfwSetKeyCallback(main_window, on_window_key)
+        glfw.glfwSetCharCallback(main_window, on_window_char)
         glfw.glfwSetMouseButtonCallback(main_window, on_button)
         glfw.glfwSetCursorPosCallback(main_window, on_pos)
         glfw.glfwSetScrollCallback(main_window, on_scroll)

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -173,7 +173,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         def on_iconify(window, iconified):
             g_pool.iconified = iconified
 
-        def on_button(window, button, action, mods):
+        def on_window_mouse_button(window, button, action, mods):
             if g_pool.display_mode == 'roi':
                 if action == glfw.GLFW_RELEASE and g_pool.u_r.active_edit_pt:
                     g_pool.u_r.active_edit_pt = False
@@ -380,7 +380,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
         glfw.glfwSetWindowIconifyCallback(main_window, on_iconify)
         glfw.glfwSetKeyCallback(main_window, on_window_key)
         glfw.glfwSetCharCallback(main_window, on_window_char)
-        glfw.glfwSetMouseButtonCallback(main_window, on_button)
+        glfw.glfwSetMouseButtonCallback(main_window, on_window_mouse_button)
         glfw.glfwSetCursorPosCallback(main_window, on_pos)
         glfw.glfwSetScrollCallback(main_window, on_scroll)
 

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -519,11 +519,11 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
 
         for key, scancode, action, mods in unused_elements.keys:
             for p in g_pool.plugins:
-                p.on_unconsumed_key(key, scancode, action, mods)
+                p.on_key(key, scancode, action, mods)
 
         for char_ in unused_elements.chars:
             for p in g_pool.plugins:
-                p.on_unconsumed_char(char_)
+                p.on_char(char_)
 
         # present frames at appropriate speed
         cap.wait(frame)

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -134,10 +134,10 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
             for p in g_pool.plugins:
                 p.on_window_resize(window, w, h)
 
-    def on_key(window, key, scancode, action, mods):
+    def on_window_key(window, key, scancode, action, mods):
         g_pool.gui.update_key(key, scancode, action, mods)
 
-    def on_char(window, char):
+    def on_window_char(window, char):
         g_pool.gui.update_char(char)
 
     def on_button(window, button, action, mods):
@@ -382,8 +382,8 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
 
     # Register callbacks main_window
     glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)
-    glfw.glfwSetKeyCallback(main_window, on_key)
-    glfw.glfwSetCharCallback(main_window, on_char)
+    glfw.glfwSetKeyCallback(main_window, on_window_key)
+    glfw.glfwSetCharCallback(main_window, on_window_char)
     glfw.glfwSetMouseButtonCallback(main_window, on_button)
     glfw.glfwSetCursorPosCallback(main_window, on_pos)
     glfw.glfwSetScrollCallback(main_window, on_scroll)

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -140,7 +140,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
     def on_window_char(window, char):
         g_pool.gui.update_char(char)
 
-    def on_button(window, button, action, mods):
+    def on_window_mouse_button(window, button, action, mods):
         g_pool.gui.update_button(button, action, mods)
 
     def on_pos(window, x, y):
@@ -384,7 +384,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
     glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)
     glfw.glfwSetKeyCallback(main_window, on_window_key)
     glfw.glfwSetCharCallback(main_window, on_window_char)
-    glfw.glfwSetMouseButtonCallback(main_window, on_button)
+    glfw.glfwSetMouseButtonCallback(main_window, on_window_mouse_button)
     glfw.glfwSetCursorPosCallback(main_window, on_pos)
     glfw.glfwSetScrollCallback(main_window, on_scroll)
     glfw.glfwSetDropCallback(main_window, on_drop)

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -105,7 +105,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
     from pupil_producers import Pupil_From_Recording, Offline_Pupil_Detection
     from gaze_producers import Gaze_From_Recording, Offline_Calibration
 
-    assert pyglui_version >= '1.5'
+    assert pyglui_version >= '1.6'
 
     runtime_plugins = import_runtime_plugins(os.path.join(user_dir, 'plugins'))
     system_plugins = [Log_Display, Seek_Bar, Trim_Marks]
@@ -508,14 +508,22 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         fps_graph.draw()
         cpu_graph.draw()
         pupil_graph.draw()
-        unused_buttons = g_pool.gui.update()
-        for b in unused_buttons:
-            button,action,mods = b
+        unused_elements = g_pool.gui.update()
+        for b in unused_elements.buttons:
+            button, action, mods = b
             pos = glfw.glfwGetCursorPos(main_window)
             pos = normalize(pos, glfw.glfwGetWindowSize(main_window))
             pos = denormalize(pos, (frame.img.shape[1], frame.img.shape[0]))  # Position in img pixels
             for p in g_pool.plugins:
                 p.on_click(pos, button, action)
+
+        for key, scancode, action, mods in unused_elements.keys:
+            for p in g_pool.plugins:
+                p.on_unconsumed_key(key, scancode, action, mods)
+
+        for char_ in unused_elements.chars:
+            for p in g_pool.plugins:
+                p.on_unconsumed_char(char_)
 
         # present frames at appropriate speed
         cap.wait(frame)

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -508,11 +508,11 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
 
             for key, scancode, action, mods in unused_elements.keys:
                 for p in g_pool.plugins:
-                    p.on_unconsumed_key(key, scancode, action, mods)
+                    p.on_key(key, scancode, action, mods)
 
             for char_ in unused_elements.chars:
                 for p in g_pool.plugins:
-                    p.on_unconsumed_char(char_)
+                    p.on_char(char_)
 
             glfw.glfwSwapBuffers(main_window)
         glfw.glfwPollEvents()

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -199,7 +199,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     def on_window_char(window, char):
         g_pool.gui.update_char(char)
 
-    def on_button(window, button, action, mods):
+    def on_window_mouse_button(window, button, action, mods):
         g_pool.gui.update_button(button, action, mods)
 
     def on_pos(window, x, y):
@@ -381,7 +381,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     glfw.glfwSetWindowIconifyCallback(main_window, on_iconify)
     glfw.glfwSetKeyCallback(main_window, on_window_key)
     glfw.glfwSetCharCallback(main_window, on_window_char)
-    glfw.glfwSetMouseButtonCallback(main_window, on_button)
+    glfw.glfwSetMouseButtonCallback(main_window, on_window_mouse_button)
     glfw.glfwSetCursorPosCallback(main_window, on_pos)
     glfw.glfwSetScrollCallback(main_window, on_scroll)
 

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -193,10 +193,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     def on_iconify(window, iconified):
         g_pool.iconified = iconified
 
-    def on_key(window, key, scancode, action, mods):
+    def on_window_key(window, key, scancode, action, mods):
         g_pool.gui.update_key(key, scancode, action, mods)
 
-    def on_char(window, char):
+    def on_window_char(window, char):
         g_pool.gui.update_char(char)
 
     def on_button(window, button, action, mods):
@@ -379,8 +379,8 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # Register callbacks main_window
     glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)
     glfw.glfwSetWindowIconifyCallback(main_window, on_iconify)
-    glfw.glfwSetKeyCallback(main_window, on_key)
-    glfw.glfwSetCharCallback(main_window, on_char)
+    glfw.glfwSetKeyCallback(main_window, on_window_key)
+    glfw.glfwSetCharCallback(main_window, on_window_char)
     glfw.glfwSetMouseButtonCallback(main_window, on_button)
     glfw.glfwSetCursorPosCallback(main_window, on_pos)
     glfw.glfwSetScrollCallback(main_window, on_scroll)

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -230,7 +230,7 @@ class Camera_Intrinsics_Estimation(Calibration_Plugin):
 
             #Register callbacks
             glfwSetFramebufferSizeCallback(self._window,on_resize)
-            glfwSetKeyCallback(self._window,self.on_key)
+            glfwSetKeyCallback(self._window,self.on_window_key)
             glfwSetWindowCloseCallback(self._window,self.on_close)
             glfwSetMouseButtonCallback(self._window,self.on_button)
 
@@ -247,7 +247,7 @@ class Camera_Intrinsics_Estimation(Calibration_Plugin):
 
 
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         if action == GLFW_PRESS:
             if key == GLFW_KEY_ESCAPE:
                 self.on_close()

--- a/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/calibration_routines/camera_intrinsics_estimation.py
@@ -232,7 +232,7 @@ class Camera_Intrinsics_Estimation(Calibration_Plugin):
             glfwSetFramebufferSizeCallback(self._window,on_resize)
             glfwSetKeyCallback(self._window,self.on_window_key)
             glfwSetWindowCloseCallback(self._window,self.on_close)
-            glfwSetMouseButtonCallback(self._window,self.on_button)
+            glfwSetMouseButtonCallback(self._window,self.on_window_mouse_button)
 
             on_resize(self._window,*glfwGetFramebufferSize(self._window))
 
@@ -253,7 +253,7 @@ class Camera_Intrinsics_Estimation(Calibration_Plugin):
                 self.on_close()
 
 
-    def on_button(self,window,button, action, mods):
+    def on_window_mouse_button(self,window,button, action, mods):
         if action ==GLFW_PRESS:
             self.clicks_to_close -=1
         if self.clicks_to_close ==0:

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -188,7 +188,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)
             glfwSetKeyCallback(self._window, self.on_window_key)
-            glfwSetMouseButtonCallback(self._window, self.on_button)
+            glfwSetMouseButtonCallback(self._window, self.on_window_mouse_button)
             on_resize(self._window, *glfwGetFramebufferSize(self._window))
 
             # gl_state settings
@@ -208,7 +208,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             if key == GLFW_KEY_ESCAPE:
                 self.clicks_to_close = 0
 
-    def on_button(self,window,button, action, mods):
+    def on_window_mouse_button(self,window,button, action, mods):
         if action ==GLFW_PRESS:
             self.clicks_to_close -=1
 

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -187,7 +187,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)
-            glfwSetKeyCallback(self._window, self.on_key)
+            glfwSetKeyCallback(self._window, self.on_window_key)
             glfwSetMouseButtonCallback(self._window, self.on_button)
             on_resize(self._window, *glfwGetFramebufferSize(self._window))
 
@@ -203,7 +203,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
 
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         if action == GLFW_PRESS:
             if key == GLFW_KEY_ESCAPE:
                 self.clicks_to_close = 0

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -145,7 +145,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)
             glfwSetKeyCallback(self._window, self.on_window_key)
-            glfwSetMouseButtonCallback(self._window, self.on_button)
+            glfwSetMouseButtonCallback(self._window, self.on_window_mouse_button)
             on_resize(self._window, *glfwGetFramebufferSize(self._window))
 
             # gl_state settings
@@ -164,7 +164,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
                 self.clicks_to_close = 0
 
 
-    def on_button(self,window,button, action, mods):
+    def on_window_mouse_button(self,window,button, action, mods):
         if action ==GLFW_PRESS:
             self.clicks_to_close -=1
 

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -144,7 +144,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
 
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)
-            glfwSetKeyCallback(self._window, self.on_key)
+            glfwSetKeyCallback(self._window, self.on_window_key)
             glfwSetMouseButtonCallback(self._window, self.on_button)
             on_resize(self._window, *glfwGetFramebufferSize(self._window))
 
@@ -158,7 +158,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
             glfwMakeContextCurrent(active_window)
 
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         if action == GLFW_PRESS:
             if key == GLFW_KEY_ESCAPE or key == GLFW_KEY_C:
                 self.clicks_to_close = 0

--- a/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/visualizer_calibration.py
@@ -164,7 +164,7 @@ class Calibration_Visualizer(Visualizer):
 		self.trackball.set_window_size(w,h)
 
 
-	def on_char(self,window,char):
+	def on_window_char(self,window,char):
 		if char == ord('r'):
 			self.trackball.distance = [0,0,-0.1]
 			self.trackball.pitch = 0

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -73,7 +73,7 @@ class Plugin(object):
         """
         pass
 
-    def on_unconsumed_key(self, key, scancode, action, mods):
+    def on_key(self, key, scancode, action, mods):
         """
         Gets called on key events that were not consumed by the GUI.
 
@@ -82,7 +82,7 @@ class Plugin(object):
         """
         pass
 
-    def on_unconsumed_char(self, character):
+    def on_char(self, character):
         """
         Gets called on char events that were not consumed by the GUI.
 

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -68,7 +68,26 @@ class Plugin(object):
 
     def on_click(self, pos, button, action):
         """
-        Gets called when the user clicks in the window screen
+        Gets called when the user clicks in the window screen and the event has
+        not been consumed by the GUI.
+        """
+        pass
+
+    def on_unconsumed_key(self, key, scancode, action, mods):
+        """
+        Gets called on key events that were not consumed by the GUI.
+
+        See http://www.glfw.org/docs/latest/input_guide.html#input_key for
+        more information key events.
+        """
+        pass
+
+    def on_unconsumed_char(self, character):
+        """
+        Gets called on char events that were not consumed by the GUI.
+
+        See http://www.glfw.org/docs/latest/input_guide.html#input_char for
+        more information char events.
         """
         pass
 

--- a/pupil_src/shared_modules/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
+++ b/pupil_src/shared_modules/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
@@ -65,9 +65,9 @@ class VisualizeSphere(Visualizer):
         glfwPollEvents()
         return True
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         # self.gui.update_button(button,action,mods)
-        super().on_key(window, key, scancode, action, mods)
+        super().on_window_key(window, key, scancode, action, mods)
         if key == GLFW_KEY_ESCAPE:
           self.running = False
           self.close_window()

--- a/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
@@ -215,7 +215,7 @@ cdef class Detector_2D:
 
             #Register callbacks
             glfw.glfwSetWindowSizeCallback(self._window,self.on_resize)
-            # glfwSetKeyCallback(self._window,self.on_key)
+            # glfwSetKeyCallback(self._window,self.on_window_key)
             glfw.glfwSetWindowCloseCallback(self._window,self.on_close)
 
             # gl_state settings

--- a/pupil_src/shared_modules/pupil_detectors/visualizer_3d.py
+++ b/pupil_src/shared_modules/pupil_detectors/visualizer_3d.py
@@ -246,7 +246,7 @@ class Eye_Visualizer(Visualizer):
         Visualizer.on_resize(self,window,w, h)
         self.trackball.set_window_size(w,h)
 
-    def on_char(self,window,char):
+    def on_window_char(self,window,char):
         if char == ord('r'):
             self.trackball.distance = [0,0,-0.1]
             self.trackball.pitch = 0

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -661,7 +661,7 @@ class Reference_Surface(object):
 
             #Register callbacks
             glfwSetFramebufferSizeCallback(self._window,self.on_resize)
-            glfwSetKeyCallback(self._window,self.on_key)
+            glfwSetKeyCallback(self._window,self.on_window_key)
             glfwSetWindowCloseCallback(self._window,self.on_close)
             glfwSetMouseButtonCallback(self._window,self.on_button)
             glfwSetCursorPosCallback(self._window,self.on_pos)
@@ -701,7 +701,7 @@ class Reference_Surface(object):
         adjust_gl_view(w,h)
         glfwMakeContextCurrent(active_window)
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         if action == GLFW_PRESS:
             if key == GLFW_KEY_ESCAPE:
                 self.on_close()

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -663,7 +663,7 @@ class Reference_Surface(object):
             glfwSetFramebufferSizeCallback(self._window,self.on_resize)
             glfwSetKeyCallback(self._window,self.on_window_key)
             glfwSetWindowCloseCallback(self._window,self.on_close)
-            glfwSetMouseButtonCallback(self._window,self.on_button)
+            glfwSetMouseButtonCallback(self._window,self.on_window_mouse_button)
             glfwSetCursorPosCallback(self._window,self.on_pos)
             glfwSetScrollCallback(self._window,self.on_scroll)
 
@@ -710,7 +710,7 @@ class Reference_Surface(object):
         self.close_window()
 
 
-    def on_button(self,window,button, action, mods):
+    def on_window_mouse_button(self,window,button, action, mods):
         if action == GLFW_PRESS:
             self.input['down'] = True
             self.input['mouse'] = glfwGetCursorPos(window)

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -174,8 +174,8 @@ class Visualizer(object):
             # Register callbacks window
             glfwSetFramebufferSizeCallback(self.window,self.on_resize)
             glfwSetWindowIconifyCallback(self.window,self.on_iconify)
-            glfwSetKeyCallback(self.window,self.on_key)
-            glfwSetCharCallback(self.window,self.on_char)
+            glfwSetKeyCallback(self.window,self.on_window_key)
+            glfwSetCharCallback(self.window,self.on_window_char)
             glfwSetMouseButtonCallback(self.window,self.on_button)
             glfwSetCursorPosCallback(self.window,self.on_pos)
             glfwSetScrollCallback(self.window,self.on_scroll)
@@ -229,7 +229,7 @@ class Visualizer(object):
             self.trackball.pan_to(x-old_x,y-old_y)
             self.input['mouse'] = x,y
 
-    def on_char(self,window,char):
+    def on_window_char(self,window,char):
         pass
 
     def on_scroll(self,window,x,y):
@@ -238,5 +238,5 @@ class Visualizer(object):
     def on_iconify(self,window,iconified):
         pass
 
-    def on_key(self,window, key, scancode, action, mods):
+    def on_window_key(self,window, key, scancode, action, mods):
         pass

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -176,7 +176,7 @@ class Visualizer(object):
             glfwSetWindowIconifyCallback(self.window,self.on_iconify)
             glfwSetKeyCallback(self.window,self.on_window_key)
             glfwSetCharCallback(self.window,self.on_window_char)
-            glfwSetMouseButtonCallback(self.window,self.on_button)
+            glfwSetMouseButtonCallback(self.window,self.on_window_mouse_button)
             glfwSetCursorPosCallback(self.window,self.on_pos)
             glfwSetScrollCallback(self.window,self.on_scroll)
 
@@ -208,7 +208,7 @@ class Visualizer(object):
         self.adjust_gl_view(w,h)
         glfwMakeContextCurrent(active_window)
 
-    def on_button(self,window,button, action, mods):
+    def on_window_mouse_button(self,window,button, action, mods):
         # self.gui.update_button(button,action,mods)
         if action == GLFW_PRESS:
             self.input['button'] = button


### PR DESCRIPTION
Requires pyglui >=1.6

This is the possibility for plugins to access unconsumed* GLFW events without having to overwrite the GLFW callbacks, as requested internally.

\* "unconsumed" means that there was no gui element that used the event for itself, e.g. no `Text_Input` used the char as input.