### PR TITLE
Accept mkv eye videos in Offline Pupil Detection and set dummy camera models

### DIFF
--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -89,9 +89,9 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
             self.correlate_publish()
 
     def start_eye_process(self, eye_id):
-        potential_locs = [os.path.join(self.g_pool.rec_dir, 'eye{}{}'.format(eye_id, ext)) for ext in ('.mjpeg', '.mp4')]
+        potential_locs = [os.path.join(self.g_pool.rec_dir, 'eye{}{}'.format(eye_id, ext)) for ext in ('.mjpeg', '.mp4', '.mkv')]
         existing_locs = [loc for loc in potential_locs if os.path.exists(loc)]
-        timestamps_path = os.path.join(self.g_pool.rec_dir,'eye{}_timestamps.npy'.format(eye_id))
+        timestamps_path = os.path.join(self.g_pool.rec_dir, 'eye{}_timestamps.npy'.format(eye_id))
 
         if not existing_locs:
             logger.error("no eye video for eye '{}' found.".format(eye_id))

--- a/pupil_src/shared_modules/video_capture/fake_backend.py
+++ b/pupil_src/shared_modules/video_capture/fake_backend.py
@@ -15,6 +15,7 @@ import cv2
 import numpy as np
 from time import time,sleep
 from pyglui import ui
+from camera_models import Dummy_Camera
 
 #logging
 import logging
@@ -46,6 +47,7 @@ class Frame(object):
     @gray.setter
     def gray(self, value):
         raise Exception('Read only.')
+
 
 class Fake_Source(Base_Source):
     """Simple source which shows random, static image.
@@ -85,6 +87,7 @@ class Fake_Source(Base_Source):
         # coarse[:,:,1] /=30
         # self._img = np.ones((size[1],size[0],3),dtype=np.uint8)
         self._img = cv2.resize(coarse,size,interpolation=cv2.INTER_LANCZOS4)
+        self.intrinsics = Dummy_Camera(size, self.name)
 
     def recent_events(self,events):
         now = time()

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -15,7 +15,7 @@ assert av.__version__ >= '0.2.5'
 
 
 from .base_backend import Base_Source, Base_Manager
-from camera_models import Dummy_Camera
+from camera_models import load_intrinsics
 
 import numpy as np
 from time import time,sleep
@@ -162,6 +162,9 @@ class File_Source(Base_Source):
         self.seek_to_frame(0)
         self.average_rate = (self.timestamps[-1]-self.timestamps[0])/len(self.timestamps)
 
+        loc, name = os.path.split(os.path.splitext(source_path)[0])
+        self.intrinsics = load_intrinsics(loc, name, self.frame_size)
+
     def ensure_initialisation(fallback_func=None):
         from functools import wraps
 
@@ -176,14 +179,6 @@ class File_Source(Base_Source):
                     logger.debug('Initialisation required.')
             return run_func
         return decorator
-
-    @property
-    def intrinsics(self):
-        return Dummy_Camera(self.frame_size, self.name)
-
-    @intrinsics.setter
-    def intrinsics(self, value):
-        pass  # TODO: load from file
 
     @property
     def initialised(self):

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -15,6 +15,7 @@ assert av.__version__ >= '0.2.5'
 
 
 from .base_backend import Base_Source, Base_Manager
+from camera_models import Dummy_Camera
 
 import numpy as np
 from time import time,sleep
@@ -175,6 +176,14 @@ class File_Source(Base_Source):
                     logger.debug('Initialisation required.')
             return run_func
         return decorator
+
+    @property
+    def intrinsics(self):
+        return Dummy_Camera(self.frame_size, self.name)
+
+    @intrinsics.setter
+    def intrinsics(self, value):
+        pass  # TODO: load from file
 
     @property
     def initialised(self):

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -15,6 +15,7 @@ import logging
 import ndsi
 
 from .base_backend import Base_Source, Base_Manager
+from camera_models import Dummy_Camera
 
 try:
     from ndsi import __version__
@@ -181,6 +182,14 @@ class NDSI_Source(Base_Source):
                 self.sensor.set_control_value('local_capture', True)
             elif 'should_stop' in subject:
                 self.sensor.set_control_value('local_capture', False)
+
+    @property
+    def intrinsics(self):
+        return Dummy_Camera(self.frame_size, self.name)
+
+    @intrinsics.setter
+    def intrinsics(self, value):
+        pass
 
     @property
     def frame_size(self):

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -15,7 +15,7 @@ import logging
 import ndsi
 
 from .base_backend import Base_Source, Base_Manager
-from camera_models import Dummy_Camera
+from camera_models import load_intrinsics
 
 try:
     from ndsi import __version__
@@ -185,7 +185,9 @@ class NDSI_Source(Base_Source):
 
     @property
     def intrinsics(self):
-        return Dummy_Camera(self.frame_size, self.name)
+        if self.intrinsics is None or self.intrinsics.resolution != self.frame_size:
+            self.intrinsics = load_intrinsics(self.g_pool.user_dir, self.name, self.frame_size)
+        return self.intrinsics
 
     @intrinsics.setter
     def intrinsics(self, value):

--- a/pupil_src/shared_modules/video_capture/realsense_backend.py
+++ b/pupil_src/shared_modules/video_capture/realsense_backend.py
@@ -21,6 +21,7 @@ from pyrealsense.constants import rs_stream, rs_option
 from version_utils import VersionFormat
 from .base_backend import Base_Source, Base_Manager
 from av_writer import AV_Writer
+from camera_models import Dummy_Camera
 
 import gl_utils
 from pyglui import cygl
@@ -272,6 +273,7 @@ class Realsense_Source(Base_Source):
         self.device = self.service.Device(device_id, streams=self.streams)
 
         self.controls = Realsense_Controls(self.device, device_options)
+        self.intrinsics = Dummy_Camera(color_frame_size, self.name)
 
         self.deinit_gui()
         self.init_gui()

--- a/pupil_src/shared_modules/video_capture/realsense_backend.py
+++ b/pupil_src/shared_modules/video_capture/realsense_backend.py
@@ -21,7 +21,7 @@ from pyrealsense.constants import rs_stream, rs_option
 from version_utils import VersionFormat
 from .base_backend import Base_Source, Base_Manager
 from av_writer import AV_Writer
-from camera_models import Dummy_Camera
+from camera_models import load_intrinsics
 
 import gl_utils
 from pyglui import cygl
@@ -273,7 +273,7 @@ class Realsense_Source(Base_Source):
         self.device = self.service.Device(device_id, streams=self.streams)
 
         self.controls = Realsense_Controls(self.device, device_options)
-        self.intrinsics = Dummy_Camera(color_frame_size, self.name)
+        self.intrinsics = load_intrinsics(self.g_pool.user_dir, self.name, self.frame_size)
 
         self.deinit_gui()
         self.init_gui()
@@ -441,7 +441,7 @@ class Realsense_Source(Base_Source):
                 try:
                     self.device.reset_device_options_to_default(self.controls.keys())
                 except pyrs.RealsenseError as err:
-                    logger.error('Resetting device options failed')
+                    logger.info('Resetting some device options failed')
                     logger.debug('Reason: {}'.format(err))
                 finally:
                     self.controls.refresh()


### PR DESCRIPTION
1. Fixes #813
2. Make sure `source.intrinsics` is not `None`