### PR TITLE
Use VersionFormat for pyglui version check

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -103,7 +103,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         from gaze_producers import Gaze_From_Recording, Offline_Calibration
         from system_graphs import System_Graphs
 
-        assert pyglui_version >= '1.9', 'pyglui out of date, please upgrade to newest version'
+        assert pyglui_version >= VersionFormat('1.9'), 'pyglui out of date, please upgrade to newest version'
 
         runtime_plugins = import_runtime_plugins(os.path.join(user_dir, 'plugins'))
         system_plugins = [Log_Display, Seek_Control, Plugin_Manager, System_Graphs]

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -92,12 +92,6 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
 
     try:
 
-        # display
-        import glfw
-        from pyglui import ui, cygl, __version__ as pyglui_version
-        assert pyglui_version >= '1.9', 'pyglui out of date, please upgrade to newest version'
-        from pyglui.cygl.utils import Named_Texture
-        import gl_utils
 
         # helpers/utils
         from version_utils import VersionFormat
@@ -107,6 +101,13 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
         logger.info('Application Version: {}'.format(version))
         logger.info('System Info: {}'.format(get_system_info()))
 
+        # display
+        import glfw
+        from pyglui import ui, cygl, __version__ as pyglui_version
+        assert pyglui_version >= VersionFormat('1.9'), 'pyglui out of date, please upgrade to newest version'
+        from pyglui.cygl.utils import Named_Texture
+        import gl_utils
+        
         import audio
 
         # trigger pupil detector cpp build:


### PR DESCRIPTION
v1.10 (current version of pyglui master) does not pass the assertion and Pupil Capture and Pupil Player will fail to launch

```python
assert pyglui_version >= '1.9', 'pyglui out of date, please upgrade to newest version'
# '1.10' >= '1.9' evaluates to False therefore test fails. VersionFormat is used to solve this problem.
```

```python
assert pyglui_version >= VersionFormat('1.9'), 'pyglui out of date, please upgrade to newest version'
# evaluates to True with v1.10
```