### PR TITLE
Fix boost linker flags on macOS

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/setup.py
@@ -74,12 +74,12 @@ else:
                 opencv_libraries = [lib + '3' for lib in opencv_libraries]
                 break
     include_dirs = [np.get_include(), '/usr/local/include/eigen3', '/usr/include/eigen3', shared_cpp_include_path ,singleeyefitter_include_path, opencv_include_dir]
+    python_version = sys.version_info
     if platform.system() == 'Linux':
-        python_version = sys.version_info
         # boost_python-py34
         boost_lib = 'boost_python-py'+str(python_version[0])+str(python_version[1])
     else:
-        boost_lib = 'boost_python3'
+        boost_lib = 'boost_python'+str(python_version[0])+str(python_version[1])
     libs = ['ceres', boost_lib]+opencv_libraries
     xtra_obj = []
     library_dirs = [opencv_library_dir]

--- a/pupil_src/shared_modules/pupil_detectors/setup.py
+++ b/pupil_src/shared_modules/pupil_detectors/setup.py
@@ -74,12 +74,12 @@ else:
                 opencv_libraries = [lib + '3' for lib in opencv_libraries]
                 break
     include_dirs = [np.get_include(), '/usr/local/include/eigen3','/usr/include/eigen3', shared_cpp_include_path, singleeyefitter_include_path, opencv_include_dir]
+    python_version = sys.version_info
     if platform.system() == 'Linux':
-        python_version = sys.version_info
         # boost_python-py34
         boost_lib = 'boost_python-py'+str(python_version[0])+str(python_version[1])
     else:
-        boost_lib = 'boost_python3'
+        boost_lib = 'boost_python'+str(python_version[0])+str(python_version[1])
     libs = ['ceres', boost_lib]+opencv_libraries
     xtra_obj2d = []
     library_dirs = [opencv_library_dir]


### PR DESCRIPTION
With the newest version of `bosst-python3` installed with `brew`, the linker must be changed to include the minor version along the major version (`-lboost_python36` instead of `-lboost_python3`). 

[I think this commit caused the change.](https://github.com/Homebrew/homebrew-core/commit/333a3293ed45c918272e248ef133838b2d7e6c61) At least that's when they changed the flags in the test.

This was only tested with macOS High Sierra and Python 3.6!