### PR TITLE
Service UI settings

### DIFF
--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -93,6 +93,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
         from calibration_routines import calibration_plugins, gaze_mapping_plugins
         from pupil_remote import Pupil_Remote
         from pupil_groups import Pupil_Groups
+        from service_ui import Service_UI
 
         logger.info('Application Version: {}'.format(version))
         logger.info('System Info: {}'.format(get_system_info()))
@@ -117,7 +118,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
 
         # manage plugins
         runtime_plugins = import_runtime_plugins(os.path.join(g_pool.user_dir, 'plugins'))
-        user_launchable_plugins = [Pupil_Groups, Pupil_Remote]+runtime_plugins
+        user_launchable_plugins = [Service_UI, Pupil_Groups, Pupil_Remote]+runtime_plugins
         plugin_by_index = runtime_plugins+calibration_plugins+gaze_mapping_plugins+user_launchable_plugins
         name_by_index = [p.__name__ for p in plugin_by_index]
         plugin_by_name = dict(zip(name_by_index, plugin_by_index))
@@ -179,6 +180,9 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
         ipc_pub.notify({'subject': 'service_process.started'})
         logger.warning('Process started.')
         g_pool.service_should_run = True
+
+        # initiate ui update loop
+        ipc_pub.notify({'subject': 'service_process.ui.should_update', 'delay': 1/30})
 
         # Event loop
         while g_pool.service_should_run:

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -182,7 +182,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
         g_pool.service_should_run = True
 
         # initiate ui update loop
-        ipc_pub.notify({'subject': 'service_process.ui.should_update', 'delay': 1/30})
+        ipc_pub.notify({'subject': 'service_process.ui.should_update', 'initial_delay': 1/40})
 
         # Event loop
         while g_pool.service_should_run:

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -121,7 +121,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
         plugin_by_index = runtime_plugins+calibration_plugins+gaze_mapping_plugins+user_launchable_plugins
         name_by_index = [p.__name__ for p in plugin_by_index]
         plugin_by_name = dict(zip(name_by_index, plugin_by_index))
-        default_plugins = [('Dummy_Gaze_Mapper', {}), ('HMD_Calibration', {}), ('Pupil_Remote', {})]
+        default_plugins = [('Service_UI', {}), ('Dummy_Gaze_Mapper', {}), ('HMD_Calibration', {}), ('Pupil_Remote', {})]
         g_pool.plugin_by_name = plugin_by_name
 
         tick = delta_t()

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -437,8 +437,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
                 for p in g_pool.plugins:
                     p.on_notify(n)
 
-
-            #a dictionary that allows plugins to post and read events
+            # a dictionary that allows plugins to post and read events
             events = {}
             # report time between now and the last loop interation
             events['dt'] = get_dt()

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -333,7 +333,7 @@ class Plugin_List(object):
         '''
         plugins may flag themselves as dead or are flagged as dead. We need to remove them.
         '''
-        for p in self._plugins[:]:
+        for p in self._plugins[::-1]:
             if not p.alive:
                 if self.g_pool.app in ("capture", "player"):
                     p.deinit_ui()

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -109,6 +109,7 @@ class Service_UI(System_Plugin_Base):
     def on_notify(self, notification):
         if notification['subject'] == 'service_process.ui.should_update':
             # resend delayed notification, keep ui loop running:
+            notification['delay'] = notification['initial_delay']
             self.notify_all(notification)
             self.update_ui()
 

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -51,25 +51,6 @@ class Service_UI(System_Plugin_Base):
                                            header_pos='headline')
         g_pool.gui.append(g_pool.menubar)
 
-        def set_window_size():
-            glfw.glfwSetWindowSize(main_window, 300, 300)
-        g_pool.menubar.append(ui.Button('Reset window size', set_window_size))
-        g_pool.menubar.append(ui.Selector('detection_mapping_mode',
-                                          g_pool,
-                                          label='Detection & mapping mode',
-                                          setter=self.set_detection_mapping_mode,
-                                          selection=['disabled', '2d', '3d']))
-        g_pool.menubar.append(ui.Switch('eye0_process',
-                                        label='Detect eye 0',
-                                        setter=lambda alive: self.start_stop_eye(0, alive),
-                                        getter=lambda: g_pool.eyes_are_alive[0].value))
-        g_pool.menubar.append(ui.Switch('eye1_process',
-                                        label='Detect eye 1',
-                                        setter=lambda alive: self.start_stop_eye(1, alive),
-                                        getter=lambda: g_pool.eyes_are_alive[1].value))
-
-        g_pool.menubar.append(ui.Info_Text('Service Version: {}'.format(g_pool.version)))
-
         # Callback functions
         def on_resize(window, w, h):
             self.window_size = w, h
@@ -93,6 +74,35 @@ class Service_UI(System_Plugin_Base):
 
         def on_scroll(window, x, y):
             g_pool.gui.update_scroll(x, y * scroll_factor)
+
+        def set_scale(new_scale):
+            g_pool.gui_user_scale = new_scale
+            on_resize(main_window, *self.window_size)
+
+        def set_window_size():
+            glfw.glfwSetWindowSize(main_window, 300, 300)
+
+        g_pool.menubar.append(ui.Selector('gui_user_scale', g_pool,
+                                          setter=set_scale,
+                                          selection=[.6, .8, 1., 1.2, 1.4],
+                                          label='Interface size'))
+
+        g_pool.menubar.append(ui.Button('Reset window size', set_window_size))
+        g_pool.menubar.append(ui.Selector('detection_mapping_mode',
+                                          g_pool,
+                                          label='Detection & mapping mode',
+                                          setter=self.set_detection_mapping_mode,
+                                          selection=['disabled', '2d', '3d']))
+        g_pool.menubar.append(ui.Switch('eye0_process',
+                                        label='Detect eye 0',
+                                        setter=lambda alive: self.start_stop_eye(0, alive),
+                                        getter=lambda: g_pool.eyes_are_alive[0].value))
+        g_pool.menubar.append(ui.Switch('eye1_process',
+                                        label='Detect eye 1',
+                                        setter=lambda alive: self.start_stop_eye(1, alive),
+                                        getter=lambda: g_pool.eyes_are_alive[1].value))
+
+        g_pool.menubar.append(ui.Info_Text('Service Version: {}'.format(g_pool.version)))
 
         # Register callbacks main_window
         glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -58,7 +58,7 @@ class Service_UI(System_Plugin_Base):
                                           g_pool,
                                           label='Detection & mapping mode',
                                           setter=self.set_detection_mapping_mode,
-                                          selection=['2d', '3d']))
+                                          selection=['disabled', '2d', '3d']))
         g_pool.menubar.append(ui.Switch('eye0_process',
                                         label='Detect eye 0',
                                         setter=lambda alive: self.start_stop_eye(0, alive),

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -1,0 +1,105 @@
+'''
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2017  Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+'''
+
+import platform
+import glfw
+from pyglui import ui, cygl
+from plugin import System_Plugin
+
+# UI Platform tweaks
+if platform.system() == 'Linux':
+    scroll_factor = 10.0
+    window_position_default = (30, 30)
+elif platform.system() == 'Windows':
+    scroll_factor = 10.0
+    window_position_default = (8, 31)
+else:
+    scroll_factor = 1.0
+    window_position_default = (0, 0)
+
+
+class Service_UI(System_Plugin):
+    def __init__(self, g_pool, window_size=(400, 300), window_position=window_position_default, gui_scale=1., ui_config={}):
+        super().__init__(g_pool)
+
+        glfw.glfwInit()
+        main_window = glfw.glfwCreateWindow(*window_size, "Pupil Service")
+        glfw.glfwSetWindowPos(main_window, *window_position)
+        glfw.glfwMakeContextCurrent(main_window)
+        cygl.utils.init()
+        g_pool.main_window = main_window
+
+        g_pool.gui = ui.UI()
+        g_pool.gui_user_scale = gui_scale
+        g_pool.menubar = ui.Scrolling_Menu("Settings", header_pos='headline')
+        g_pool.gui.append(g_pool.menubar)
+
+        g_pool.menubar.append(ui.Selector('detection_mapping_mode',
+                                          g_pool,
+                                          label='Detection & mapping mode',
+                                          setter=self.set_detection_mapping_mode,
+                                          selection=['2d', '3d']))
+        g_pool.menubar.append(ui.Switch('eye0_process',
+                                        label='Detect eye 0',
+                                        setter=lambda alive: self.start_stop_eye(0, alive),
+                                        getter=lambda: g_pool.eyes_are_alive[0].value))
+        g_pool.menubar.append(ui.Switch('eye1_process',
+                                        label='Detect eye 1',
+                                        setter=lambda alive: self.start_stop_eye(1, alive),
+                                        getter=lambda: g_pool.eyes_are_alive[1].value))
+
+        g_pool.menubar.append(ui.Info_Text('Service Version: {}'.format(g_pool.version)))
+
+        # Callback functions
+        def on_resize(window, w, h):
+            self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            g_pool.gui.scale = g_pool.gui_user_scale * self.hdpi_factor
+            g_pool.gui.update_window(w, h)
+            g_pool.gui.collect_menus()
+
+        def on_window_key(window, key, scancode, action, mods):
+            g_pool.gui.update_key(key, scancode, action, mods)
+
+        def on_window_char(window, char):
+            g_pool.gui.update_char(char)
+
+        def on_window_mouse_button(window, button, action, mods):
+            g_pool.gui.update_button(button, action, mods)
+
+        def on_pos(window, x, y):
+            x, y = x * self.hdpi_factor, y * self.hdpi_factor
+            g_pool.gui.update_mouse(x, y)
+
+        def on_scroll(window, x, y):
+            g_pool.gui.update_scroll(x, y * scroll_factor)
+
+        # Register callbacks main_window
+        glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)
+        glfw.glfwSetKeyCallback(main_window, on_window_key)
+        glfw.glfwSetCharCallback(main_window, on_window_char)
+        glfw.glfwSetMouseButtonCallback(main_window, on_window_mouse_button)
+        glfw.glfwSetCursorPosCallback(main_window, on_pos)
+        glfw.glfwSetScrollCallback(main_window, on_scroll)
+        g_pool.gui.configuration = ui_config
+
+    def cleanup(self):
+        del self.g_pool.menubar[:]
+        self.g_pool.gui.remove(self.g_pool.menubar)
+
+    def start_stop_eye(self, eye_id, make_alive):
+        if make_alive:
+            n = {'subject': 'eye_process.should_start.{}'.format(eye_id), 'eye_id': eye_id}
+        else:
+            n = {'subject': 'eye_process.should_stop.{}'.format(eye_id), 'eye_id': eye_id, 'delay': 0.2}
+        self.notify_all(n)
+
+    def set_detection_mapping_mode(self, new_mode):
+        self.notify_all({'subject': 'set_detection_mapping_mode', 'mode': new_mode})

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -11,6 +11,7 @@ See COPYING and COPYING.LESSER for license details.
 
 import platform
 import logging
+import socket
 
 import numpy as np
 
@@ -30,7 +31,7 @@ else:
     scroll_factor = 1.0
     window_position_default = (0, 0)
 
-window_size_default = (400, 350)
+window_size_default = (400, 400)
 logger = logging.getLogger(__name__)
 
 
@@ -98,6 +99,13 @@ class Service_UI(System_Plugin_Base):
                                           label='Interface size'))
 
         g_pool.menubar.append(ui.Button('Reset window size', set_window_size))
+
+        pupil_remote_addr = '{}:50020'.format(socket.gethostbyname(socket.gethostname()))
+        g_pool.menubar.append(ui.Text_Input('pupil_remote_addr',
+                                            getter=lambda: pupil_remote_addr,
+                                            setter=lambda x: None,
+                                            label='Pupil Remote address'))
+
         g_pool.menubar.append(ui.Selector('detection_mapping_mode',
                                           g_pool,
                                           label='Detection & mapping mode',


### PR DESCRIPTION
The only way to quit `Service` is via notifications, since it does not have a main window. This PR adds a small main window to the `Service` process that allows the user to:
- Start/stop eye processes
- Reset the user settings
- Set the detection and mapping method
- Quit `Service` by closing the main window