### PR TITLE
Set default Y position of application windows to 90 for Windows OS

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -138,7 +138,7 @@ def eye(timebase, is_alive_flag, ipc_pub_url, ipc_sub_url, ipc_push_url,
             window_position_default = (600, 300 * eye_id + 30)
         elif platform.system() == 'Windows':
             scroll_factor = 10.0
-            window_position_default = (600, 51 + 300 * eye_id)
+            window_position_default = (600, 90 + 300 * eye_id)
         else:
             scroll_factor = 1.0
             window_position_default = (600, 300 * eye_id)

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -22,7 +22,7 @@ if platform.system() == 'Linux':
     window_position_default = (30, 30)
 elif platform.system() == 'Windows':
     scroll_factor = 10.0
-    window_position_default = (8, 51)
+    window_position_default = (8, 90)
 else:
     scroll_factor = 1.0
     window_position_default = (0, 0)

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -145,7 +145,7 @@ def world(timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url,
             window_position_default = (30, 30)
         elif platform.system() == 'Windows':
             scroll_factor = 10.0
-            window_position_default = (8, 51)
+            window_position_default = (8, 90)
         else:
             scroll_factor = 1.0
             window_position_default = (0, 0)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -103,7 +103,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         if system() == 'Linux':
             self.window_position_default = (0, 0)
         elif system() == 'Windows':
-            self.window_position_default = (8, 31)
+            self.window_position_default = (8, 90)
         else:
             self.window_position_default = (0, 0)
 

--- a/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/single_marker_calibration.py
@@ -80,7 +80,7 @@ class Single_Marker_Calibration(Calibration_Plugin):
         if system() == 'Linux':
             self.window_position_default = (0, 0)
         elif system() == 'Windows':
-            self.window_position_default = (8, 31)
+            self.window_position_default = (8, 90)
         else:
             self.window_position_default = (0, 0)
 

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -114,7 +114,7 @@ class Reference_Surface(object):
         if system() == 'Linux':
             self.window_position_default = (0, 0)
         elif system() == 'Windows':
-            self.window_position_default = (8, 31)
+            self.window_position_default = (8, 90)
         else:
             self.window_position_default = (0, 0)
 

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -26,7 +26,7 @@ if platform.system() == 'Linux':
     window_position_default = (30, 30)
 elif platform.system() == 'Windows':
     scroll_factor = 10.0
-    window_position_default = (8, 51)
+    window_position_default = (8, 90)
 else:
     scroll_factor = 1.0
     window_position_default = (0, 0)

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -22,11 +22,11 @@ import numpy as np
 
 #UI Platform tweaks
 if system() == 'Linux':
-    window_position_default = (0,0)
+    window_position_default = (0, 0)
 elif system() == 'Windows':
-    window_position_default = (8,31)
+    window_position_default = (8, 90)
 else:
-    window_position_default = (0,0)
+    window_position_default = (0, 0)
 
 class Visualizer(object):
     """docstring for Visualizer


### PR DESCRIPTION
## Overview
If a user sets the system taskbar to be located at the top of their screen, application window controls will be located underneath the taskbar. With old default `y` value for `window_position_default` this would make it impossible for a user to move or close the application window. 

## Proposed Fix
The proposed `y` value in this PR is set to `90`. The default Windows taskbar height is approx `50` pixels in height and the window controls are approx `40` pixels in height. This positions the Pupil application windows just below the taskbar if taskbar is positioned at the top of the screen. 

## Further Fixes

### Left Taskbar - Update window_position_default x = 50
We might want to consider updating `window_position_default` `x` value to `50` so that none of our application windows will be under the taskbar if the user has set the task bar to be located on the left hand side of the screen. What do you think @mkassner @papr 

## Side notes
Bigger question - why would Windows OS allow applications to create windows under the task bar **and** why would Winodws OS let users position (drag and release) a window's controls under the task bar in the first place - is there a use case/reasoning for this?