### PR TITLE
Unify online fixation detectors

### DIFF
--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -97,7 +97,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # Plug-ins
     from plugin import Plugin, Plugin_List, import_runtime_plugins
     from calibration_routines import calibration_plugins, gaze_mapping_plugins, Calibration_Plugin
-    from fixation_detector import Fixation_Detector_3D
+    from fixation_detector import Fixation_Detector_3D, Naive_Fixation_Detector
     from recorder import Recorder
     from display_recent_gaze import Display_Recent_Gaze
     from time_sync import Time_Sync
@@ -151,8 +151,8 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     manager_classes += [p for p in runtime_plugins if issubclass(p, Base_Manager)]
     runtime_plugins = [p for p in runtime_plugins if not issubclass(p, Base_Manager)]
     user_launchable_plugins = [Audio_Capture, Pupil_Groups, Frame_Publisher, Pupil_Remote, Time_Sync, Surface_Tracker,
-                               Annotation_Capture, Log_History, Fixation_Detector_3D, Blink_Detection,
-                               Remote_Recorder] + runtime_plugins
+                               Annotation_Capture, Log_History, Naive_Fixation_Detector, Fixation_Detector_3D,
+                               Blink_Detection, Remote_Recorder] + runtime_plugins
     system_plugins = [Log_Display, Display_Recent_Gaze, Recorder, Pupil_Data_Relay]
     plugin_by_index = (system_plugins + user_launchable_plugins + calibration_plugins
                        + gaze_mapping_plugins + manager_classes + source_classes)

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -97,7 +97,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     # Plug-ins
     from plugin import Plugin, Plugin_List, import_runtime_plugins
     from calibration_routines import calibration_plugins, gaze_mapping_plugins, Calibration_Plugin
-    from fixation_detector import Fixation_Detector_3D, Naive_Fixation_Detector
+    from fixation_detector import Fixation_Detector_3D, Online_Fixation_Detector
     from recorder import Recorder
     from display_recent_gaze import Display_Recent_Gaze
     from time_sync import Time_Sync
@@ -151,7 +151,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
     manager_classes += [p for p in runtime_plugins if issubclass(p, Base_Manager)]
     runtime_plugins = [p for p in runtime_plugins if not issubclass(p, Base_Manager)]
     user_launchable_plugins = [Audio_Capture, Pupil_Groups, Frame_Publisher, Pupil_Remote, Time_Sync, Surface_Tracker,
-                               Annotation_Capture, Log_History, Naive_Fixation_Detector, Fixation_Detector_3D,
+                               Annotation_Capture, Log_History, Fixation_Detector_3D, Online_Fixation_Detector,
                                Blink_Detection, Remote_Recorder] + runtime_plugins
     system_plugins = [Log_Display, Display_Recent_Gaze, Recorder, Pupil_Data_Relay]
     plugin_by_index = (system_plugins + user_launchable_plugins + calibration_plugins

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -211,9 +211,7 @@ class Manual_Marker_Calibration(Calibration_Plugin):
                         ref["timestamp"] = frame.timestamp
                         self.ref_list.append(ref)
                         if events.get('fixations', []):
-                            method = events['fixations'][0]['method']
-                            fixation_boost = 2 if method == 'naive' else 10
-                            self.counter -= fixation_boost
+                            self.counter -= 5
                         if self.counter <= 0:
                             #last sample before counter done and moving on
                             audio.tink()

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -47,7 +47,6 @@ class Manual_Marker_Calibration(Calibration_Plugin):
         self.sample_site = (-2,-2)
         self.counter = 0
         self.counter_max = 30
-        self.fixation_boost = 15
         self.markers = []
         self.world_size = None
 
@@ -212,7 +211,9 @@ class Manual_Marker_Calibration(Calibration_Plugin):
                         ref["timestamp"] = frame.timestamp
                         self.ref_list.append(ref)
                         if events.get('fixations', []):
-                            self.counter -= self.fixation_boost
+                            method = events['fixations'][0]['method']
+                            fixation_boost = 2 if method == 'naive' else 10
+                            self.counter -= fixation_boost
                         if self.counter <= 0:
                             #last sample before counter done and moving on
                             audio.tink()

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -271,8 +271,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     self.pupil_list.append(p_pt)
 
             if on_position and self.detected and events.get('fixations', []):
-                method = events['fixations'][0]['method']
-                fixation_boost = 2 if method == 'naive' else 10
+                fixation_boost = 5
                 self.screen_marker_state = min(
                     self.sample_duration+self.lead_in,
                     self.screen_marker_state+fixation_boost)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -76,7 +76,6 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         self.detected = False
         self.screen_marker_state = 0.
         self.sample_duration =  sample_duration # number of frames to sample per site
-        self.fixation_boost = sample_duration/2.
         self.lead_in = 25 #frames of marker shown before starting to sample
         self.lead_out = 5 #frames of markers shown after sampling is donw
 
@@ -272,9 +271,11 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     self.pupil_list.append(p_pt)
 
             if on_position and self.detected and events.get('fixations', []):
+                method = events['fixations'][0]['method']
+                fixation_boost = 2 if method == 'naive' else 10
                 self.screen_marker_state = min(
                     self.sample_duration+self.lead_in,
-                    self.screen_marker_state+self.fixation_boost)
+                    self.screen_marker_state+fixation_boost)
 
             # Animate the screen marker
             if self.screen_marker_state < self.sample_duration+self.lead_in+self.lead_out:

--- a/pupil_src/shared_modules/display_recent_gaze.py
+++ b/pupil_src/shared_modules/display_recent_gaze.py
@@ -27,7 +27,7 @@ class Display_Recent_Gaze(Plugin):
 
     def recent_events(self,events):
         for pt in events.get('gaze_positions',[]):
-            self.pupil_display_list.append((pt['norm_pos'] , pt['confidence']))
+            self.pupil_display_list.append((pt['norm_pos'] , pt['confidence']*0.8))
         self.pupil_display_list[:-3] = []
 
 


### PR DESCRIPTION
Todo:
- [ ] Remove old `3d Pupil Angle Fixation Detector`
- [ ] The fixation boost for calibration procedures should be based on the number of gaze positions that a fixation is based on instead of being a fixed number.