### PR TITLE
Reinit 200Hz eye cameras if stripe effect was detected

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -12,13 +12,13 @@ See COPYING and COPYING.LESSER for license details.
 import numpy as np
 
 
-class CheckFrameStripes(object):
+class Check_Frame_Stripes(object):
     def __init__(self, frame_size, num_check_frames=200):
         self.row_index = np.linspace(0, frame_size[0] - 1, 10, dtype=np.int)
         self.num_check_frames = num_check_frames
         self.num_local_optimum = []
 
-    def __call__(self, frame):
+    def check(self, frame):
         restart_flag = 0
         self.num_local_optimum.append(self.check_row(frame))
         if len(self.num_local_optimum) >= self.num_check_frames:
@@ -35,13 +35,9 @@ class CheckFrameStripes(object):
         for i in self.row_index:
             arr = np.array(frame[i, :], dtype=np.int)
 
-            local_max = \
-            np.where(np.r_[False, True, arr[2:] > arr[:-2] + 20] & np.r_[arr[:-2] > arr[2:] + 20, True, False] == True)[
-                0]
+            local_max = np.where(np.r_[False, True, arr[2:] > arr[:-2] + 20] & np.r_[arr[:-2] > arr[2:] + 20, True, False] == True)[0]
             num_local_max += len(local_max)
-            local_min = \
-            np.where(np.r_[False, True, arr[2:] + 20 < arr[:-2]] & np.r_[arr[:-2] + 20 < arr[2:], True, False] == True)[
-                0]
+            local_min = np.where(np.r_[False, True, arr[2:] + 20 < arr[:-2]] & np.r_[arr[:-2] + 20 < arr[2:], True, False] == True)[0]
             num_local_min += len(local_min)
 
         return num_local_max + num_local_min

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -13,31 +13,53 @@ import numpy as np
 
 
 class Check_Frame_Stripes(object):
-    def __init__(self, frame_size, num_check_frames=200):
-        self.row_index = np.linspace(0, frame_size[0] - 1, 10, dtype=np.int)
-        self.num_check_frames = num_check_frames
-        self.num_local_optimum = []
+    def __init__(self, check_freq_init=0.2, check_freq_upperbound=5, check_freq_lowerbound=0.0001, factor=1.5):
+        self.check_freq_init = check_freq_init
+        self.check_freq = self.check_freq_init
+        self.check_freq_upperbound = check_freq_upperbound
+        self.check_freq_lowerbound = check_freq_lowerbound
+        self.factor = factor
 
-    def check(self, frame):
-        restart_flag = 0
-        self.num_local_optimum.append(self.check_row(frame))
-        if len(self.num_local_optimum) >= self.num_check_frames:
-            stripes_ratio = np.mean(self.num_local_optimum) / len(self.row_index)
-            restart_flag = 1 if stripes_ratio > 0.35 else -1
-            self.num_local_optimum = []
+        self.last_check_timestamp = None
+        self.len_row_index = 10
+        self.len_col_index = 10
 
-        return restart_flag
+    def require_restart(self, frame):
+        if self.last_check_timestamp is None:
+            self.last_check_timestamp = frame.timestamp
 
-    def check_row(self, frame):
-        num_local_max = 0
-        num_local_min = 0
+        if frame.timestamp - self.last_check_timestamp > self.check_freq:
+            self.last_check_timestamp = frame.timestamp
+            if self.check_slice(frame.gray):
+                self.check_freq = min(self.check_freq_init, self.check_freq)
+                self.check_freq /= self.factor
+            else:
+                if self.check_freq < self.check_freq_upperbound:
+                    self.check_freq = min(self.check_freq*self.factor, self.check_freq_upperbound)
+            if self.check_freq < self.check_freq_lowerbound:
+                return True
 
-        for i in self.row_index:
-            arr = np.array(frame[i, :], dtype=np.int)
+        return False
 
-            local_max = np.where(np.r_[False, True, arr[2:] > arr[:-2] + 20] & np.r_[arr[:-2] > arr[2:] + 20, True, False] == True)[0]
-            num_local_max += len(local_max)
-            local_min = np.where(np.r_[False, True, arr[2:] + 20 < arr[:-2]] & np.r_[arr[:-2] + 20 < arr[2:], True, False] == True)[0]
-            num_local_min += len(local_min)
+    def check_slice(self, frame_gray):
+        num_local_max = np.zeros(2, dtype=np.int)
+        num_local_min = np.zeros(2, dtype=np.int)
 
-        return num_local_max + num_local_min
+        row_index = np.random.randint(0, frame_gray.shape[0], size=self.len_row_index)
+        col_index = np.random.randint(0, frame_gray.shape[1], size=self.len_col_index)
+        for n in range(2):
+            if n == 0:
+                arrs = np.array(frame_gray[row_index, :], dtype=np.int)
+            else:
+                arrs = np.array(frame_gray[:, col_index], dtype=np.int)
+                arrs = np.transpose(arrs)
+            for arr in arrs:
+                local_max = np.where(np.r_[False, True, arr[2:] > arr[:-2] + 30] & np.r_[arr[:-2] > arr[2:] + 30, True, False] == True)[0]
+                num_local_max[n] += len(local_max)
+                local_min = np.where(np.r_[False, True, arr[2:] + 30 < arr[:-2]] & np.r_[arr[:-2] + 30 < arr[2:], True, False] == True)[0]
+                num_local_min[n] += len(local_min)
+
+        num_local_optimum = num_local_max + num_local_min
+        stripes_ratio = num_local_optimum[0] / self.len_row_index, num_local_optimum[1] / self.len_col_index
+
+        return max(stripes_ratio) > 0.4

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -1,0 +1,47 @@
+'''
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+'''
+
+import numpy as np
+
+
+class CheckFrameStripes(object):
+    def __init__(self, frame_size, num_check_frames=200):
+        self.row_index = np.linspace(0, frame_size[0] - 1, 10, dtype=np.int)
+        self.num_check_frames = num_check_frames
+        self.num_local_optimum = []
+
+    def __call__(self, frame):
+        restart_flag = 0
+        self.num_local_optimum.append(self.check_row(frame))
+        if len(self.num_local_optimum) >= self.num_check_frames:
+            stripes_ratio = np.mean(self.num_local_optimum) / len(self.row_index)
+            restart_flag = 1 if stripes_ratio > 0.35 else -1
+            self.num_local_optimum = []
+
+        return restart_flag
+
+    def check_row(self, frame):
+        num_local_max = 0
+        num_local_min = 0
+
+        for i in self.row_index:
+            arr = np.array(frame[i, :], dtype=np.int)
+
+            local_max = \
+            np.where(np.r_[False, True, arr[2:] > arr[:-2] + 20] & np.r_[arr[:-2] > arr[2:] + 20, True, False] == True)[
+                0]
+            num_local_max += len(local_max)
+            local_min = \
+            np.where(np.r_[False, True, arr[2:] + 20 < arr[:-2]] & np.r_[arr[:-2] + 20 < arr[2:], True, False] == True)[
+                0]
+            num_local_min += len(local_min)
+
+        return num_local_max + num_local_min

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -174,7 +174,7 @@ class UVC_Source(Base_Source):
                 except KeyError: pass
 
         elif ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes()
 
             try: controls_dict['Auto Exposure Mode'].value = 1
             except KeyError: pass
@@ -245,13 +245,8 @@ class UVC_Source(Base_Source):
         try:
             frame = self.uvc_capture.get_frame(0.05)
 
-            if self.checkframestripes is not None:
-                restart_flag = self.checkframestripes.check(frame.gray)
-                if restart_flag == 1:
-                    self._restart_in = -1
-                    self._restart_logic()
-                elif restart_flag == -1:
-                    self.checkframestripes = None
+            if self.checkframestripes and self.checkframestripes.require_restart(frame):
+                self.frame_rate = self.frame_rate  # set the self.frame_rate in order to restart
 
         except uvc.StreamError:
             self._recent_frame = None
@@ -314,7 +309,7 @@ class UVC_Source(Base_Source):
         self._intrinsics = load_intrinsics(self.g_pool.user_dir, self.name, self.frame_size)
 
         if ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes()
         else:
             self.checkframestripes = None
 
@@ -338,7 +333,7 @@ class UVC_Source(Base_Source):
         self.frame_rate_backup = rate
 
         if ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes()
 
             controls_dict = dict([(c.display_name, c) for c in self.uvc_capture.controls])
 

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -15,7 +15,7 @@ import uvc
 from version_utils import VersionFormat
 from .base_backend import InitialisationError, Base_Source, Base_Manager
 from camera_models import load_intrinsics
-from .utils import CheckFrameStripes
+from .utils import Check_Frame_Stripes
 
 # check versions for our own depedencies as they are fast-changing
 assert VersionFormat(uvc.__version__) >= VersionFormat('0.13')
@@ -174,7 +174,7 @@ class UVC_Source(Base_Source):
                 except KeyError: pass
 
         elif ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
 
             try: controls_dict['Auto Exposure Mode'].value = 1
             except KeyError: pass
@@ -246,7 +246,7 @@ class UVC_Source(Base_Source):
             frame = self.uvc_capture.get_frame(0.05)
 
             if self.checkframestripes is not None:
-                restart_flag = self.checkframestripes(frame.gray)
+                restart_flag = self.checkframestripes.check(frame.gray)
                 if restart_flag == 1:
                     self._restart_in = -1
                     self._restart_logic()
@@ -314,7 +314,7 @@ class UVC_Source(Base_Source):
         self._intrinsics = load_intrinsics(self.g_pool.user_dir, self.name, self.frame_size)
 
         if ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
         else:
             self.checkframestripes = None
 
@@ -338,7 +338,7 @@ class UVC_Source(Base_Source):
         self.frame_rate_backup = rate
 
         if ("Pupil Cam2" in self.uvc_capture.name):
-            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
+            self.checkframestripes = Check_Frame_Stripes(self.uvc_capture.frame_size)
 
             controls_dict = dict([(c.display_name, c) for c in self.uvc_capture.controls])
 

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -15,6 +15,7 @@ import uvc
 from version_utils import VersionFormat
 from .base_backend import InitialisationError, Base_Source, Base_Manager
 from camera_models import load_intrinsics
+from .utils import CheckFrameStripes
 
 # check versions for our own depedencies as they are fast-changing
 assert VersionFormat(uvc.__version__) >= VersionFormat('0.13')
@@ -75,6 +76,7 @@ class UVC_Source(Base_Source):
                             logger.error("Camera failed to initialize.")
                         else:
                             break
+        self.checkframestripes = None
 
         # check if we were sucessfull
         if not self.uvc_capture:
@@ -172,6 +174,7 @@ class UVC_Source(Base_Source):
                 except KeyError: pass
 
         elif ("Pupil Cam2" in self.uvc_capture.name):
+            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
 
             try: controls_dict['Auto Exposure Mode'].value = 1
             except KeyError: pass
@@ -241,6 +244,15 @@ class UVC_Source(Base_Source):
     def recent_events(self, events):
         try:
             frame = self.uvc_capture.get_frame(0.05)
+
+            if self.checkframestripes is not None:
+                restart_flag = self.checkframestripes(frame.gray)
+                if restart_flag == 1:
+                    self._restart_in = -1
+                    self._restart_logic()
+                elif restart_flag == -1:
+                    self.checkframestripes = None
+
         except uvc.StreamError:
             self._recent_frame = None
             self._restart_logic()
@@ -301,6 +313,11 @@ class UVC_Source(Base_Source):
 
         self._intrinsics = load_intrinsics(self.g_pool.user_dir, self.name, self.frame_size)
 
+        if ("Pupil Cam2" in self.uvc_capture.name):
+            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
+        else:
+            self.checkframestripes = None
+
     @property
     def frame_rate(self):
         if self.uvc_capture:
@@ -321,12 +338,15 @@ class UVC_Source(Base_Source):
         self.frame_rate_backup = rate
 
         if ("Pupil Cam2" in self.uvc_capture.name):
+            self.checkframestripes = CheckFrameStripes(self.uvc_capture.frame_size)
 
             controls_dict = dict([(c.display_name, c) for c in self.uvc_capture.controls])
 
             special_settings = {200: 28, 180: 31}
             try: controls_dict['Absolute Exposure Time'].value = special_settings.get(new_rate, 32)
             except KeyError: pass
+        else:
+            self.checkframestripes = None
 
     @property
     def jpeg_support(self):


### PR DESCRIPTION
Check if there are stripes in the frames of the 200 HZ eye camera.
If yes, restart the camera.

Workaround for  #1116