### PR TITLE
Avoid ZeroDivisionError when calculating hdpi factors

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -173,7 +173,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
 
             active_window = glfw.glfwGetCurrentContext()
             glfw.glfwMakeContextCurrent(window)
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            hdpi_factor = glfw.getHDPIFactor(window)
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -173,7 +173,10 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
 
             active_window = glfw.glfwGetCurrentContext()
             glfw.glfwMakeContextCurrent(window)
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            try:
+                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                pass
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -173,10 +173,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
 
             active_window = glfw.glfwGetCurrentContext()
             glfw.glfwMakeContextCurrent(window)
-            try:
-                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                pass
+            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -137,7 +137,10 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal hdpi_factor
 
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            try:
+                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                pass
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             g_pool.camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h
@@ -607,7 +610,10 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url,
         while not glfw.glfwWindowShouldClose(window):
 
             fb_size = glfw.glfwGetFramebufferSize(window)
-            hdpi_factor = float(fb_size[0] / glfw.glfwGetWindowSize(window)[0])
+            try:
+                hdpi_factor = float(fb_size[0] / glfw.glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                hdpi_factor = 1.
             gl_utils.adjust_gl_view(*fb_size)
 
             if rec_dir:

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -137,7 +137,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal hdpi_factor
 
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            hdpi_factor = glfw.getHDPIFactor(window)
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             g_pool.camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h
@@ -607,7 +607,7 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url,
         while not glfw.glfwWindowShouldClose(window):
 
             fb_size = glfw.glfwGetFramebufferSize(window)
-            hdpi_factor = float(fb_size[0] / glfw.glfwGetWindowSize(window)[0])
+            hdpi_factor = glfw.getHDPIFactor(window)
             gl_utils.adjust_gl_view(*fb_size)
 
             if rec_dir:

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -137,10 +137,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal hdpi_factor
 
-            try:
-                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                pass
+            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w, h
             g_pool.camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h
@@ -610,10 +607,7 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url,
         while not glfw.glfwWindowShouldClose(window):
 
             fb_size = glfw.glfwGetFramebufferSize(window)
-            try:
-                hdpi_factor = float(fb_size[0] / glfw.glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                hdpi_factor = 1.
+            hdpi_factor = float(fb_size[0] / glfw.glfwGetWindowSize(window)[0])
             gl_utils.adjust_gl_view(*fb_size)
 
             if rec_dir:

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -220,10 +220,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal camera_render_size
             nonlocal hdpi_factor
-            try:
-                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                pass  # keep previous value
+            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w,h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -220,7 +220,10 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal camera_render_size
             nonlocal hdpi_factor
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            try:
+                hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                pass  # keep previous value
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w,h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -220,7 +220,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             nonlocal window_size
             nonlocal camera_render_size
             nonlocal hdpi_factor
-            hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            hdpi_factor = glfw.getHDPIFactor(window)
             g_pool.gui.scale = g_pool.gui_user_scale * hdpi_factor
             window_size = w,h
             camera_render_size = w-int(icon_bar_width*g_pool.gui.scale), h

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -310,10 +310,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        try:
-            hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
-        except ZeroDivisionError:
-            hdpi_factor = 1.
+        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -310,7 +310,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        hdpi_factor = getHDPIFactor(self._window)
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -310,7 +310,10 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        try:
+            hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        except ZeroDivisionError:
+            hdpi_factor = 1.
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -290,7 +290,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        hdpi_factor = getHDPIFactor(self._window)
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -290,10 +290,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        try:
-            hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
-        except ZeroDivisionError:
-            hdpi_factor = 1.
+        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -290,7 +290,10 @@ class Single_Marker_Calibration(Calibration_Plugin):
 
         clear_gl_screen()
 
-        hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        try:
+            hdpi_factor = glfwGetFramebufferSize(self._window)[0]/glfwGetWindowSize(self._window)[0]
+        except ZeroDivisionError:
+            hdpi_factor = 1.
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()

--- a/pupil_src/shared_modules/glfw.py
+++ b/pupil_src/shared_modules/glfw.py
@@ -659,3 +659,11 @@ exec(__callback__('MouseButton'))
 exec(__callback__('CursorPos'))
 exec(__callback__('Scroll'))
 exec(__callback__('Drop'))
+
+
+def getHDPIFactor(window):
+    try:
+        return float(glfwGetFramebufferSize(window)[0] /
+                     glfwGetWindowSize(window)[0])
+    except ZeroDivisionError:
+        return 1.

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -67,7 +67,7 @@ class Log_Display(System_Plugin_Base):
         self.alpha = min(self.alpha, 6.)
 
     def on_window_resize(self, window, w, h):
-        self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+        self.window_scale = glfw.getHDPIFactor(window)
         self.glfont.set_size(32*self.window_scale)
         self.window_size = w, h
         self.tex.resize(*self.window_size)

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -67,10 +67,7 @@ class Log_Display(System_Plugin_Base):
         self.alpha = min(self.alpha, 6.)
 
     def on_window_resize(self, window, w, h):
-        try:
-            self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-        except ZeroDivisionError:
-            self.window_scale = 1.
+        self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
         self.glfont.set_size(32*self.window_scale)
         self.window_size = w, h
         self.tex.resize(*self.window_size)

--- a/pupil_src/shared_modules/log_display.py
+++ b/pupil_src/shared_modules/log_display.py
@@ -67,7 +67,10 @@ class Log_Display(System_Plugin_Base):
         self.alpha = min(self.alpha, 6.)
 
     def on_window_resize(self, window, w, h):
-        self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+        try:
+            self.window_scale = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+        except ZeroDivisionError:
+            self.window_scale = 1.
         self.glfont.set_size(32*self.window_scale)
         self.window_size = w, h
         self.tex.resize(*self.window_size)

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -59,7 +59,10 @@ class Service_UI(System_Plugin_Base):
         # Callback functions
         def on_resize(window, w, h):
             self.window_size = w, h
-            self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            try:
+                self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                self.hdpi_factor = 1.
             g_pool.gui.scale = g_pool.gui_user_scale * self.hdpi_factor
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -59,7 +59,7 @@ class Service_UI(System_Plugin_Base):
         # Callback functions
         def on_resize(window, w, h):
             self.window_size = w, h
-            self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
+            self.hdpi_factor = glfw.getHDPIFactor(window)
             g_pool.gui.scale = g_pool.gui_user_scale * self.hdpi_factor
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -59,10 +59,7 @@ class Service_UI(System_Plugin_Base):
         # Callback functions
         def on_resize(window, w, h):
             self.window_size = w, h
-            try:
-                self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                self.hdpi_factor = 1.
+            self.hdpi_factor = float(glfw.glfwGetFramebufferSize(window)[0] / glfw.glfwGetWindowSize(window)[0])
             g_pool.gui.scale = g_pool.gui_user_scale * self.hdpi_factor
             g_pool.gui.update_window(w, h)
             g_pool.gui.collect_menus()

--- a/pupil_src/shared_modules/system_graphs.py
+++ b/pupil_src/shared_modules/system_graphs.py
@@ -101,7 +101,7 @@ class System_Graphs(System_Plugin_Base):
 
     def on_window_resize(self, window, *args):
         fb_size = glfw.glfwGetFramebufferSize(window)
-        hdpi_factor = fb_size[0] / glfw.glfwGetWindowSize(window)[0]
+        hdpi_factor = glfw.getHDPIFactor(window)
 
         self.cpu_graph.scale = hdpi_factor
         self.fps_graph.scale = hdpi_factor

--- a/pupil_src/shared_modules/system_graphs.py
+++ b/pupil_src/shared_modules/system_graphs.py
@@ -101,10 +101,7 @@ class System_Graphs(System_Plugin_Base):
 
     def on_window_resize(self, window, *args):
         fb_size = glfw.glfwGetFramebufferSize(window)
-        try:
-            hdpi_factor = fb_size[0] / glfw.glfwGetWindowSize(window)[0]
-        except ZeroDivisionError:
-            hdpi_factor = 1.
+        hdpi_factor = fb_size[0] / glfw.glfwGetWindowSize(window)[0]
 
         self.cpu_graph.scale = hdpi_factor
         self.fps_graph.scale = hdpi_factor

--- a/pupil_src/shared_modules/system_graphs.py
+++ b/pupil_src/shared_modules/system_graphs.py
@@ -101,7 +101,10 @@ class System_Graphs(System_Plugin_Base):
 
     def on_window_resize(self, window, *args):
         fb_size = glfw.glfwGetFramebufferSize(window)
-        hdpi_factor = fb_size[0] / glfw.glfwGetWindowSize(window)[0]
+        try:
+            hdpi_factor = fb_size[0] / glfw.glfwGetWindowSize(window)[0]
+        except ZeroDivisionError:
+            hdpi_factor = 1.
 
         self.cpu_graph.scale = hdpi_factor
         self.fps_graph.scale = hdpi_factor

--- a/pupil_src/shared_modules/vis_eye_video_overlay.py
+++ b/pupil_src/shared_modules/vis_eye_video_overlay.py
@@ -212,10 +212,7 @@ class Vis_Eye_Video_Overlay(Visualizer_Plugin_Base):
 
         if self.g_pool.app != 'exporter':
             window = g_pool.main_window
-            try:
-                self.hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
-            except ZeroDivisionError:
-                self.hdpi_factor = 1.
+            self.hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
         else:
             self.hdpi_factor = 1.
 

--- a/pupil_src/shared_modules/vis_eye_video_overlay.py
+++ b/pupil_src/shared_modules/vis_eye_video_overlay.py
@@ -15,7 +15,7 @@ from glob import glob
 import cv2
 import numpy as np
 from pyglui import ui
-from glfw import glfwGetCursorPos, glfwGetFramebufferSize, glfwGetWindowSize, glfwGetCurrentContext
+from glfw import glfwGetCursorPos, glfwGetFramebufferSize, glfwGetWindowSize, glfwGetCurrentContext, getHDPIFactor
 
 from plugin import Visualizer_Plugin_Base
 from player_methods import transparent_image_overlay
@@ -212,7 +212,7 @@ class Vis_Eye_Video_Overlay(Visualizer_Plugin_Base):
 
         if self.g_pool.app != 'exporter':
             window = g_pool.main_window
-            self.hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
+            self.hdpi_factor = getHDPIFactor(window)
         else:
             self.hdpi_factor = 1.
 

--- a/pupil_src/shared_modules/vis_eye_video_overlay.py
+++ b/pupil_src/shared_modules/vis_eye_video_overlay.py
@@ -212,7 +212,10 @@ class Vis_Eye_Video_Overlay(Visualizer_Plugin_Base):
 
         if self.g_pool.app != 'exporter':
             window = g_pool.main_window
-            self.hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
+            try:
+                self.hdpi_factor = float(glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0])
+            except ZeroDivisionError:
+                self.hdpi_factor = 1.
         else:
             self.hdpi_factor = 1.
 

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -217,7 +217,7 @@ class Visualizer(object):
             self.input['button'] = None
 
     def on_pos(self,window,x, y):
-        hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
+        hdpi_factor = getHDPIFactor(window)
         x,y = x*hdpi_factor,y*hdpi_factor
         # self.gui.update_mouse(x,y)
         if self.input['button']==GLFW_MOUSE_BUTTON_RIGHT:

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -217,10 +217,7 @@ class Visualizer(object):
             self.input['button'] = None
 
     def on_pos(self,window,x, y):
-        try:
-            hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
-        except ZeroDivisionError:
-            hdpi_factor = 1.
+        hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
         x,y = x*hdpi_factor,y*hdpi_factor
         # self.gui.update_mouse(x,y)
         if self.input['button']==GLFW_MOUSE_BUTTON_RIGHT:

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -217,7 +217,10 @@ class Visualizer(object):
             self.input['button'] = None
 
     def on_pos(self,window,x, y):
-        hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
+        try:
+            hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
+        except ZeroDivisionError:
+            hdpi_factor = 1.
         x,y = x*hdpi_factor,y*hdpi_factor
         # self.gui.update_mouse(x,y)
         if self.input['button']==GLFW_MOUSE_BUTTON_RIGHT:


### PR DESCRIPTION
Reasoning: `glfwGetWindowSize` might return window widths of value `zero` on Windows.
Fixes #1087