### PR TITLE
Capture/Player: Collapsed main menu by default

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -375,6 +375,8 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         glfw.glfwSetScrollCallback(main_window, on_scroll)
         glfw.glfwSetDropCallback(main_window, on_drop)
 
+        toggle_general_settings(True)
+
         g_pool.gui.configuration = session_settings.get('ui_config', {})
 
         # gl_state settings

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -401,7 +401,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
         gl_utils.basic_gl_setup()
         g_pool.image_tex = Named_Texture()
 
-        toggle_general_settings(False)
+        toggle_general_settings(True)
 
         # now the we have  aproper window we can load the last gui configuration
         g_pool.gui.configuration = session_settings.get('ui_config', {})


### PR DESCRIPTION
The idea is to collapse the main menu by default. We were not able to do so before the introduction of the icon bar since the collapse icon was not obvious to the user. It is more obvious that the icons allow interaction. Having the menu collapsed initially shows the user that the main menu can be collapsed. This is important for those users that used to drag the menu to collapse it. This is not possible anymore with the introduction of the minimum menu width.