### PR TITLE
Singleeyefitter: Fix type where solve() returned a wrong variable

### DIFF
--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/solve.h
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/solve.h
@@ -95,7 +95,7 @@ namespace singleeyefitter {
             else
                 y = cbrt((w - v) / 2) - (u / 3) * cbrt(2 / (w - v)) - p / 3;
 
-            return std::tuple<T, T, T>(-p, -p, -p);
+            return std::tuple<T, T, T>(y, y, y);
 
         } else {
             // Three real roots


### PR DESCRIPTION
Fixes #975. I would like to know if this fix has an impact on the model fitter and if this might ave been the cause for instable models...