### PR TITLE
Offline Pupil Detector Fixes

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -164,20 +164,19 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
             nonlocal window_size
             nonlocal camera_render_size
 
-            if is_window_visible(window):
-                active_window = glfw.glfwGetCurrentContext()
-                glfw.glfwMakeContextCurrent(window)
-                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-                g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
-                window_size = w, h
-                camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h
-                g_pool.gui.update_window(w, h)
-                g_pool.gui.collect_menus()
-                for g in g_pool.graphs:
-                    g.scale = hdpi_factor
-                    g.adjust_window_size(w, h)
-                adjust_gl_view(w, h)
-                glfw.glfwMakeContextCurrent(active_window)
+            active_window = glfw.glfwGetCurrentContext()
+            glfw.glfwMakeContextCurrent(window)
+            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
+            window_size = w, h
+            camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h
+            g_pool.gui.update_window(w, h)
+            g_pool.gui.collect_menus()
+            for g in g_pool.graphs:
+                g.scale = hdpi_factor
+                g.adjust_window_size(w, h)
+            adjust_gl_view(w, h)
+            glfw.glfwMakeContextCurrent(active_window)
 
         def on_window_key(window, key, scancode, action, mods):
             g_pool.gui.update_key(key, scancode, action, mods)

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -158,6 +158,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.eye_processes[eye_id] = None
 
     def recent_events(self, events):
+        super().recent_events(events)
         while self.data_sub.new_data:
             topic, payload = self.data_sub.recv()
             if topic.startswith('pupil.'):

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -92,34 +92,34 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.data_sub = zmq_tools.Msg_Receiver(zmq_ctx, g_pool.ipc_sub_url, topics=('pupil','notify.file_source.video_finished'))
 
         self.data_dir = os.path.join(g_pool.rec_dir, 'offline_data')
-        os.makedirs(self.data_dir , exist_ok=True)
+        os.makedirs(self.data_dir, exist_ok=True)
         try:
-            session_data = load_object(os.path.join(self.data_dir , 'offline_pupil_data'))
+            session_data = load_object(os.path.join(self.data_dir, 'offline_pupil_data'))
             assert session_data.get('version') != self.session_data_version
         except:
             session_data = {}
-            session_data["detection_method"]='3d'
+            session_data["detection_method"] = '3d'
             session_data['pupil_positions'] = []
-            session_data['detection_progress'] = [0.,0.]
-            session_data['detection_status'] = ["unknown","unknown"]
+            session_data['detection_status'] = ["unknown", "unknown"]
         self.detection_method = session_data["detection_method"]
-        self.pupil_positions = session_data['pupil_positions']
-        self.eye_processes = [None, None]
-        self.detection_progress = session_data['detection_progress']
+        self.pupil_positions = {pp['timestamp']: pp for pp in session_data['pupil_positions']}
         self.detection_status = session_data['detection_status']
+        self.eye_video_loc = [None, None]
+        self.eye_frame_num = [0, 0]
+        for pp in self.pupil_positions.values():
+            self.eye_frame_num[pp['id']] += 1
 
         self.pause_switch = None
         self.detection_paused = False
 
         # start processes
-        if self.detection_progress[0] < 100:
-            self.start_eye_process(0)
-        if self.detection_progress[1] < 100:
-            self.start_eye_process(1)
+        for eye_id in range(2):
+            if self.detection_status[eye_id] != 'complete':
+                self.start_eye_process(eye_id)
 
         # either we did not start them or they failed to start (mono setup etc)
         # either way we are done and can publish
-        if self.eye_processes == [None, None]:
+        if self.eye_video_loc == [None, None]:
             self.correlate_publish()
 
     def start_eye_process(self, eye_id):
@@ -134,51 +134,47 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         if not os.path.exists(timestamps_path):
             logger.error("no timestamps for eye video for eye '{}' found.".format(eye_id))
             self.detection_status[eye_id] = "No eye video found."
-
             return
 
         video_loc = existing_locs[0]
-        ts = np.load(timestamps_path)
-        self.detection_progress[eye_id] = 0.
+        self.eye_frame_num[eye_id] = len(np.load(timestamps_path))
+
         capure_settings = 'File_Source', {
             'source_path': video_loc,
             'timed_playback': False
         }
         self.notify_all({'subject': 'eye_process.should_start', 'eye_id': eye_id,
                          'overwrite_cap_settings': capure_settings})
-        eye_p = Empty()  # dummy object holding meta data
-        eye_p.video_path = video_loc
-        eye_p.min_ts = ts[0]
-        eye_p.max_ts = ts[-1]
-        self.eye_processes[eye_id] = eye_p
+        self.eye_video_loc[eye_id] = video_loc
         self.detection_status[eye_id] = "Detecting..."
 
     def stop_eye_process(self, eye_id):
         self.notify_all({'subject': 'eye_process.should_stop', 'eye_id': eye_id})
-        self.eye_processes[eye_id] = None
+        self.eye_video_loc[eye_id] = None
 
     def recent_events(self, events):
         super().recent_events(events)
         while self.data_sub.new_data:
             topic, payload = self.data_sub.recv()
             if topic.startswith('pupil.'):
-                self.pupil_positions.append(payload)
-                self.update_progress(payload)
+                self.pupil_positions[payload['timestamp']] = payload
             elif payload['subject'] == 'file_source.video_finished':
-                if self.eye_processes[0] and self.eye_processes[0].video_path == payload['source_path']:
+                if self.eye_video_loc[0] == payload['source_path']:
                     logger.debug("eye 0 process complete")
                     self.detection_status[0] = "complete"
                     self.stop_eye_process(0)
-                elif self.eye_processes[1] and self.eye_processes[1].video_path == payload['source_path']:
+                elif self.eye_video_loc[1] == payload['source_path']:
                     logger.debug("eye 1 process complete")
                     self.detection_status[1] = "complete"
                     self.stop_eye_process(1)
-                if self.eye_processes == [None, None]:
+                if self.eye_video_loc == [None, None]:
                     self.correlate_publish()
+        total = sum(self.eye_frame_num)
+        self.menu_icon.indicator_stop = len(self.pupil_positions) / total if total else 0.
 
     def correlate_publish(self):
-        self.g_pool.pupil_positions = self.pupil_positions
-        self.g_pool.pupil_positions_by_frame = correlate_data(self.pupil_positions, self.g_pool.timestamps)
+        self.g_pool.pupil_positions = sorted(self.pupil_positions.values(), key=lambda pp: pp['timestamp'])
+        self.g_pool.pupil_positions_by_frame = correlate_data(list(self.pupil_positions.values()), self.g_pool.timestamps)
         self.notify_all({'subject': 'pupil_positions_changed'})
         logger.debug('pupil positions changed')
 
@@ -186,25 +182,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         if notification['subject'] == 'eye_process.started':
             self.set_detection_mapping_mode(self.detection_method)
         elif notification['subject'] == 'eye_process.stopped':
-            self.eye_processes[notification['eye_id']] = None
-
-    def update_progress(self, pupil_position):
-        eye_id = pupil_position['id']
-        cur_ts = pupil_position['timestamp']
-        if self.eye_processes[eye_id] is not None:
-            min_ts = self.eye_processes[eye_id].min_ts
-            max_ts = self.eye_processes[eye_id].max_ts
-            current_progress = 100 * (cur_ts - min_ts) / (max_ts - min_ts)
-            self.detection_progress[eye_id] = current_progress
-            total_progress = 100.
-        else:
-            current_progress = 0.
-            total_progress = 0.
-        other_eye_id = 0 if eye_id else 1
-        if self.eye_processes[other_eye_id] is not None:
-            current_progress += self.detection_progress[other_eye_id]
-            total_progress += 100.
-        self.menu_icon.indicator_stop = current_progress / total_progress if total_progress else 0.
+            self.eye_video_loc[notification['eye_id']] = None
 
     def cleanup(self):
         self.stop_eye_process(0)
@@ -214,24 +192,21 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
         session_data = {}
         session_data["detection_method"] = self.detection_method
-        session_data['pupil_positions'] = self.pupil_positions
-        session_data['detection_progress'] = self.detection_progress
+        session_data['pupil_positions'] = list(self.pupil_positions.values())
         session_data['detection_status'] = self.detection_status
         save_object(session_data, os.path.join(self.data_dir, 'offline_pupil_data'))
 
     def redetect(self):
-        del self.pupil_positions[:]  # delete previously detected pupil positions
+        self.pupil_positions.clear()  # delete previously detected pupil positions
         self.g_pool.pupil_positions_by_frame = [[] for x in self.g_pool.timestamps]
         self.detection_finished_flag = False
-        self.detection_progress[0] = 0.
-        self.detection_progress[1] = 0.
         self.detection_paused = False
         for eye_id in range(2):
-            if self.eye_processes[eye_id] is None:
+            if self.eye_video_loc[eye_id] is None:
                 self.start_eye_process(eye_id)
             else:
                 self.notify_all({'subject': 'file_source.seek', 'frame_index': 0,
-                                 'source_path': self.eye_processes[eye_id].video_path})
+                                 'source_path': self.eye_video_loc[eye_id]})
 
     def set_detection_mapping_mode(self, new_mode):
         n = {'subject': 'set_detection_mapping_mode', 'mode': new_mode}
@@ -247,19 +222,16 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                                      selection=['2d', '3d'], setter=self.set_detection_mapping_mode))
         self.menu.append(ui.Switch('detection_paused', self, label='Pause detection'))
         self.menu.append(ui.Button('Redetect', self.redetect))
-        self.menu.append(ui.Text_Input("0",label='eye0:',getter=lambda :self.detection_status[0],
-                                    setter=lambda _: _))
-        progress_slider = ui.Slider('0',
-                                    label='Progress Eye 0',
-                                    getter=lambda :self.detection_progress[0],
-                                    setter=lambda _: _)
-        progress_slider.display_format = '%3.0f%%'
-        self.menu.append(progress_slider)
-        self.menu.append(ui.Text_Input("1",label='eye1:',getter=lambda :self.detection_status[1],
-                                    setter=lambda _: _))
-        progress_slider = ui.Slider('1',
-                                    label='Progress Eye 1',
-                                    getter=lambda :self.detection_progress[1],
+        self.menu.append(ui.Text_Input("0", label='eye0:', getter=lambda: self.detection_status[0], setter=lambda _: _))
+        self.menu.append(ui.Text_Input("1", label='eye1:', getter=lambda: self.detection_status[1], setter=lambda _: _))
+
+        def detection_progress():
+            total = sum(self.eye_frame_num)
+            return 100 * len(self.pupil_positions) / total if total else 0.
+
+        progress_slider = ui.Slider('detection_progress',
+                                    label='Detection Progress',
+                                    getter=detection_progress,
                                     setter=lambda _: _)
         progress_slider.display_format = '%3.0f%%'
         self.menu.append(progress_slider)
@@ -272,6 +244,6 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
     def detection_paused(self, should_pause):
         self._detection_paused = should_pause
         for eye_id in range(2):
-            if self.eye_processes[eye_id] is not None:
+            if self.eye_video_loc[eye_id] is not None:
                 subject = 'file_source.' + ('should_pause' if should_pause else 'should_play')
-                self.notify_all({'subject': subject, 'source_path': self.eye_processes[eye_id].video_path})
+                self.notify_all({'subject': subject, 'source_path': self.eye_video_loc[eye_id]})


### PR DESCRIPTION
### Overview
Fixes the visualization of the pupil ellipses in the eye overlay plugin and calculates the offline pupil detection progress based on how many detection processes are active.

### Fixed Issues
- #891
- #892

### Discussion
~~Concerning b7d766e:
This implementation uses the number of currently running detection processes to calculate the total progress. This leads to a short jump in the progress indicator as soon as one detection process finishes before the other. Is this an acceptable behavior? The alternative would be a slightly more complex implementation. Shot screen capture:
![peek 2017-10-30 12-05](https://user-images.githubusercontent.com/168390/32167875-a97b1dde-bd6a-11e7-9e89-fb481b418a4c.gif)~~