### PR TITLE
update glfw path for docker image's system libglfw

### DIFF
--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -91,7 +91,7 @@ elif platform.system() == 'Linux':
                    binaries,
                    a.zipfiles,
                    a.datas,
-                   [('libglfw.so', '/usr/local/lib/libglfw.so','BINARY')],
+                   [('libglfw.so', '/usr/lib/x86_64-linux-gnu/libglfw.so','BINARY')],
                    [('libGLEW.so', '/usr/lib/x86_64-linux-gnu/libGLEW.so','BINARY')],
                    [('OpenSans-Regular.ttf',ui.get_opensans_font_path(),'DATA')],
                    [('Roboto-Regular.ttf',ui.get_roboto_font_path(),'DATA')],

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -90,7 +90,7 @@ elif platform.system() == 'Linux':
                    binaries,
                    a.zipfiles,
                    a.datas,
-                   [('libglfw.so', '/usr/local/lib/libglfw.so','BINARY')],
+                   [('libglfw.so', '/usr/lib/x86_64-linux-gnu/libglfw.so','BINARY')],
                    [('libGLEW.so', '/usr/lib/x86_64-linux-gnu/libGLEW.so','BINARY')],
                    [('OpenSans-Regular.ttf',ui.get_opensans_font_path(),'DATA')],
                    [('Roboto-Regular.ttf',ui.get_roboto_font_path(),'DATA')],

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -89,7 +89,7 @@ elif platform.system() == 'Linux':
                    binaries,
                    a.zipfiles,
                    a.datas,
-                   [('libglfw.so', '/usr/local/lib/libglfw.so','BINARY')],
+                   [('libglfw.so', '/usr/lib/x86_64-linux-gnu/libglfw.so','BINARY')],
                    [('libGLEW.so', '/usr/lib/x86_64-linux-gnu/libGLEW.so','BINARY')],
                    [('OpenSans-Regular.ttf',ui.get_opensans_font_path(),'DATA')],
                    [('Roboto-Regular.ttf',ui.get_roboto_font_path(),'DATA')],


### PR DESCRIPTION
bundle in docker image will not run unless the path to `libglfw` is correctly specified. 