### PR TITLE
Improved docs and naming of a couple files and exported values.

### DIFF
--- a/pupil_src/shared_modules/offline_surface_tracker.py
+++ b/pupil_src/shared_modules/offline_surface_tracker.py
@@ -471,9 +471,9 @@ class Offline_Surface_Tracker(Surface_Tracker, Analysis_Plugin_Base):
             surface_name = '_'+s.name.replace('/','')+'_'+s.uid
 
             #save surface_positions as csv
-            with open(os.path.join(metrics_dir,'srf_positons'+surface_name+'.csv'),'w',encoding='utf-8',newline='') as csvfile:
+            with open(os.path.join(metrics_dir,'surface_positons'+surface_name+'.csv'),'w',encoding='utf-8',newline='') as csvfile:
                 csv_writer =csv.writer(csvfile, delimiter=',')
-                csv_writer.writerow(('frame_idx','timestamp','m_to_screen','m_from_screen','detected_markers'))
+                csv_writer.writerow(('frame_idx','timestamp','m_to_surface','m_from_surface','detected_markers'))
                 for idx,ts,ref_srf_data in zip(range(len(self.g_pool.timestamps)),self.g_pool.timestamps,s.cache):
                     if in_mark <= idx < out_mark:
                         if ref_srf_data is not None and ref_srf_data is not False:

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -30,7 +30,7 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
     keys:
         timestamp - timestamp of the source image frame
         index - associated_frame: closest world video frame
-        id - 0 or 1 for left/right eye
+        id - 0 or 1 for right and left eye (from wearer's POV)
         confidence - is an assessment by the pupil detector on how sure we can be on this measurement. A value of `0` indicates no confidence. `1` indicates perfect confidence. In our experience usefull data carries a confidence value greater than ~0.6. A `confidence` of exactly `0` means that we don't know anything. So you should ignore the position data.        norm_pos_x - x position in the eye image frame in normalized coordinates
         norm_pos_x - x position in the eye image frame in normalized coordinates
         norm_pos_y - y position in the eye image frame in normalized coordinates

--- a/pupil_src/shared_modules/reference_surface.py
+++ b/pupil_src/shared_modules/reference_surface.py
@@ -12,6 +12,7 @@ See COPYING and COPYING.LESSER for license details.
 from platform import system
 from time import time
 from collections import deque
+import random
 
 import numpy as np
 import cv2
@@ -84,7 +85,7 @@ class Reference_Surface(object):
         self.camera_pose_3d = None
         self.use_distortion = True
 
-        self.uid = str(time())
+        self.uid = "{:04}".format(random.randint(0,9999))
         self.real_world_size = {'x': 1., 'y': 1.}
 
         self.heatmap = np.ones(0)


### PR DESCRIPTION
Several minor changes:

Offline Surface Tracker Data Format: Changed naming of file `srf_positons_<surface_name>_<surface_id>.csv` to `surface_positons_<surface_name>_<surface_id>.csv` to match the naming of the other files. The acronym `srf` is not used anywhere else.

Also changed the naming of the contained values `m_to_screen` and `m_from_screen` to `m_to_surface` and `m_from_surface`. The word screen is only accurate in a subset of all use cases.

Reduced the surface id from a long float number to a 4 digit integer, which should easily be sufficient while being a lot more manageable.

Minor correction/improvement to formulation to the `pupil_gaze_positions_info.txt` file.