### PR TITLE
Decrease false negatives in fixation detector

### DIFF
--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -397,7 +397,8 @@ class Offline_Fixation_Detector(Fixation_Detector_Base):
         # now lets bin fixations into frames. Fixations are allotted to the first frame they appear in.
         fixations_by_frame = [[] for x in self.g_pool.timestamps]
         for f in self.fixations:
-            fixations_by_frame[f['start_frame_index']].append(f)
+            for idx in range(f['start_frame_index'], f['end_frame_index'] + 1):
+                fixations_by_frame[idx].append(f)
 
         self.g_pool.fixations_by_frame = fixations_by_frame
         self.notify_all({'subject': 'fixations_changed', 'delay': 1})

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -147,11 +147,10 @@ def detect_fixations(capture, gaze_data, max_dispersion, min_duration, max_durat
     Q = deque()
     enum = deque(gaze_data)
     while enum:
-        datum = enum.popleft()
-        Q.append(datum)
-
         # check if Q contains enough data
         if len(Q) < 2 or Q[-1]['timestamp'] - Q[0]['timestamp'] < min_duration:
+            datum = enum.popleft()
+            Q.append(datum)
             continue
 
         # min duration reached, check for fixation
@@ -195,7 +194,8 @@ def detect_fixations(capture, gaze_data, max_dispersion, min_duration, max_durat
             dispersion, origin, base_data = gaze_dispersion(capture, slicable[:right_idx], use_pupil=use_pupil)
 
         yield 'Detecting fixations...', [fixation_from_data(dispersion, origin, base_data, capture.timestamps)]
-        Q = deque(slicable[right_idx:])
+        Q = deque()  # clear queue
+        enum.extendleft(slicable[right_idx:])
 
     yield "Fixation detection complete", []
 


### PR DESCRIPTION
### Symptoms
The fixation detector does not detect a high amount of fixations if `max_duration` is set to an high value.

### Cause
The fixation detector detects fixations of maximal length given a specific window. This window was not reset correctly after finding a fixation.

### Solution
Reset detection window correctly and increase window only if necessary.