### PR TITLE
Fix pupil_positions_by_id

### DIFF
--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -60,7 +60,7 @@ class Bisector(object):
 
     def by_ts(self, ts):
         '''
-        :param ts: matching or closest timestamp to extract.
+        :param ts: timestamp to extract.
         :return: datum that is matching or None if none is found
         '''
         found_i = np.searchsorted(self.data_ts, ts)

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -40,7 +40,7 @@ def exact_window(timestamps, index_range):
     return (timestamps[index_range[0]], timestamps[end_index])
 
 class Bisector(object):
-    """docstring for ClassName"""
+    """Stores data with associated timestamps, both sorted by the timestamp."""
     def __init__(self, data=(), data_ts=()):
         if len(data) != len(data_ts):
             raise ValueError(('Each element in `data` requires a corresponding'
@@ -57,6 +57,21 @@ class Bisector(object):
             self.sorted_idc = np.argsort(self.data_ts)
             self.data_ts = self.data_ts[self.sorted_idc]
             self.data = self.data[self.sorted_idc].tolist()
+
+    def by_ts(self, ts):
+        '''
+        :param ts: matching or closest timestamp to extract.
+        :return: datum that is matching or None if none is found
+        '''
+        found_i = np.searchsorted(self.data_ts, ts)
+        # searchsorted returns len(array) if the query is bigger than all elements
+        in_range = found_i < len(self.data_ts)
+        if not in_range:
+            return None
+        found = self.data_ts[found_i] == ts
+        if not found:
+            return None
+        return self.data[found_i]
 
     def by_ts_window(self, ts_window):
         start_idx, stop_idx = self._start_stop_idc_for_window(ts_window)

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -63,15 +63,17 @@ class Bisector(object):
         :param ts: timestamp to extract.
         :return: datum that is matching or None if none is found
         '''
-        found_i = np.searchsorted(self.data_ts, ts)
-        # searchsorted returns len(array) if the query is bigger than all elements
-        in_range = found_i < len(self.data_ts)
-        if not in_range:
-            return None
-        found = self.data_ts[found_i] == ts
+        found_index = np.searchsorted(self.data_ts, ts)
+        try:
+            found_data = self.data[found_index]
+            found_ts = self.data_ts[found_index]
+        except IndexError:
+            raise ValueError
+        found = found_ts == ts
         if not found:
-            return None
-        return self.data[found_i]
+            raise ValueError
+        else:
+            return found_data
 
     def by_ts_window(self, ts_window):
         start_idx, stop_idx = self._start_stop_idc_for_window(ts_window)

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -61,7 +61,8 @@ class Bisector(object):
     def by_ts(self, ts):
         '''
         :param ts: timestamp to extract.
-        :return: datum that is matching or None if none is found
+        :return: datum that is matching
+        :raises: ValueError if no matching datum is found
         '''
         found_index = np.searchsorted(self.data_ts, ts)
         try:


### PR DESCRIPTION
Previously, pupil data was loaded into a Bisector pupil_positions that was split to create pupil_positions_by_id. However, during the creation of this Bisector the data gets sorted s.t. the data from the Bisector did not fit with the content of the topics variable.

This fixes this by creating pupil_positions_by_id from the original pupil data instead of the Bisector.