### PR TITLE
Force logging and csv encodings to utf-8

### DIFF
--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -140,7 +140,7 @@ def launcher():
         #set log level
         logger.setLevel(logging.NOTSET)
         #Stream to file
-        fh = logging.FileHandler(os.path.join(user_dir,'{}.log'.format(app)),mode='w')
+        fh = logging.FileHandler(os.path.join(user_dir,'{}.log'.format(app)),mode='w', encoding='utf-8')
         fh.setFormatter(logging.Formatter('%(asctime)s - %(processName)s - [%(levelname)s] %(name)s: %(message)s'))
         logger.addHandler(fh)
         #Stream to console.

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -254,7 +254,7 @@ class Recorder(System_Plugin_Base):
 
         self.meta_info_path = os.path.join(self.rec_path, "info.csv")
 
-        with open(self.meta_info_path, 'w', newline='') as csvfile:
+        with open(self.meta_info_path, 'w', newline='',  encoding='utf-8') as csvfile:
             csv_utils.write_key_value_file(csvfile, {
                 'Recording Name': self.session_name,
                 'Start Date': strftime("%d.%m.%Y", localtime(self.start_time)),


### PR DESCRIPTION
Fixes issue on Windows with unicode characters that are not present in the system locale
Requires : [Use utf-8 encoding for codec name](https://github.com/pupil-labs/PyAV/pull/11)