### PR TITLE
CauchyLoss function in Swirski sphere optimization

### DIFF
--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.cpp
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.cpp
@@ -404,7 +404,8 @@ double EyeModel::refineWithEdges(Sphere& sphere )
                 new EllipseDistanceResidualFunction<double>( pupilInliers, sphere.radius, mFocalLength),
                 pupilInliers.size()
                 ),
-                NULL, &x[0], &x[3 + 3 * i]);
+                new ceres::CauchyLoss(0.01),
+                &x[0], &x[3 + 3 * i]);
         }
     }
 


### PR DESCRIPTION
Added a loss function to the sphere optimization in order to increase robustness with outliers. The loss scale (0.01) was optimized to make standard deviations of sphere positions minimal. 