### PR TITLE
Require ndsi >= v0.3.3

### DIFF
--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -19,7 +19,7 @@ from camera_models import load_intrinsics
 
 try:
     from ndsi import __version__
-    assert __version__ >= '0.3.2'
+    assert __version__ >= '0.3.3'
     from ndsi import __protocol_version__
 except (ImportError, AssertionError):
     raise Exception("pyndsi version is to old. Please upgrade")


### PR DESCRIPTION
ndsi v0.3.3 includes the bug fixes for #976 and #910 


*This PR requires https://github.com/pupil-labs/pyndsi/pull/31 to be merged first.*