### PR TITLE
Player: Incremental increasing export folder names

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -33,9 +33,8 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
     # general imports
     from time import sleep
     import logging
-    import errno
     from glob import glob
-    from time import time
+    from time import time, strftime, localtime
     # networking
     import zmq
     import zmq_tools
@@ -59,7 +58,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
     try:
 
         # imports
-        from file_methods import Persistent_Dict, load_object
+        from file_methods import Persistent_Dict, load_object, next_export_sub_dir
 
         # display
         import glfw
@@ -76,6 +75,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         from version_utils import VersionFormat
         from methods import normalize, denormalize, delta_t, get_system_info
         from player_methods import correlate_data, is_pupil_rec_dir, load_meta_info
+        from csv_utils import write_key_value_file
 
         # Plug-ins
         from plugin import Plugin, Plugin_List, import_runtime_plugins
@@ -284,20 +284,21 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
             right_idx = g_pool.seek_control.trim_right
             export_range = left_idx, right_idx + 1  # exclusive range.stop
 
-            export_dir = os.path.join(g_pool.rec_dir, 'exports',
-                                      g_pool.seek_control.get_folder_name_from_trims())
+            export_dir = os.path.join(g_pool.rec_dir, 'exports')
+            export_dir = next_export_sub_dir(export_dir)
 
-            try:
-                os.makedirs(export_dir)
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    logger.error("Could not create export dir")
-                    raise e
-                else:
-                    overwrite_warning = "Previous export for range [{}] already exists - overwriting."
-                    logger.warning(overwrite_warning.format(g_pool.seek_control.get_trim_range_string()))
-            else:
-                logger.info('Created export dir at "{}"'.format(export_dir))
+            os.makedirs(export_dir)
+            logger.info('Created export dir at "{}"'.format(export_dir))
+
+            export_info = {'Player Software Version': str(g_pool.version),
+                           'Data Format Version': meta_info['Data Format Version'],
+                           'Export Date': strftime("%d.%m.%Y", localtime()),
+                           'Export Time': strftime("%H:%M:%S", localtime()),
+                           'Frame Index Range:': g_pool.seek_control.get_frame_index_trim_range_string(),
+                           'Relative Time Range': g_pool.seek_control.get_rel_time_trim_range_string(),
+                           'Absolute Time Range': g_pool.seek_control.get_abs_time_trim_range_string()}
+            with open(os.path.join(export_dir, 'export_info.csv'), 'w') as csv:
+                write_key_value_file(csv, export_info)
 
             notification = {'subject': 'should_export', 'range': export_range, 'export_dir': export_dir}
             g_pool.ipc_pub.notify(notification)
@@ -345,6 +346,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         general_settings.append(ui.Info_Text('Data Format Version: {}'.format(meta_info['Data Format Version'])))
         general_settings.append(ui.Slider('min_data_confidence', g_pool, setter=set_data_confidence,
                                           step=.05, min=0.0, max=1.0, label='Confidence threshold'))
+
         general_settings.append(ui.Button('Restart with default settings', reset_restart))
 
         g_pool.menubar.append(general_settings)
@@ -382,6 +384,15 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
                            ('Pupil_From_Recording', {}),
                            ('Gaze_From_Recording', {})]
         g_pool.plugins = Plugin_List(g_pool, session_settings.get('loaded_plugins', default_plugins))
+
+        general_settings.insert(-1 ,ui.Text_Input('rel_time_trim_section',
+                                              getter=g_pool.seek_control.get_rel_time_trim_range_string,
+                                              setter=g_pool.seek_control.set_rel_time_trim_range_string,
+                                              label='Relative time range to export'))
+        general_settings.insert(-1 ,ui.Text_Input('frame_idx_trim_section',
+                                              getter=g_pool.seek_control.get_frame_index_trim_range_string,
+                                              setter=g_pool.seek_control.set_frame_index_trim_range_string,
+                                              label='Frame index range to export'))
 
         # Register callbacks main_window
         glfw.glfwSetFramebufferSizeCallback(main_window, on_resize)

--- a/pupil_src/shared_modules/file_methods.py
+++ b/pupil_src/shared_modules/file_methods.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 import traceback as tb
 import logging
+from glob import iglob
 logger = logging.getLogger(__name__)
 UnpicklingError = pickle.UnpicklingError
 
@@ -81,75 +82,14 @@ def save_object(object_, file_path):
         msgpack.pack(object_, fh, use_bin_type=True,default=ndarrray_to_list)
 
 
+def next_export_sub_dir(root_export_dir):
+    # match any sub directories or files a three digit pattern
+    pattern = os.path.join(root_export_dir, '[0-9][0-9][0-9]')
+    existing_subs = sorted(iglob(pattern))
+    try:
+        latest = os.path.split(existing_subs[-1])[-1]
+        next_sub_dir = '{:03d}'.format(int(latest) + 1)
+    except IndexError:
+        next_sub_dir = '000'
 
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
-    # settings = Persistent_Dict("~/Desktop/test")
-    # settings['f'] = "this is a test"
-    # settings['list'] = ["list 1","list2"]
-    # settings.close()
-
-    # save_object("string",'test')
-    # print load_object('test')
-    # settings = Persistent_Dict('~/Desktop/pupil_settings/user_settings_eye')
-    # print settings['roi']
-
-    def run():
-
-        # example. Write out pupil data into csv file.
-        from time import time
-        t = time()
-        l = load_object('/Users/mkassner/Downloads/data/pupil_data')
-        # print(l['notifications'])
-        print(time()-t)
-        # t = time()
-        save_object((np.ones((2,2)),np.ones((2,2))),'/Users/mkassner/Downloads/data/arrry')
-        print(load_object('/Users/mkassner/Downloads/data/arrry'))
-        t = time()
-        save_object(l,'/Users/mkassner/Downloads/data/pupil_data2')
-        print(time()-t)
-
-        t = time()
-        l = load_object('/Users/mkassner/Downloads/data/pupil_data2')
-        # print(l['gaze_positions'][:100])
-
-        print(time()-t)
-        # save_object(l,'/Users/mkassner/Downloads/data/pupil_data2')
-
-    run()
-    exit()
-    import csv
-    with open(os.path.join('/Users/mkassner/Pupil/pupil_code/pupil_src/capture/pupil_postions.csv'), 'w') as csvfile:
-        csv_writer = csv.writer(csvfile, delimiter=',')
-        csv_writer.writerow(('timestamp',
-                             'id',
-                             'confidence',
-                             'norm_pos_x',
-                             'norm_pos_y',
-                             'diameter',
-                             'method',
-                             'ellipse_center_x',
-                             'ellipse_center_y',
-                             'ellipse_axis_a',
-                             'ellipse_axis_b',
-                             'ellipse_angle'))
-        for p in l['pupil_positions']:
-            data_2d = [str(p['timestamp']),  # use str to be consitant with csv lib.
-                       p['id'],
-                       p['confidence'],
-                       p['norm_pos'][0],
-                       p['norm_pos'][1],
-                       p['diameter'],
-                       p['method']]
-            try:
-                ellipse_data = [p['ellipse']['center'][0],
-                                p['ellipse']['center'][1],
-                                p['ellipse']['axes'][0],
-                                p['ellipse']['axes'][1],
-                                p['ellipse']['angle']]
-            except KeyError:
-                ellipse_data = [None]*5
-
-            row = data_2d + ellipse_data
-            csv_writer.writerow(row)
-
+    return os.path.join(root_export_dir, next_sub_dir)

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -106,11 +106,6 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
         self.menu.label = 'Raw Data Exporter'
         self.menu.append(ui.Info_Text('Export Raw Pupil Capture data into .csv files.'))
         self.menu.append(ui.Info_Text('Select your export frame range using the trim marks in the seek bar. This will affect all exporting plugins.'))
-        self.menu.append(ui.Info_Text('Select your export frame range using the trim marks in the seek bar. This will affect all exporting plugins.'))
-        self.menu.append(ui.Text_Input('in_mark',
-                                       getter=self.g_pool.seek_control.get_trim_range_string,
-                                       setter=self.g_pool.seek_control.set_trim_range_string,
-                                       label='frame range to export'))
         self.menu.append(ui.Info_Text("Press the export button or type 'e' to start the export."))
 
     def deinit_ui(self):

--- a/pupil_src/shared_modules/seek_control.py
+++ b/pupil_src/shared_modules/seek_control.py
@@ -148,7 +148,7 @@ class Seek_Control(System_Plugin_Base):
     def set_trim_range(self, mark_range):
         self.trim_left, self.trim_right = mark_range
 
-    def get_trim_range_string(self):
+    def get_rel_time_trim_range_string(self):
         time_fmt = ''
         min_ts = self.g_pool.timestamps[0]
         for ts in (self.trim_left_ts, self.trim_right_ts):
@@ -159,7 +159,7 @@ class Seek_Control(System_Plugin_Base):
             time_fmt += '{:02.0f}:{:02d}.{:03d} - '.format(abs(minutes), int(seconds), micro_seconds_e1)
         return time_fmt[:-3]
 
-    def set_trim_range_string(self, range_str):
+    def set_rel_time_trim_range_string(self, range_str):
         try:
             range_list = range_str.split('-')
             assert len(range_list) == 2
@@ -180,7 +180,28 @@ class Seek_Control(System_Plugin_Base):
             self.trim_left_ts = left
 
         except (AssertionError, ValueError):
-            logger.warning('Invalid trim range entered')
+            logger.warning('Invalid time range entered')
+
+    def get_abs_time_trim_range_string(self):
+        return '{} - {}'.format(self.g_pool.timestamps[self.trim_left],
+                                self.g_pool.timestamps[self.trim_right])
+
+    def get_frame_index_trim_range_string(self):
+        return '{} - {}'.format(self.trim_left, self.trim_right)
+
+    def set_frame_index_trim_range_string(self, range_str):
+        try:
+            range_list = range_str.split('-')
+            assert len(range_list) == 2
+
+            left, right = map(int, range_list)
+            assert left < right
+
+            self.trim_right = right
+            self.trim_left = left
+
+        except AssertionError:
+            logger.warning('Invalid frame index range entered')
 
     def get_folder_name_from_trims(self):
         time_fmt = ''

--- a/pupil_src/shared_modules/video_export_launcher.py
+++ b/pupil_src/shared_modules/video_export_launcher.py
@@ -77,10 +77,6 @@ class Video_Export_Launcher(Analysis_Plugin_Base):
         self.menu.append(ui.Info_Text('Supply export video recording name. The export will be in the recording dir. If you give a path the export will end up there instead.'))
         self.menu.append(ui.Text_Input('rec_name',self,label='Export name'))
         self.menu.append(ui.Info_Text('Select your export frame range using the trim marks in the seek bar. This will affect all exporting plugins.'))
-        self.menu.append(ui.Text_Input('trim_section',
-                                       getter=self.g_pool.seek_control.get_trim_range_string,
-                                       setter=self.g_pool.seek_control.set_trim_range_string,
-                                       label='Frame range to export'))
         self.menu.append(ui.Info_Text("Press the export button or type 'e' to start the export."))
 
         for job in self.exports[::-1]:


### PR DESCRIPTION
- Add trim section displays to general settings
    - Relative recording time
   - Frame indeces
- Remove trim section displays from video and raw data exporters
- Add export_info.csv
   - Player version
   - Data format version
   - Export start date and time
   - Frame index trim range
   - Relative time trim range
   - Absolute time trim range (`world` timestamp range)
- Do not use trim range as naming convention
- Use incrementally increasing folder names with format `%d%d%d`, e.g.:
  - `<recording>/exports/000/`
  - `<recording>/exports/001/`
  - `<recording>/exports/002/`