### PR TITLE
Fix gaze field consistency and pupil-based fixation detection

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -411,8 +411,8 @@ class Binocular_Vector_Gaze_Mapper(Binocular_Gaze_Mapper_Base,Gaze_Mapping_Plugi
         normal_3d = self.rotation_matricies[p_id] @ np.array(p['circle_3d']['normal'])
 
         g = {'topic': 'gaze.3d.{}.'.format(p_id),
-             'eye_centers_3d': {p['id']: eye_center.tolist()},
-             'gaze_normals_3d': {p['id']: normal_3d.tolist()},
+             'eye_center_3d': eye_center.tolist(),
+             'gaze_normal_3d': normal_3d.tolist(),
              'gaze_point_3d': gaze_3d.tolist(),
              'confidence': p['confidence'],
              'timestamp': p['timestamp'],

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -158,7 +158,7 @@ def detect_fixations(capture, gaze_data, max_dispersion, min_duration,
         logger.warning('No data available to find fixations')
         return "Fixation detection complete", ()
 
-    use_pupil = 'gaze_normal_3d' in gaze_data[0]
+    use_pupil = 'gaze_normal_3d' in gaze_data[0] or 'gaze_normals_3d' in gaze_data[0]
     logger.info('Starting fixation detection using {} data...'.format('3d' if use_pupil else '2d'))
     fixation_result = Fixation_Result_Factory()
 


### PR DESCRIPTION
1. **Monocularly** mapped 3d gaze had different fields but the same topic depending on the mapper class
    - Binocular_Vector_Gaze_Mapper: Plural field names
    - Vector_Gaze_Mapper: Singular field names
- Fixed by changing monocular Binocular_Vector_Gaze_Mapper gaze to singular field names.

2. Fixes #1286 by checking gaze for `gaze_normal_3d` and `gaze_normals_3d`