### PR TITLE
PEP 479 incompatibility

### DIFF
--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -217,7 +217,6 @@ class Audio_Playback(System_Plugin_Base):
             for frame in packet.decode():
                 if frame:
                     yield frame
-        raise StopIteration()
 
     def audio_idx_to_pts(self, idx):
         return idx * self.audio_pts_rate

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -78,7 +78,6 @@ class Audio_Viz_Transform():
             for frame in packet.decode():
                 if frame:
                     yield frame
-        raise StopIteration()
 
     def sec_to_frames(self, sec):
         return int(np.ceil(sec * self.audio_stream.rate / self.audio_stream.frame_size))

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -217,7 +217,6 @@ class File_Source(Playback_Source, Base_Source):
             for frame in packet.decode():
                 if frame:
                     yield frame
-        raise StopIteration()
 
     @ensure_initialisation()
     def pts_to_idx(self, pts):


### PR DESCRIPTION
[Python 3.7](https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior) enforces [PEP 479](https://www.python.org/dev/peps/pep-0479/). Raising a `StopIteration` within a generator will raise a RuntimeError instead.