### PR TITLE
Fix invalid batch exporter argument

### DIFF
--- a/pupil_src/shared_modules/batch_exporter.py
+++ b/pupil_src/shared_modules/batch_exporter.py
@@ -89,8 +89,9 @@ class Batch_Exporter(Analysis_Plugin_Base):
 
         for idx, job in enumerate(self.exports[::-1]):
             submenu = ui.Growing_Menu("Export Job {}: '{}'".format(idx, job.out_file_path))
-            progress_bar = ui.Slider('progress', getter=job.status, min=0, max=job.frames_to_export.value)
+            progress_bar = ui.Slider('Progress', getter=job.status, min=0, max=job.frames_to_export.value)
             progress_bar.read_only = True
+            progress_bar.display_format = '%i frames'
             submenu.append(progress_bar)
             submenu.append(ui.Button('cancel', job.cancel))
             self.menu.append(submenu)

--- a/pupil_src/shared_modules/batch_exporter.py
+++ b/pupil_src/shared_modules/batch_exporter.py
@@ -145,10 +145,11 @@ class Batch_Exporter(Analysis_Plugin_Base):
             user_dir = self.g_pool.user_dir
 
             # we need to know the timestamps of our exports.
-            try:  # 0.4
+            try:
                 frames_to_export.value = len(np.load(os.path.join(export_dir, 'world_timestamps.npy')))
-            except:  # <0.4
-                frames_to_export.value = len(np.load(os.path.join(export_dir, 'timestamps.npy')))
+            except:
+                logger.error('Invalid export directory: {}'.format(export_dir))
+                continue
 
             # Here we make clones of every plugin that supports it.
             # So it runs in the current config when we lauch the exporter.

--- a/pupil_src/shared_modules/batch_exporter.py
+++ b/pupil_src/shared_modules/batch_exporter.py
@@ -167,7 +167,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
 
                 process = Export_Process(target=export, args=(should_terminate, frames_to_export, current_frame,
                                                               export_dir, user_dir, self.g_pool.min_data_confidence,
-                                                              start_frame, end_frame, plugins, out_file_path,None))
+                                                              start_frame, end_frame, plugins, out_file_path, {}))
                 self.exports.append(process)
 
     def start(self):

--- a/pupil_src/shared_modules/batch_exporter.py
+++ b/pupil_src/shared_modules/batch_exporter.py
@@ -85,7 +85,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
         self.menu.elements[:] = []
         self.menu.append(ui.Text_Input('source_dir', self, label='Recording Source Directory', setter=self.set_src_dir))
         self.menu.append(ui.Text_Input('destination_dir', self, label='Recording Destination Directory', setter=self.set_dest_dir))
-        self.menu.append(ui.Button('start export', self.start))
+        self.menu.append(ui.Button('Start Export', self.start))
 
         for idx, job in enumerate(self.exports[::-1]):
             submenu = ui.Growing_Menu("Export Job {}: '{}'".format(idx, job.out_file_path))
@@ -95,7 +95,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
             submenu.append(ui.Button('cancel', job.cancel))
             self.menu.append(submenu)
         if not self.exports:
-            self.menu.append(ui.Info_Text('Please select a Recording Source directory from with to pull all recordings for export.'))
+            self.menu.append(ui.Info_Text('Please select a Recording Source directory from which to pull all recordings for the batch export.'))
 
     def deinit_ui(self):
         self.remove_menu()

--- a/pupil_src/shared_modules/exporter.py
+++ b/pupil_src/shared_modules/exporter.py
@@ -25,7 +25,7 @@ from video_capture import File_Source, EndofVideoFileError
 from player_methods import update_recording_to_recent, load_meta_info
 from av_writer import AV_Writer
 from file_methods import load_object
-from player_methods import correlate_data
+from player_methods import correlate_data, update_recording_to_recent
 
 
 # logging
@@ -57,6 +57,7 @@ def export(should_terminate, frames_to_export, current_frame, rec_dir, user_dir,
     logger.info('Starting video export with pid: {}'.format(os.getpid()))
 
     try:
+        update_recording_to_recent(rec_dir)
 
         vis_plugins = sorted([Vis_Circle, Vis_Cross, Vis_Polyline, Vis_Light_Points,
                               Vis_Watermark, Vis_Scan_Path, Vis_Eye_Video_Overlay],


### PR DESCRIPTION
This PR fixes an issue where the batch export would not export videos due to an invalid argument.

Support for recordings with data format `<v0.4` has been removed as well in 60df7c5. This brings up the question if the (batch) exporter should be responsible for upgrading recordings. ~~We will add an assertion for now that test if the recording is up-to-date.~~ We will add `player_methods.update_recording_to_recent()` to the start of the video export process.