### PR TITLE
fix typo in uvc_backend for logger

### DIFF
--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -423,7 +423,7 @@ class UVC_Source(Base_Source):
         size = self.uvc_capture.frame_sizes[best_size_idx]
         if tuple(size) != tuple(new_size):
             logger.warning(
-                "%s resolution capture mode not available. Selected {}.".format(
+                "{} resolution capture mode not available. Selected {}.".format(
                     new_size, size
                 )
             )


### PR DESCRIPTION
`%s` doesn't work, replaced with `{}`.