### PR TITLE
Use as many threads to transcode video as there are cpus

### DIFF
--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -117,7 +117,7 @@ class AV_Writer(object):
         self.video_stream = self.container.add_stream(video_stream['codec'], 1/self.time_base)
         self.video_stream.bit_rate = video_stream['bit_rate']
         self.video_stream.bit_rate_tolerance = video_stream['bit_rate']/20
-        self.video_stream.thread_count = mp.cpu_count()
+        self.video_stream.thread_count = max(1, mp.cpu_count() - 1)
         # self.video_stream.pix_fmt = "yuv420p"
         self.configured = False
         self.start_time = None

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 from threading import Thread
 from threading import Event
+import multiprocessing as mp
 
 
 """
@@ -116,7 +117,7 @@ class AV_Writer(object):
         self.video_stream = self.container.add_stream(video_stream['codec'], 1/self.time_base)
         self.video_stream.bit_rate = video_stream['bit_rate']
         self.video_stream.bit_rate_tolerance = video_stream['bit_rate']/20
-        self.video_stream.thread_count = 1
+        self.video_stream.thread_count = mp.cpu_count()
         # self.video_stream.pix_fmt = "yuv420p"
         self.configured = False
         self.start_time = None


### PR DESCRIPTION
The transcoding thread count was previously set to one. This was due to a bug on Linux where the program would crash if more threads than available cpus were used.