### PR TITLE
To improve the accuracy of correct marker detection in manual marker calibration

### DIFF
--- a/pupil_src/shared_modules/circle_detector.py
+++ b/pupil_src/shared_modules/circle_detector.py
@@ -16,7 +16,7 @@ from methods import dist_pts_ellipse
 
 def find_concetric_circles(gray_img,min_ring_count=3, visual_debug=False):
     # get threshold image used to get crisp-clean edges using blur to remove small features
-    edges = cv2.adaptiveThreshold(cv2.blur(gray_img,(3,3)), 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY, 5, 11)
+    edges = cv2.adaptiveThreshold(cv2.blur(gray_img,(3,3)), 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 13, 7)
     _, contours, hierarchy = cv2.findContours(edges,
                                     mode=cv2.RETR_TREE,
                                     method=cv2.CHAIN_APPROX_NONE,offset=(0,0)) #TC89_KCOS


### PR DESCRIPTION
[The 1-ring-marker](
https://docs.pupil-labs.com/images/pupil-capture/calibration-markers/pupil_calibration_marker.v0914.pdf) and [the 2-rings-marker](
https://drive.google.com/open?id=0BzhCo4DVViZKeFl0dENVYjd1eUE) are used as standard markers.