### PR TITLE
Settable Pupil Remote port via argument parsing

### DIFF
--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -13,7 +13,7 @@ import argparse
 import sys
 
 
-def parse(*, running_from_bundle, app="capture", port=None, **kwargs):
+def parse(running_from_bundle, app="capture", port=None, **kwargs):
     parser = argparse.ArgumentParser()
 
     # Caveat: We need explicit defaults for app+port arguments in order to maintain

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -85,8 +85,3 @@ def _add_debug_profile_args(parser):
     parser.add_argument(
         "--profile", action="store_true", help="profile the application's CPU time"
     )
-
-
-if __name__ == "__main__":
-    args = parse(running_from_bundle=False)
-    print(args)

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -42,7 +42,7 @@ def parse(*, running_from_bundle, app="capture", port=None, **kwargs):
 def _setup_source_parsers(main_parser):
     subparsers = main_parser.add_subparsers(
         title="Applications",
-        description="Select which application you want to run",
+        description="Select which application you want to run, by default `capture`",
         dest="app",
     )
     parser_capture = subparsers.add_parser(

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -1,0 +1,87 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+import argparse
+import sys
+
+
+def parse():
+    parser = argparse.ArgumentParser()
+
+    # setup namespace to have app attribute, required for bundled
+    target_ns = argparse.Namespace()
+    target_ns.app = "capture"
+    target_ns.running_from_bundle = getattr(sys, "frozen", False)
+
+    if target_ns.running_from_bundle:
+        _setup_bundle_parsers(parser, namespace=target_ns)
+    else:
+        _setup_source_parsers(parser)
+
+    return parser.parse_args(namespace=target_ns)
+
+
+def _setup_source_parsers(main_parser):
+    subparsers = main_parser.add_subparsers(
+        title="Applications",
+        description="Select which application you want to run",
+        dest="app",
+    )
+    parser_capture = subparsers.add_parser(
+        "capture", help="Real-time processing and recording"
+    )
+    _add_remote_port_arg(parser_capture)
+    _add_debug_profile_args(parser_capture)
+
+    parser_service = subparsers.add_parser("service", help="VR/AR interface")
+    _add_remote_port_arg(parser_service)
+    _add_debug_profile_args(parser_service)
+
+    parser_player = subparsers.add_parser(
+        "player", help="Process, visualize, and export recordings"
+    )
+    _add_recording_arg(parser_player)
+    _add_debug_profile_args(parser_player)
+
+
+def _setup_bundle_parsers(main_parser, namespace):
+    if "pupil_player" in sys.executable:
+        _add_recording_arg(main_parser)
+        namespace.app = "player"
+    else:
+        _add_remote_port_arg(main_parser)
+        if "pupil_capture" in sys.executable:
+            namespace.app = "capture"
+        else:
+            namespace.app = "service"
+    _add_debug_profile_args(main_parser)
+
+
+def _add_remote_port_arg(parser):
+    parser.add_argument("-P", "--port", type=int, help="Pupil Remote port")
+
+
+def _add_recording_arg(parser):
+    parser.add_argument("recording", nargs="?", help="path to recording")
+
+
+def _add_debug_profile_args(parser):
+    parser.add_argument(
+        "--debug", help="display debug log messages", action="store_true"
+    )
+    parser.add_argument(
+        "--profile", action="store_true", help="profile the application's CPU time"
+    )
+
+
+if __name__ == "__main__":
+    args = parse()
+    print(args)

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -22,12 +22,11 @@ def parse(*, running_from_bundle, app="capture", port=None, **kwargs):
     target_ns = argparse.Namespace()
     target_ns.app = app
     target_ns.port = port
-    target_ns.running_from_bundle = running_from_bundle
 
     if kwargs:
         target_ns.__dict__.update(kwargs)
 
-    if target_ns.running_from_bundle:
+    if running_from_bundle:
         _setup_bundle_parsers(parser, namespace=target_ns)
     else:
         _setup_source_parsers(parser)

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -13,18 +13,20 @@ import argparse
 import sys
 
 
-def parse(running_from_bundle, app="capture", port=None, **kwargs):
+class DefaultNamespace(argparse.Namespace):
+    def __init__(self, **defaults):
+        # Caveat: We need explicit default values for app+port arguments in order to
+        # maintain the convenience to start Capture without having to pass any explicit
+        # arguments, e.g. `python3 main.py` instead of `python3 main.py capture`.
+        self.app = "capture"
+        self.port = None
+        for name, value in defaults.items():
+            setattr(self, name, value)
+
+
+def parse(running_from_bundle, **defaults):
     parser = argparse.ArgumentParser()
-
-    # Caveat: We need explicit defaults for app+port arguments in order to maintain
-    #         the convenience to start Capture without having to pass any explicit
-    #         arguments, e.g. `python3 main.py` instead of `python3 main.py capture`.
-    target_ns = argparse.Namespace()
-    target_ns.app = app
-    target_ns.port = port
-
-    if kwargs:
-        target_ns.__dict__.update(kwargs)
+    target_ns = DefaultNamespace(**defaults)
 
     if running_from_bundle:
         _setup_bundle_parsers(parser, namespace=target_ns)

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -14,14 +14,11 @@ import sys
 
 
 def parse(*, running_from_bundle, app="capture", port=None, **kwargs):
-    """Setup application specific argument parsing.
-
-    Caveat: We need explicit defaults for app+port arguments in order to maintain
-            the convenience to start Capture without having to pass any explicit
-            arguments, e.g. `python3 main.py` instead of `python3 main.py capture`.
-    """
     parser = argparse.ArgumentParser()
 
+    # Caveat: We need explicit defaults for app+port arguments in order to maintain
+    #         the convenience to start Capture without having to pass any explicit
+    #         arguments, e.g. `python3 main.py` instead of `python3 main.py capture`.
     target_ns = argparse.Namespace()
     target_ns.app = app
     target_ns.port = port

--- a/pupil_src/launchables/args.py
+++ b/pupil_src/launchables/args.py
@@ -47,7 +47,9 @@ def _setup_source_parsers(main_parser):
     )
     _add_remote_port_arg(parser_capture)
 
-    parser_service = subparsers.add_parser("service", help="VR/AR interface")
+    parser_service = subparsers.add_parser(
+        "service", help="Real-time processing with minimal UI"
+    )
     _add_remote_port_arg(parser_service)
 
     parser_player = subparsers.add_parser(

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -107,7 +107,6 @@ def service(
         from frame_publisher import Frame_Publisher
         from blink_detection import Blink_Detection
         from service_ui import Service_UI
-
         from background_helper import IPC_Logging_Task_Proxy
 
         IPC_Logging_Task_Proxy.push_url = ipc_push_url

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -18,7 +18,13 @@ class Global_Container(object):
 
 
 def service(
-    timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, version
+    timebase,
+    eyes_are_alive,
+    ipc_pub_url,
+    ipc_sub_url,
+    ipc_push_url,
+    user_dir,
+    version,
 ):
     """Maps pupil to gaze data, can run various plug-ins.
 
@@ -102,6 +108,7 @@ def service(
         from service_ui import Service_UI
 
         from background_helper import IPC_Logging_Task_Proxy
+
         IPC_Logging_Task_Proxy.push_url = ipc_push_url
 
         logger.info("Application Version: {}".format(version))
@@ -301,7 +308,13 @@ def service(
 
 
 def service_profiled(
-    timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, version
+    timebase,
+    eyes_are_alive,
+    ipc_pub_url,
+    ipc_sub_url,
+    ipc_push_url,
+    user_dir,
+    version,
 ):
     import cProfile, subprocess, os
     from .service import service

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -25,6 +25,7 @@ def service(
     ipc_push_url,
     user_dir,
     version,
+    preferred_remote_port,
 ):
     """Maps pupil to gaze data, can run various plug-ins.
 
@@ -127,6 +128,7 @@ def service(
         g_pool.ipc_push_url = ipc_push_url
         g_pool.eyes_are_alive = eyes_are_alive
         g_pool.timebase = timebase
+        g_pool.preferred_remote_port = preferred_remote_port
 
         def get_timestamp():
             return get_time_monotonic() - g_pool.timebase.value
@@ -315,6 +317,7 @@ def service_profiled(
     ipc_push_url,
     user_dir,
     version,
+    preferred_remote_port,
 ):
     import cProfile, subprocess, os
     from .service import service
@@ -329,6 +332,7 @@ def service_profiled(
             "ipc_push_url": ipc_push_url,
             "user_dir": user_dir,
             "version": version,
+            "preferred_remote_port": preferred_remote_port,
         },
         locals(),
         "service.pstats",

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -19,7 +19,7 @@ class Global_Container(object):
 
 def service(
     timebase,
-    eyes_are_alive,
+    eye_procs_alive,
     ipc_pub_url,
     ipc_sub_url,
     ipc_push_url,
@@ -125,7 +125,7 @@ def service(
         g_pool.ipc_pub_url = ipc_pub_url
         g_pool.ipc_sub_url = ipc_sub_url
         g_pool.ipc_push_url = ipc_push_url
-        g_pool.eyes_are_alive = eyes_are_alive
+        g_pool.eye_procs_alive = eye_procs_alive
         g_pool.timebase = timebase
         g_pool.preferred_remote_port = preferred_remote_port
 
@@ -274,8 +274,8 @@ def service(
 
         session_settings["loaded_plugins"] = g_pool.plugins.get_initializers()
         session_settings["version"] = str(g_pool.version)
-        session_settings["eye0_process_alive"] = eyes_are_alive[0].value
-        session_settings["eye1_process_alive"] = eyes_are_alive[1].value
+        session_settings["eye0_process_alive"] = eye_procs_alive[0].value
+        session_settings["eye1_process_alive"] = eye_procs_alive[1].value
         session_settings[
             "min_calibration_confidence"
         ] = g_pool.min_calibration_confidence
@@ -310,7 +310,7 @@ def service(
 
 def service_profiled(
     timebase,
-    eyes_are_alive,
+    eye_procs_alive,
     ipc_pub_url,
     ipc_sub_url,
     ipc_push_url,
@@ -322,10 +322,10 @@ def service_profiled(
     from .service import service
 
     cProfile.runctx(
-        "service(timebase,eyes_are_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version)",
+        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version)",
         {
             "timebase": timebase,
-            "eyes_are_alive": eyes_are_alive,
+            "eye_procs_alive": eye_procs_alive,
             "ipc_pub_url": ipc_pub_url,
             "ipc_sub_url": ipc_sub_url,
             "ipc_push_url": ipc_push_url,

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -18,7 +18,7 @@ class Global_Container(object):
 
 def world(
     timebase,
-    eyes_are_alive,
+    eye_procs_alive,
     ipc_pub_url,
     ipc_sub_url,
     ipc_push_url,
@@ -207,7 +207,7 @@ def world(
         g_pool.ipc_pub_url = ipc_pub_url
         g_pool.ipc_sub_url = ipc_sub_url
         g_pool.ipc_push_url = ipc_push_url
-        g_pool.eyes_are_alive = eyes_are_alive
+        g_pool.eye_procs_alive = eye_procs_alive
         g_pool.preferred_remote_port = preferred_remote_port
 
         def get_timestamp():
@@ -506,7 +506,7 @@ def world(
                 "eye0_process",
                 label="Detect eye 0",
                 setter=lambda alive: start_stop_eye(0, alive),
-                getter=lambda: eyes_are_alive[0].value,
+                getter=lambda: eye_procs_alive[0].value,
             )
         )
         general_settings.append(
@@ -514,7 +514,7 @@ def world(
                 "eye1_process",
                 label="Detect eye 1",
                 setter=lambda alive: start_stop_eye(1, alive),
-                getter=lambda: eyes_are_alive[1].value,
+                getter=lambda: eye_procs_alive[1].value,
             )
         )
 
@@ -675,8 +675,8 @@ def world(
         session_settings["ui_config"] = g_pool.gui.configuration
         session_settings["window_position"] = glfw.glfwGetWindowPos(main_window)
         session_settings["version"] = str(g_pool.version)
-        session_settings["eye0_process_alive"] = eyes_are_alive[0].value
-        session_settings["eye1_process_alive"] = eyes_are_alive[1].value
+        session_settings["eye0_process_alive"] = eye_procs_alive[0].value
+        session_settings["eye1_process_alive"] = eye_procs_alive[1].value
         session_settings[
             "min_calibration_confidence"
         ] = g_pool.min_calibration_confidence
@@ -716,7 +716,7 @@ def world(
 
 def world_profiled(
     timebase,
-    eyes_are_alive,
+    eye_procs_alive,
     ipc_pub_url,
     ipc_sub_url,
     ipc_push_url,
@@ -730,10 +730,10 @@ def world_profiled(
     from .world import world
 
     cProfile.runctx(
-        "world(timebase, eyes_are_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version)",
+        "world(timebase, eye_procs_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version)",
         {
             "timebase": timebase,
-            "eyes_are_alive": eyes_are_alive,
+            "eye_procs_alive": eye_procs_alive,
             "ipc_pub_url": ipc_pub_url,
             "ipc_sub_url": ipc_sub_url,
             "ipc_push_url": ipc_push_url,

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -24,6 +24,7 @@ def world(
     ipc_push_url,
     user_dir,
     version,
+    preferred_remote_port,
 ):
     """Reads world video and runs plugins.
 
@@ -721,6 +722,7 @@ def world_profiled(
     ipc_push_url,
     user_dir,
     version,
+    preferred_remote_port,
 ):
     import cProfile
     import subprocess
@@ -737,6 +739,7 @@ def world_profiled(
             "ipc_push_url": ipc_push_url,
             "user_dir": user_dir,
             "version": version,
+            "preferred_remote_port": preferred_remote_port,
         },
         locals(),
         "world.pstats",

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -17,7 +17,13 @@ class Global_Container(object):
 
 
 def world(
-    timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, version
+    timebase,
+    eyes_are_alive,
+    ipc_pub_url,
+    ipc_sub_url,
+    ipc_push_url,
+    user_dir,
+    version,
 ):
     """Reads world video and runs plugins.
 
@@ -201,6 +207,7 @@ def world(
         g_pool.ipc_sub_url = ipc_sub_url
         g_pool.ipc_push_url = ipc_push_url
         g_pool.eyes_are_alive = eyes_are_alive
+        g_pool.preferred_remote_port = preferred_remote_port
 
         def get_timestamp():
             return get_time_monotonic() - g_pool.timebase.value
@@ -707,7 +714,13 @@ def world(
 
 
 def world_profiled(
-    timebase, eyes_are_alive, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, version
+    timebase,
+    eyes_are_alive,
+    ipc_pub_url,
+    ipc_sub_url,
+    ipc_push_url,
+    user_dir,
+    version,
 ):
     import cProfile
     import subprocess

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -173,7 +173,7 @@ def launcher():
 
     ## IPC
     timebase = Value(c_double, 0)
-    eyes_are_alive = Value(c_bool, 0), Value(c_bool, 0)
+    eye_procs_alive = Value(c_bool, 0), Value(c_bool, 0)
 
     zmq_ctx = zmq.Context()
 
@@ -267,7 +267,7 @@ def launcher():
                         name="eye{}".format(eye_id),
                         args=(
                             timebase,
-                            eyes_are_alive[eye_id],
+                            eye_procs_alive[eye_id],
                             ipc_pub_url,
                             ipc_sub_url,
                             ipc_push_url,
@@ -296,7 +296,7 @@ def launcher():
                         name="world",
                         args=(
                             timebase,
-                            eyes_are_alive,
+                            eye_procs_alive,
                             ipc_pub_url,
                             ipc_sub_url,
                             ipc_push_url,
@@ -315,7 +315,7 @@ def launcher():
                         name="service",
                         args=(
                             timebase,
-                            eyes_are_alive,
+                            eye_procs_alive,
                             ipc_pub_url,
                             ipc_sub_url,
                             ipc_push_url,

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -12,12 +12,13 @@ See COPYING and COPYING.LESSER for license details.
 import os, sys, platform
 import launchables.args
 
+running_from_bundle = getattr(sys, "frozen", False)
 default_args = {"app": "capture", "debug": False, "profile": False}
 parsed_args = launchables.args.parse(
-    running_from_bundle=getattr(sys, "frozen", False), **default_args
+    running_from_bundle=running_from_bundle, **default_args
 )
 
-if parsed_args.running_from_bundle:
+if running_from_bundle:
     # Specifiy user dir.
     folder_name = "pupil_{}_settings".format(parsed_args.app)
     user_dir = os.path.expanduser(os.path.join("~", folder_name))

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -213,7 +213,7 @@ def launcher():
     pull_pub.setDaemon(True)
     pull_pub.start()
 
-    log_thread = Thread(target=log_loop, args=(ipc_sub_url, "debug" in sys.argv))
+    log_thread = Thread(target=log_loop, args=(ipc_sub_url, parsed_args.debug))
     log_thread.setDaemon(True)
     log_thread.start()
 

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -303,6 +303,7 @@ def launcher():
                             ipc_push_url,
                             user_dir,
                             app_version,
+                            parsed_args.port,
                         ),
                     ).start()
                 elif "notify.clear_settings_process.should_start" in topic:
@@ -321,6 +322,7 @@ def launcher():
                             ipc_push_url,
                             user_dir,
                             app_version,
+                            parsed_args.port,
                         ),
                     ).start()
                 elif "notify.player_drop_process.should_start" in topic:

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -14,9 +14,7 @@ import launchables.args
 
 running_from_bundle = getattr(sys, "frozen", False)
 default_args = {"app": "capture", "debug": False, "profile": False}
-parsed_args = launchables.args.parse(
-    running_from_bundle=running_from_bundle, **default_args
-)
+parsed_args = launchables.args.parse(running_from_bundle, **default_args)
 
 if running_from_bundle:
     # Specifiy user dir.

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -10,14 +10,12 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import os, sys, platform
-
-# sys.argv.append('--profile')
-# sys.argv.append('--debug')
-# sys.argv.append('service')
-
 import launchables.args
 
-parsed_args = launchables.args.parse()
+default_args = {"app": "capture", "debug": False, "profile": False}
+parsed_args = launchables.args.parse(
+    running_from_bundle=getattr(sys, "frozen", False), **default_args
+)
 
 if parsed_args.running_from_bundle:
     # Specifiy user dir.

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -75,7 +75,7 @@ class Pupil_Remote(Plugin):
     icon_chr = chr(0xE307)
     icon_font = "pupil_icons"
 
-    def __init__(self, g_pool, port="50020", host="*", use_primary_interface=True):
+    def __init__(self, g_pool, port=50020, host="*", use_primary_interface=True):
         super().__init__(g_pool)
         self.order = 0.01  # excecute first
         self.context = g_pool.zmq_ctx
@@ -83,7 +83,7 @@ class Pupil_Remote(Plugin):
 
         self.use_primary_interface = use_primary_interface
         assert type(host) == str
-        assert type(port) == str
+        assert type(port) == int
         self.host = host
         self.port = g_pool.preferred_remote_port or port
 
@@ -98,7 +98,7 @@ class Pupil_Remote(Plugin):
         if response == "Bind OK":
             host, port = msg.split(":")
             self.host = host
-            self.port = port
+            self.port = int(port)
             return
 
         # fail logic
@@ -119,7 +119,7 @@ class Pupil_Remote(Plugin):
             if response == "Bind OK":
                 host, port = msg.split(":")
                 self.host = host
-                self.port = port
+                self.port = int(port)
             else:
                 logger.error(msg)
                 raise Exception("Could not bind to port")
@@ -148,7 +148,7 @@ class Pupil_Remote(Plugin):
         if self.use_primary_interface:
 
             def set_port(new_port):
-                new_address = "tcp://*:" + new_port
+                new_address = "tcp://*:{}".format(new_port)
                 self.start_server(new_address)
                 self.update_menu()
 

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -85,9 +85,9 @@ class Pupil_Remote(Plugin):
         assert type(host) == str
         assert type(port) == str
         self.host = host
-        self.port = port
+        self.port = g_pool.preferred_remote_port or port
 
-        self.start_server("tcp://{}:{}".format(host, port))
+        self.start_server("tcp://{}:{}".format(host, self.port))
         self.menu = None
 
     def start_server(self, new_address):

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -137,7 +137,7 @@ class Service_UI(System_Plugin_Base):
                 "eye0_process",
                 label="Detect eye 0",
                 setter=lambda alive: self.start_stop_eye(0, alive),
-                getter=lambda: g_pool.eyes_are_alive[0].value,
+                getter=lambda: g_pool.eye_procs_alive[0].value,
             )
         )
         g_pool.menubar.append(
@@ -145,7 +145,7 @@ class Service_UI(System_Plugin_Base):
                 "eye1_process",
                 label="Detect eye 1",
                 setter=lambda alive: self.start_stop_eye(1, alive),
-                getter=lambda: g_pool.eyes_are_alive[1].value,
+                getter=lambda: g_pool.eye_procs_alive[1].value,
             )
         )
 

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -111,8 +111,8 @@ class Service_UI(System_Plugin_Base):
 
         g_pool.menubar.append(ui.Button("Reset window size", set_window_size))
 
-        pupil_remote_addr = "{}:50020".format(
-            socket.gethostbyname(socket.gethostname())
+        pupil_remote_addr = "{}:{}".format(
+            socket.gethostbyname(socket.gethostname()), g_pool.preferred_remote_port
         )
         g_pool.menubar.append(
             ui.Text_Input(


### PR DESCRIPTION
This PR implements #1315 by fixing #1377 

Todos:
- [ ] Test on Linux/Mac when running from bundle
- [ ] Test on Windows when running from source and from bundle

---

#### Help Texts

```bash
> python main.py -h
usage: main.py [-h] [--debug] [--profile] {capture,service,player} ...

optional arguments:
  -h, --help            show this help message and exit
  --debug               display debug log messages
  --profile             profile the application's CPU time

Applications:
  Select which application you want to run, by default `capture`

  {capture,service,player}
    capture             Real-time processing and recording
    service             VR/AR interface
    player              Process, visualize, and export recordings
```

```bash
> python main.py capture -h
usage: main.py capture [-h] [-P PORT]

optional arguments:
  -h, --help            show this help message and exit
  -P PORT, --port PORT  Pupil Remote port
```

```bash
> python main.py service -h
usage: main.py service [-h] [-P PORT]

optional arguments:
  -h, --help            show this help message and exit
  -P PORT, --port PORT  Pupil Remote port
```

```bash
>  python main.py player -h
usage: main.py player [-h] [recording]

positional arguments:
  recording   path to recording

optional arguments:
  -h, --help  show this help message and exit
```