### PR TITLE
Refactor Batch Exporter

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -94,7 +94,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         from offline_surface_tracker import Offline_Surface_Tracker
         # from marker_auto_trim_marks import Marker_Auto_Trim_Marks
         from fixation_detector import Offline_Fixation_Detector
-        # from batch_exporter import Batch_Exporter
+        from batch_exporter import Batch_Exporter
         from log_display import Log_Display
         from annotations import Annotation_Player
         from raw_data_exporter import Raw_Data_Exporter
@@ -109,7 +109,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         system_plugins = [Log_Display, Seek_Control, Plugin_Manager, System_Graphs]
         user_plugins = [Vis_Circle, Vis_Fixation, Vis_Polyline, Vis_Light_Points,
                         Vis_Cross, Vis_Watermark, Vis_Eye_Video_Overlay, Vis_Scan_Path,
-                        Offline_Fixation_Detector,
+                        Offline_Fixation_Detector, Batch_Exporter,
                         Video_Export_Launcher, Offline_Surface_Tracker, Raw_Data_Exporter,
                         Annotation_Player, Log_History,
                         Pupil_From_Recording, Offline_Pupil_Detection, Gaze_From_Recording,

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -103,7 +103,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         from gaze_producers import Gaze_From_Recording, Offline_Calibration
         from system_graphs import System_Graphs
 
-        assert VersionFormat(pyglui_version) >= VersionFormat('1.10'), 'pyglui out of date, please upgrade to newest version'
+        assert VersionFormat(pyglui_version) >= VersionFormat('1.11'), 'pyglui out of date, please upgrade to newest version'
 
         runtime_plugins = import_runtime_plugins(os.path.join(user_dir, 'plugins'))
         system_plugins = [Log_Display, Seek_Control, Plugin_Manager, System_Graphs]

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -94,7 +94,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         from offline_surface_tracker import Offline_Surface_Tracker
         # from marker_auto_trim_marks import Marker_Auto_Trim_Marks
         from fixation_detector import Offline_Fixation_Detector
-        from batch_exporter import Batch_Exporter
+        from batch_exporter import Batch_Exporter, Batch_Export
         from log_display import Log_Display
         from annotations import Annotation_Player
         from raw_data_exporter import Raw_Data_Exporter
@@ -106,7 +106,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         assert VersionFormat(pyglui_version) >= VersionFormat('1.11'), 'pyglui out of date, please upgrade to newest version'
 
         runtime_plugins = import_runtime_plugins(os.path.join(user_dir, 'plugins'))
-        system_plugins = [Log_Display, Seek_Control, Plugin_Manager, System_Graphs]
+        system_plugins = [Log_Display, Seek_Control, Plugin_Manager, System_Graphs, Batch_Export]
         user_plugins = [Vis_Circle, Vis_Fixation, Vis_Polyline, Vis_Light_Points,
                         Vis_Cross, Vis_Watermark, Vis_Eye_Video_Overlay, Vis_Scan_Path,
                         Offline_Fixation_Detector, Batch_Exporter,

--- a/pupil_src/shared_modules/batch_exporter.py
+++ b/pupil_src/shared_modules/batch_exporter.py
@@ -55,10 +55,9 @@ class Batch_Exporter(Analysis_Plugin_Base):
     icon_chr = chr(0xec05)
     icon_font = 'pupil_icons'
 
-    def __init__(self, g_pool, source_dir='~/', destination_dir='~/'):
+    def __init__(self, g_pool, source_dir='~/work/pupil/recordings/BATCH', destination_dir='~/'):
         super().__init__(g_pool)
 
-        self._requires_ui_update = False
         self.available_exports = []
         self.queued_exports = []
         self.active_exports = []
@@ -91,15 +90,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
         self.menu.append(ui.Button('Export selected', self.queue_selected))
         self.menu.append(ui.Button('Clear search results', self._clear_avail))
 
-        self._mark_outdated_ui()
-
-    def _mark_outdated_ui(self):
-        self._requires_ui_update = True
-
-    def gl_display(self):
-        if self._requires_ui_update:
-            self._update_ui()
-            self._requires_ui_update = False
+        self._update_ui()
 
     def _update_ui(self):
         del self.menu.elements[7:]
@@ -114,7 +105,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
                             self.queued_exports.remove(qd)
                             self.available_exports.append({'source': qd['source'], 'selected': True})
                             self._update_avail_recs_menu()
-                            self._mark_outdated_ui()
+                            self._update_ui()
                     return cancel
                 self.menu.append(ui.Button('Cancel', cancel_qd(queued), outer_label=queued['dest']))
 
@@ -183,7 +174,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
 
     def _clear_previous(self):
         del self.previous_exports[:]
-        self._mark_outdated_ui()
+        self._update_ui()
 
     def _clear_avail(self):
         del self.available_exports[:]
@@ -224,7 +215,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
                 self.available_exports.remove(avail)
                 self.queued_exports.append(export)
         self._update_avail_recs_menu()
-        self._mark_outdated_ui()
+        self._update_ui()
 
     def start_export(self, queued):
         user_dir = self.g_pool.user_dir
@@ -239,6 +230,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
         process.progress = 0
         self.active_exports.append(process)
         self.queued_exports.remove(queued)
+        self._update_ui()
 
     def recent_events(self, events):
         if self.search_task:
@@ -264,7 +256,7 @@ class Batch_Exporter(Analysis_Plugin_Base):
             if process.canceled or process.completed:
                 self.active_exports.remove(process)
                 self.previous_exports.append(process)
-                self._mark_outdated_ui()
+                self._update_ui()
 
         # Add queued exports to active queue
         for queued in self.queued_exports[:self.worker_count - len(self.active_exports)]:

--- a/pupil_src/shared_modules/exporter.py
+++ b/pupil_src/shared_modules/exporter.py
@@ -53,8 +53,9 @@ class Global_Container(object):
 def export(rec_dir, user_dir, min_data_confidence, start_frame=None, end_frame=None,
            plugin_initializers=(), out_file_path=None, pre_computed={}):
 
-    logger = logging.getLogger(__name__+' with pid: '+str(os.getpid()))
-    start_status = 'Starting video export with pid: {}'.format(os.getpid())
+    PID = str(os.getpid())
+    logger = logging.getLogger(__name__+' with pid: '+PID)
+    start_status = 'Starting video export with pid: {}'.format(PID)
     print(start_status)
     yield start_status, 0
 
@@ -181,7 +182,7 @@ def export(rec_dir, user_dir, min_data_confidence, start_frame=None, end_frame=N
 
             writer.write_video_frame(frame)
             current_frame += 1
-            yield 'Exporting', current_frame
+            yield 'Exporting with pid {}'.format(PID), current_frame
 
         writer.close()
         writer = None

--- a/pupil_src/shared_modules/exporter.py
+++ b/pupil_src/shared_modules/exporter.py
@@ -196,9 +196,10 @@ def export(rec_dir, user_dir, min_data_confidence, start_frame=None, end_frame=N
 
     except GeneratorExit:
         print('Video export with pid {} was canceled.'.format(os.getpid()))
-    except:
+    except Exception as e:
         from time import sleep
         import traceback
         trace = traceback.format_exc()
         print('Process Export (pid: {}) crashed with trace:\n{}'.format(os.getpid(), trace))
+        yield e
         sleep(1.0)

--- a/pupil_src/shared_modules/video_export_launcher.py
+++ b/pupil_src/shared_modules/video_export_launcher.py
@@ -127,11 +127,15 @@ class Video_Export_Launcher(Analysis_Plugin_Base):
 
     def recent_events(self, events):
         for e in self.exports:
-            recent = [d for d in e.fetch()]
-            if recent:
-                e.status, e.progress = recent[-1]
-            if e.canceled:
-                e.status = 'Export has been canceled.'
+            try:
+                recent = [d for d in e.fetch()]
+            except Exception as e:
+                self.status, self.progress = '{}: {}'.format(type(e).__name__, e), 0
+            else:
+                if recent:
+                    e.status, e.progress = recent[-1]
+                if e.canceled:
+                    e.status = 'Export has been canceled.'
 
     def cleanup(self):
         """ called when the plugin gets terminated.


### PR DESCRIPTION
This PR uses #927 to fix #913.

### Behaviour

The batch export is split into 4 stages:
1. Search for available recordings
2. Queued exports
3. Active exports
4. Previous exports

- Canceling a queued export (2) puts it back to the list of available recordings (1).
- Canceling an active export (3) adds the export to the list of previous exports (4).

### Discussion
I feel like (1) and (2-4) should be split into two different menus. What do you think about that?