### PR TITLE
Recorder: Add unix and synced recording start times to info.csv

### DIFF
--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -219,6 +219,7 @@ class Recorder(System_Plugin_Base):
         self.running = True
         self.menu.read_only = True
         self.start_time = time()
+        start_time_synced = self.g_pool.get_timestamp()
 
         # set up self incrementing folder within session folder
         counter = 0
@@ -238,7 +239,9 @@ class Recorder(System_Plugin_Base):
             csv_utils.write_key_value_file(csvfile, {
                 'Recording Name': self.session_name,
                 'Start Date': strftime("%d.%m.%Y", localtime(self.start_time)),
-                'Start Time': strftime("%H:%M:%S", localtime(self.start_time))
+                'Start Time': strftime("%H:%M:%S", localtime(self.start_time)),
+                'Start Time (Unix)': self.start_time,
+                'Start Time (synced)': start_time_synced
             })
 
         self.video_path = os.path.join(self.rec_path, "world.mp4")

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -240,8 +240,8 @@ class Recorder(System_Plugin_Base):
                 'Recording Name': self.session_name,
                 'Start Date': strftime("%d.%m.%Y", localtime(self.start_time)),
                 'Start Time': strftime("%H:%M:%S", localtime(self.start_time)),
-                'Start Time (Unix)': self.start_time,
-                'Start Time (synced)': start_time_synced
+                'Start Time (System)': self.start_time,
+                'Start Time (Synced)': start_time_synced
             })
 
         self.video_path = os.path.join(self.rec_path, "world.mp4")


### PR DESCRIPTION
The unix timestamp corresponds to the Python system timebase, the synced timestamp corresponds to the synced timebased used for all data points in the recording.

Fixes #989, #982