### PR TITLE
Opt-out online pupil detection

### DIFF
--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -361,8 +361,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
                                             g_pool,
                                             label='detection & mapping mode',
                                             setter=set_detection_mapping_mode,
-                                            selection=['2d','3d']
-                                        ))
+                                            selection=['disabled', '2d', '3d']))
         general_settings.append(ui.Switch('eye0_process',
                                             label='Detect eye 0',
                                             setter=lambda alive: start_stop_eye(0,alive),

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -236,7 +236,6 @@ def launcher():
             rec_dir = None
         cmd_push.notify({'subject':'player_drop_process.should_start','rec_dir':rec_dir})
 
-
     with Prevent_Idle_Sleep():
         while True:
             # listen for relevant messages.

--- a/pupil_src/shared_modules/pupil_detectors/__init__.py
+++ b/pupil_src/shared_modules/pupil_detectors/__init__.py
@@ -17,6 +17,7 @@ if not getattr(sys, 'frozen', False):
 
 from .detector_2d import Detector_2D
 from .detector_3d import Detector_3D
+from .detector_dummy import Detector_Dummy
 
 
 #explicit import here for pyinstaller because it will not search .pyx source files.

--- a/pupil_src/shared_modules/pupil_detectors/detector_dummy.py
+++ b/pupil_src/shared_modules/pupil_detectors/detector_dummy.py
@@ -1,0 +1,29 @@
+'''
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+'''
+
+from plugin import Plugin
+
+
+class Detector_Dummy(Plugin):
+    def __init__(g_pool, *args, **kwargs):
+        super().__init__(g_pool)
+
+    def detect(self, frame, *args, **kwargs):
+        return None
+
+    def visualize(self):
+        pass
+
+    def get_settings(self):
+        return {}
+
+    def on_resolution_change(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
Feature idea by @anligert. Online pupil detection is not required if one plans to use offline pupil detection anyway. Select `disable` as `detection & mapping mode` in the general settings to turn off pupil detection and gaze mapping. Do not forget to enable the `Record eye` option in the recorder settings if you do not use online pupil detection.