### PR TITLE
Fixes for RealSense backend and blink detection

### DIFF
--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -103,6 +103,7 @@ class Blink_Detection(Plugin):
             'confidence': confidence,
             'base_data': list(self.history),
             'timestamp': self.history[len(self.history)//2]['timestamp'],
+            'record': True
         }
         events['blinks'].append(blink_entry)
         self._recent_blink = blink_entry

--- a/pupil_src/shared_modules/video_capture/realsense_backend.py
+++ b/pupil_src/shared_modules/video_capture/realsense_backend.py
@@ -208,6 +208,7 @@ class Realsense_Source(Base_Source):
         color_frame_size = tuple(color_frame_size)
         depth_frame_size = tuple(depth_frame_size)
 
+        self.streams = [ColorStream(), DepthStream()]
         self.last_color_frame_ts = None
         self.last_depth_frame_ts = None
         self._recent_frame = None
@@ -226,7 +227,6 @@ class Realsense_Source(Base_Source):
             device_id = 0
 
         # use default streams to filter modes by rs_stream and rs_format
-        self.streams = [ColorStream(), DepthStream()]
         self._available_modes = self._enumerate_formats(device_id)
 
         # make sure that given frame sizes and rates are available


### PR DESCRIPTION
- Fix RealSense backend: Always initialize `self.streams`
- Blink detector: Enable recording of events