### PR TITLE
Fix crash when changing calibration method during calibration

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -49,9 +49,13 @@ class HMD_Calibration(Calibration_Plugin):
         self.g_pool.quickbar.insert(0, self.button)
 
     def deinit_ui(self):
+        if self.active:
+            self.stop()
+
         if self.button:
             self.g_pool.quickbar.remove(self.button)
             self.button = None
+
         super().deinit_ui()
 
     def on_notify(self,notification):
@@ -181,13 +185,6 @@ class HMD_Calibration(Calibration_Plugin):
     def get_init_dict(self):
         d = {}
         return d
-
-    def cleanup(self):
-        """gets called when the plugin get terminated.
-           either voluntarily or forced.
-        """
-        if self.active:
-            self.stop()
 
 
 class HMD_Calibration_3D(HMD_Calibration,Calibration_Plugin):

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -261,10 +261,11 @@ class Manual_Marker_Calibration(Calibration_Plugin):
         else:
             pass
 
-    def cleanup(self):
+    def deinit_ui(self):
         """gets called when the plugin get terminated.
         This happens either voluntarily or forced.
         if you have an atb bar or glfw window destroy it here.
         """
         if self.active:
             self.stop()
+        super().deinit_ui()

--- a/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
@@ -109,29 +109,24 @@ class Natural_Features_Calibration(Calibration_Plugin):
             else:
                 self.button.status_text = 'Click to Sample at Location'
 
-
-
-
     def gl_display(self):
         if self.detected:
-            draw_points_norm([self.pos],size=self.r,color=RGBA(0.,1.,0.,.5))
+            draw_points_norm([self.pos], size=self.r, color=RGBA(0., 1., 0., .5))
 
-
-
-    def on_click(self,pos,button,action):
+    def on_click(self, pos, button, action):
         if action == GLFW_PRESS and self.active:
             self.first_img = None
-            self.point = np.array([pos,],dtype=np.float32)
+            self.point = np.array([pos], dtype=np.float32)
             self.count = 30
 
     def get_init_dict(self):
         return {}
 
-
-    def cleanup(self):
+    def deinit_ui(self):
         """gets called when the plugin get terminated.
         This happens either voluntarily or forced.
         if you have an atb bar or glfw window destroy it here.
         """
         if self.active:
             self.stop()
+        super().deinit_ui()

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -343,7 +343,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         d['marker_scale'] = self.marker_scale
         return d
 
-    def cleanup(self):
+    def deinit_ui(self):
         """gets called when the plugin get terminated.
            either voluntarily or forced.
         """
@@ -351,3 +351,4 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             self.stop()
         if self._window:
             self.close_window()
+        super().deinit_ui()

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -294,7 +294,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
         d['marker_scale'] = self.marker_scale
         return d
 
-    def cleanup(self):
+    def deinit_ui(self):
         """gets called when the plugin get terminated.
            either voluntarily or forced.
         """
@@ -302,3 +302,4 @@ class Single_Marker_Calibration(Calibration_Plugin):
             self.stop()
         if self._window:
             self.close_window()
+        super().deinit_ui()


### PR DESCRIPTION
Solution: A running calibration needs to be stopped before the UI is being deinitialized.