### PR TITLE
Check for None returned from next_frame()

### DIFF
--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -279,6 +279,8 @@ class File_Source(Playback_Source, Base_Source):
         frame = None
         logged = False
         for frame in self.next_frame:
+            if not frame:
+                break
             index = self.pts_to_idx(frame.pts)
             if index == self.target_frame_idx:
                 break


### PR DESCRIPTION
None is a valid return value from next_frame() in case the stream has ended. 