### PR TITLE
Travis-ci linux bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: required
 services:
 - docker
 language: python
-branches:
-  only:
-  - master
 os:
 - linux
 
@@ -29,9 +26,10 @@ deploy:
   file_glob: true
   file: $TRAVIS_BUILD_DIR/deployment/*.zip
   skip_cleanup: true
-  name: "release from travis ci"
-  body: "release from travis ci for linux"
+  name: $TRAVIS_TAG $TRAVIS_OS_NAME - CI
+  body: $TRAVIS_TAG $TRAVIS_OS_NAME release built by CI
   draft: true
   on:
+    tags: true
+    branch: master
     repo: pupil-labs/pupil
-    branch: travis_ci_linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: required
+services:
+- docker
+language: python
+branches:
+  only:
+  - master
+os:
+- linux
+
+before_install:
+- docker --version
+- docker run -d --name pupil-ubuntu --mount type=bind,source=$TRAVIS_BUILD_DIR,target=/root/pupil
+  pupillabs/pupil-docker-ubuntu:latest tail -f /dev/null
+- docker ps
+
+script:
+- docker exec -t pupil-ubuntu bash -c "chmod +x pupil && 
+  cd pupil/deployment &&
+  ./bundle.sh"
+
+before_deploy:
+  - echo "Preparing to deploy to Github"
+
+deploy:
+  provider: releases
+  api_key:
+    secure: Qlzhn0zM3J+JPTW1aTUwb2uY2LCljna5pgZjJfF5fxoEMb0RHwFXazncqTlqgXwF+WJfefdgdsvXIuLJ6cuylikzMhebv5x5oq11j+B//16lV/juiQCA0B6ej7CyTWVUevWS1Av/ImfaUOcF18wdNHiKJX+T5tnwirYswnDwK4DFmTwduYQtCuyDCMvPZQtzVhHS807+fPJCnoWAPp+nir44WvOMW31KSSYVz/LOqndb3+rAZl7LVVW4riF1uSMB7La16NQ9qx/ZvMNOAk3IXelKrkzOWp5kWWF3PEj6xGf5r1SAf/caCcfBbMYOTNXvcUNBhBED+klRK0nNtEATrHDN5+K3MGMOSklKUz5MNi6EPrj8rNfUjs0H7nyCXzh8qjV6/fJ807lIywVsIsASAjD2mfYBztX/flDMNmUDC5mntZYUmMlbDgJdF3Zxs9LHJBb5j53LYQ4QCRhnShKp4/ZtAsFFgtQw9i/cj+lE/m+hF2iZOtqYUPMlV2/zHIPm8PZWPA5tE16B3pr/rq5JXtrfjReEE2cr8+TyjycUA1yvVgyjeqHD5jgf8l2Fbn4FNAsU8bylbKGLxHGJV3LPJtqg44SQSTaqDkpbs5XWM52M5tCgiBtpa0gj8rY8Qe+f/4P6+LVzUezGMn+4RgBavhL6IFKigc7X9E99hc7/U2o=
+  file_glob: true
+  file: $TRAVIS_BUILD_DIR/deployment/*.zip
+  skip_cleanup: true
+  name: "release from travis ci"
+  body: "release from travis ci for linux"
+  draft: true
+  on:
+    repo: pupil-labs/pupil
+    branch: travis_ci_linux

--- a/deployment/bundle.sh
+++ b/deployment/bundle.sh
@@ -1,17 +1,39 @@
-python ../pupil_src/shared_modules/pupil_detectors/build.py
-python ../pupil_src/shared_modules/cython_methods/build.py
-rm *.dmg
-rm *.deb
+#!/bin/sh
+
+# create release dir from latest tag
+current_tag=$(git describe --tags | awk -F"-" '{print $1"."$2}')
+release_dir=$(echo "pupil_${current_tag}_linux_x64")
+echo "release_dir:  ${release_dir}"
+mkdir ${release_dir}
+
+# build dependencies
+printf "\n##########\nBuilding pupil detector\n##########\n\n"
+python3 ../pupil_src/shared_modules/pupil_detectors/build.py
+
+printf "\n##########\nBuilding cython modules\n##########\n\n"
+python3 ../pupil_src/shared_modules/cython_methods/build.py
+
+printf "\n##########\nBuilding calibration methods\n##########\n\n"
+python3 ../pupil_src/shared_modules/calibration_routines/optimization_calibration/build.py
+
+# bundle Pupil Capture
+printf "\n##########\nBundling Pupil Capture\n##########\n\n"
 cd deploy_capture
 ./bundle.sh
-mv *.deb ../
-mv *.dmg ../
+mv *.deb ../$release_dir
+
+# bundle Pupil Service
+printf "\n##########\nBundling Pupil Service\n##########\n\n"
 cd ../deploy_service
 ./bundle.sh
-mv *.deb ../
-mv *.dmg ../
+mv *.deb ../$release_dir
+
+# bundle Pupil Player
+printf "\n##########\nBundling Pupil Player\n##########\n\n"
 cd ../deploy_player
 ./bundle.sh
-mv *.deb ../
-mv *.dmg ../
-cd ../
+mv *.deb ../$release_dir
+
+cd ..
+printf "\n##########\nzipping release\n##########\n\n"
+zip -r $release_dir.zip $release_dir


### PR DESCRIPTION
## Overview

Automated bundle builds for Ubuntu 16.04. The `.travis.yml` file instructs travis to create a bundle on each commit to the master branch. If the bundle builds successfully it will be added as a new **draft** release on `pupil-labs/pupil/releases`. 

Note that a successful build does not necessarily mean that it is a working bundle. Human testing of the bundle is still required on a host system with Pupil hardware.   

## Discussion

- Triggers for build - currently a new build is triggered on a commit to master. But, maybe we only want to make a build for each minor tag. @mkassner @papr what do you think? 

## Notes on Docker Images

The Pupil app bundles are built using our Ubuntu 16.04 Docker image. The Dockerfile for the 16.04 is the master branch of [this repo](https://github.com/pupil-labs/pupil-docker-ubuntu). The docker image is hosted on [docker hub](https://hub.docker.com/r/pupillabs/pupil-docker-ubuntu/). 

Reasons for using an image:
1. Build time - While we could theoretically build everything using Travis, we would encounter limitations. Travis limits build times to 50 minutes. Building all dependencies for Ubuntu takes around 30 to 40 minutes. Bundling could take another 10+ minutes, which would lead to a timeout. Therefore we use an image so that travis just pulls the docker image and uses this image to build, so the build time is just the time it takes to make a bundle and transfer the bundled files over the internet. 
1. Dependency and source code decoupling - The dependencies/image do not (and should not) be linked to the source code as we target different build systems, and because we don't want to be making needless commits to the source code just for build changes.

## Next Steps

1. Automate macOS Bundling - unfortunately we will not be able to build a docker image for macOS, so we will need to either try to use travis-ci macos build env or circle-ci and just build the environment and bundle under the time limit or find another route. 
1. Automate Windows Bundling :face_with_head_bandage: - Maybe something like [appveyor](https://www.appveyor.com/docs/build-environment/)   
1. [multi-os travis specification and build matrix](https://docs.travis-ci.com/user/multi-os/)