### PR TITLE
Confidence threshold consistency

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -252,6 +252,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         g_pool.rec_dir = rec_dir
         g_pool.meta_info = meta_info
         g_pool.min_data_confidence = session_settings.get('min_data_confidence', 0.6)
+        g_pool.min_calibration_confidence = session_settings.get('min_calibration_confidence', 0.8)
 
         g_pool.pupil_positions = []
         g_pool.gaze_positions = []
@@ -344,8 +345,12 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         general_settings.append(ui.Info_Text('Player Version: {}'.format(g_pool.version)))
         general_settings.append(ui.Info_Text('Capture Version: {}'.format(meta_info['Capture Software Version'])))
         general_settings.append(ui.Info_Text('Data Format Version: {}'.format(meta_info['Data Format Version'])))
-        general_settings.append(ui.Slider('min_data_confidence', g_pool, setter=set_data_confidence,
-                                          step=.05, min=0.0, max=1.0, label='Confidence threshold'))
+
+        general_settings.append(ui.Info_Text('High level data, e.g. fixations, or visualizations only consider gaze data that has an equal or higher confidence than the minimum data confidence.'))
+        general_settings.append(ui.Slider('min_data_confidence', g_pool,
+                                          setter=set_data_confidence,
+                                          step=.05, min=0.0, max=1.0,
+                                          label='Minimum data confidence'))
 
         general_settings.append(ui.Button('Restart with default settings', reset_restart))
 
@@ -519,6 +524,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url,
         session_settings['playback_speed'] = g_pool.capture.playback_speed
         session_settings['loaded_plugins'] = g_pool.plugins.get_initializers()
         session_settings['min_data_confidence'] = g_pool.min_data_confidence
+        session_settings['min_calibration_confidence'] = g_pool.min_calibration_confidence
         session_settings['gui_scale'] = g_pool.gui_user_scale
         session_settings['ui_config'] = g_pool.gui.configuration
         session_settings['window_position'] = glfw.glfwGetWindowPos(main_window)

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -136,6 +136,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
             logger.info("Session setting are from older version of this app. I will not use those.")
             session_settings.clear()
 
+        g_pool.min_calibration_confidence = session_settings.get('min_calibration_confidence', 0.8)
         g_pool.detection_mapping_mode = session_settings.get('detection_mapping_mode', '2d')
         g_pool.active_calibration_plugin = None
         g_pool.active_gaze_mapping_plugin = None
@@ -212,6 +213,7 @@ def service(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, us
         session_settings['version'] = str(g_pool.version)
         session_settings['eye0_process_alive'] = eyes_are_alive[0].value
         session_settings['eye1_process_alive'] = eyes_are_alive[1].value
+        session_settings['min_calibration_confidence'] = g_pool.min_calibration_confidence
         session_settings['detection_mapping_mode'] = g_pool.detection_mapping_mode
         session_settings['audio_mode'] = audio.audio_mode
         session_settings.close()

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -267,6 +267,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             logger.info("Session setting are from a different version of this app. I will not use those.")
             session_settings.clear()
 
+        g_pool.min_calibration_confidence = session_settings.get('min_calibration_confidence', 0.8)
         g_pool.detection_mapping_mode = session_settings.get('detection_mapping_mode', '3d')
         g_pool.active_calibration_plugin = None
         g_pool.active_gaze_mapping_plugin = None
@@ -513,6 +514,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
         session_settings['version'] = str(g_pool.version)
         session_settings['eye0_process_alive'] = eyes_are_alive[0].value
         session_settings['eye1_process_alive'] = eyes_are_alive[1].value
+        session_settings['min_calibration_confidence'] = g_pool.min_calibration_confidence
         session_settings['detection_mapping_mode'] = g_pool.detection_mapping_mode
         session_settings['audio_mode'] = audio.audio_mode
 

--- a/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
+++ b/pupil_src/shared_modules/calibration_routines/calibration_plugin_base.py
@@ -25,7 +25,6 @@ class Calibration_Plugin(Plugin):
     def __init__(self, g_pool):
         super().__init__(g_pool)
         self.g_pool.active_calibration_plugin = self
-        self.pupil_confidence_threshold = 0.6
         self.active = False
         self.mode = 'calibration'
 
@@ -51,6 +50,11 @@ class Calibration_Plugin(Plugin):
                                 labels=[p.__name__.replace('_', ' ') for p in calibration_plugins],
                                 label='Calibration Method'
                             ))
+
+        self.menu.append(ui.Info_Text('Calibration only considers pupil data that has an equal or higher confidence than the minimum calibration confidence.'))
+        self.menu.append(ui.Slider('min_calibration_confidence', self.g_pool,
+                                   step=.01, min=0.0, max=1.0,
+                                   label='Minimum calibration confidence'))
 
     @property
     def mode_pretty(self):

--- a/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/hmd_calibration.py
@@ -173,9 +173,7 @@ class HMD_Calibration(Calibration_Plugin):
 
     def recent_events(self, events):
         if self.active:
-            for p_pt in events['pupil_positions']:
-                if p_pt['confidence'] > self.pupil_confidence_threshold:
-                    self.pupil_list.append(p_pt)
+            self.pupil_list.extend(events['pupil_positions'])
 
     def get_init_dict(self):
         d = {}

--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -100,8 +100,6 @@ class Manual_Marker_Calibration(Calibration_Plugin):
         """
         frame = events.get('frame')
         if self.active and frame:
-            recent_pupil_positions = events['pupil_positions']
-
             gray_img = frame.gray
 
             # Update the marker
@@ -179,9 +177,7 @@ class Manual_Marker_Calibration(Calibration_Plugin):
                             self.notify_all({'subject':'calibration.marker_sample_completed','timestamp':self.g_pool.get_timestamp(),'record':True})
 
             # Always save pupil positions
-            for p_pt in recent_pupil_positions:
-                if p_pt['confidence'] > self.pupil_confidence_threshold:
-                    self.pupil_list.append(p_pt)
+            self.pupil_list.extend(events['pupil_positions'])
 
             if self.counter:
                 if len(self.markers):

--- a/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/natural_features_calibration.py
@@ -73,8 +73,6 @@ class Natural_Features_Calibration(Calibration_Plugin):
         if not frame:
             return
         if self.active:
-            recent_pupil_positions = events['pupil_positions']
-
             if self.first_img is None:
                 self.first_img = frame.gray.copy()
 
@@ -99,10 +97,8 @@ class Natural_Features_Calibration(Calibration_Plugin):
                     ref["timestamp"] = frame.timestamp
                     self.ref_list.append(ref)
 
-            #always save pupil positions
-            for p_pt in recent_pupil_positions:
-                if p_pt['confidence'] > self.pupil_confidence_threshold:
-                    self.pupil_list.append(p_pt)
+            # Always save pupil positions
+            self.pupil_list.extend(events['pupil_positions'])
 
             if self.count:
                 self.button.status_text = 'Sampling Gaze Data'

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -222,7 +222,6 @@ class Screen_Marker_Calibration(Calibration_Plugin):
     def recent_events(self, events):
         frame = events.get('frame')
         if self.active and frame:
-            recent_pupil_positions = events['pupil_positions']
             gray_img = frame.gray
 
             if self.clicks_to_close <=0:
@@ -257,9 +256,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                 self.ref_list.append(ref)
 
             # Always save pupil positions
-            for p_pt in recent_pupil_positions:
-                if p_pt['confidence'] > self.pupil_confidence_threshold:
-                    self.pupil_list.append(p_pt)
+            self.pupil_list.extend(events['pupil_positions'])
 
             if on_position and len(self.markers) and events.get('fixations', []):
                 fixation_boost = 5

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -193,11 +193,9 @@ class Single_Marker_Calibration(Calibration_Plugin):
     def recent_events(self, events):
         frame = events.get('frame')
         if self.active and frame:
-            recent_pupil_positions = events['pupil_positions']
-
             gray_img = frame.gray
 
-            if self.clicks_to_close <=0:
+            if self.clicks_to_close <= 0:
                 self.stop()
                 return
 
@@ -237,17 +235,14 @@ class Single_Marker_Calibration(Calibration_Plugin):
                 self.ref_list.append(ref)
 
             # always save pupil positions
-            for p_pt in recent_pupil_positions:
-                if p_pt['confidence'] > self.pupil_confidence_threshold:
-                    self.pupil_list.append(p_pt)
-
+            self.pupil_list.extend(events['pupil_positions'])
 
             # Animate the screen marker
             if len(self.markers) or not on_position:
                 self.screen_marker_state += 1
 
             # Stop if autostop condition is satisfied:
-            if self.auto_stop >=self.auto_stop_max:
+            if self.auto_stop >= self.auto_stop_max:
                 self.auto_stop = 0
                 self.stop()
 


### PR DESCRIPTION
1. Previously, all binocular mappers dismissed pupil data with confidence lower than `0.6` to prevent bad binocular mapping. Now, low confidence pupil data is mapped monocularly.
2. Introduction of a user-settable global **minimum calibration confidence** threshold: A threshold that lower bounds the pupil data confidence that is used for calibration. This value was previously fixed to `0.8` in Pupil Capture and to `0.0` in Pupil Player -- effectively using low confidence pupil data for calibration.

These changes were introduced based on #1052 and #1047.

**Minimum data confidence**: Lower bounds _gaze_ data by confidence that is used to generate visualizations and high level data, e.g. fixations. This does not effect the raw data export. Following data points are effected by it:
- Fixations
- Offline surface heatmaps
- Circle, cross, light points and polyline visualizations