### PR TITLE
Coarse detection implemented in C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,18 @@ hmd_cal_data
 
 mprofile_*.dat
 .ipynb_checkpoints/
+.idea/misc.xml
+.idea/modules.xml
+.idea/other.xml
+.idea/pupil-coarse-detect.iml
+.idea/vcs.xml
+.idea/workspace.xml
+.idea/runConfigurations/pupil.xml
+venv/pip-selfcheck.json
+venv/pyvenv.cfg
+venv/bin/activate
+venv/bin/activate.csh
+venv/bin/activate.fish
+venv/bin/python
+venv/bin/python3
+venv/bin/python3.6

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -15,7 +15,7 @@ import os, sys, platform
 # sys.argv.append('debug')
 # sys.argv.append('service')
 
-app = 'capture'
+app = 'player'
 
 if getattr(sys, 'frozen', False):
     if 'pupil_service' in sys.executable:

--- a/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
@@ -61,7 +61,7 @@ cdef class Detector_2D:
         self.coarseDetectionPreviousWidth = -1
         self.coarseDetectionPreviousPosition =  (0,0)
         if not self.detectProperties:
-            self.detectProperties["coarse_detection"] = True
+            self.detectProperties["coarse_detection"] = False
             self.detectProperties["coarse_filter_min"] = 128
             self.detectProperties["coarse_filter_max"] = 280
             self.detectProperties["intensity_range"] = 23

--- a/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
@@ -70,7 +70,7 @@ cdef class Detector_3D:
         self.detectProperties3D = settings['3D_Settings'] if settings else {}
 
         if not self.detectProperties2D:
-            self.detectProperties2D["coarse_detection"] = True
+            self.detectProperties2D["coarse_detection"] = False
             self.detectProperties2D["coarse_filter_min"] = 128
             self.detectProperties2D["coarse_filter_max"] = 280
             self.detectProperties2D["intensity_range"] = 23


### PR DESCRIPTION
I disabled the coarse pupil detection in Python and implemented a similar approach in C++. Please review the performance and accuracy. The main parameters are minimum coverage of the pupil in a ROI frame, the min and max estimated pupil radii. A user specified ROI is taken into account.

Please test on Windows and Linux as well.