### PR TITLE
Reference Location Management

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -109,10 +109,17 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         from video_export.plugins.imotions_exporter import iMotions_Exporter
         from video_export.plugins.eye_video_exporter import Eye_Video_Exporter
         from video_export.plugins.world_video_exporter import World_Video_Exporter
+        from gaze_producer.gaze_from_offline_calibration import (
+            GazeFromOfflineCalibration,
+        )
 
         from background_helper import IPC_Logging_Task_Proxy
 
         IPC_Logging_Task_Proxy.push_url = ipc_push_url
+
+        from tasklib.background.patches import IPCLoggingPatch
+
+        IPCLoggingPatch.ipc_push_url = ipc_push_url
 
         assert VersionFormat(pyglui_version) >= VersionFormat(
             "1.23"
@@ -149,6 +156,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
             iMotions_Exporter,
             Eye_Video_Exporter,
             Offline_Calibration,
+            GazeFromOfflineCalibration,
         ] + runtime_plugins
 
         plugins = system_plugins + user_plugins

--- a/pupil_src/shared_modules/gaze_producer/controller/reference_location_controllers.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/reference_location_controllers.py
@@ -1,0 +1,119 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+import logging
+
+import numpy as np
+import glfw
+
+import tasklib
+from gaze_producer.worker.detect_circle_markers import CircleMarkerDetectionTask
+from observable import Observable
+
+logger = logging.getLogger(__name__)
+
+
+class ReferenceDetectionController(Observable):
+    def __init__(self, task_manager, reference_location_storage):
+        self._task_manager = task_manager
+        self._reference_location_storage = reference_location_storage
+        self.task = None
+
+    def start_detection(self):
+        self.task = CircleMarkerDetectionTask()
+        self.task.add_observer("on_exception", tasklib.raise_exception)
+        self.task.add_observer("on_yield", self._on_detection_yields)
+        self._task_manager.add_task(self.task)
+        return self.task
+
+    def _on_detection_yields(self, detection):
+        self._reference_location_storage.add(
+            detection.screen_pos, detection.frame_index, detection.timestamp
+        )
+
+    def cancel_detection(self):
+        if not self.task:
+            raise ValueError("No detection task running!")
+        self.task.cancel_gracefully()
+
+    @property
+    def is_running_detection(self):
+        return self.task is not None and self.task.running
+
+
+class ReferenceEditController:
+    def __init__(
+        self,
+        reference_location_storage,
+        plugin,
+        all_timestamps,
+        get_current_frame_index,
+        seek_to_frame,
+    ):
+        self.edit_mode_active = True
+
+        self._reference_location_storage = reference_location_storage
+
+        self._all_timestamps = all_timestamps
+        self._get_current_frame_index = get_current_frame_index
+        self._seek_to_frame = seek_to_frame
+
+        plugin.add_observer("on_click", self.on_click)
+
+    def jump_to_next_ref(self):
+        try:
+            current_index = self._get_current_frame_index()
+            next_ref = self._reference_location_storage.get_next(current_index)
+        except ValueError:
+            logger.warning("Could not jump, no next reference location found!")
+        else:
+            self._seek_to_frame(next_ref.frame_index)
+
+    def jump_to_prev_ref(self):
+        try:
+            current_index = self._get_current_frame_index()
+            prev_ref = self._reference_location_storage.get_previous(current_index)
+        except ValueError:
+            logger.warning("Could not jump, no previous reference location found!")
+        else:
+            self._seek_to_frame(prev_ref.frame_index)
+
+    def on_click(self, pos, button, action):
+        if not self.edit_mode_active:
+            return
+        if action == glfw.GLFW_PRESS:
+            current_reference = self._get_current_reference()
+            if self._clicked_on_reference(current_reference, pos):
+                self._reference_location_storage.delete(current_reference)
+            else:
+                self._add_reference(pos)
+
+    def _get_current_reference(self):
+        current_index = self._get_current_frame_index()
+        return self._reference_location_storage.get_or_none(current_index)
+
+    @staticmethod
+    def _clicked_on_reference(reference_location, click_pos):
+        if reference_location is None:
+            return False
+        pos_x = click_pos[0]
+        pos_y = click_pos[1]
+        click_distance = np.sqrt(
+            (pos_x - reference_location.screen_x) ** 2
+            + (pos_y - reference_location.screen_y) ** 2
+        )
+        return click_distance < 15
+
+    def _add_reference(self, pos):
+        screen_pos = tuple(pos)
+        frame_index = self._get_current_frame_index()
+        timestamp = self._all_timestamps[frame_index]
+        self._reference_location_storage.add(screen_pos, frame_index, timestamp)

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -1,0 +1,92 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+from gaze_producer.controller.reference_location_controllers import (
+    ReferenceDetectionController,
+    ReferenceEditController,
+)
+from gaze_producer.model.reference_location_storage import ReferenceLocationStorage
+from gaze_producer.ui.reference_location_renderer import ReferenceLocationRenderer
+from gaze_producer.ui.reference_location_menu import ReferenceLocationMenu
+from gaze_producer.ui.timeline import Timeline
+from observable import Observable
+from plugin import Analysis_Plugin_Base
+from plugin_timeline import PluginTimeline
+from tasklib.manager import PluginTaskManager
+
+
+class GazeFromOfflineCalibration(Analysis_Plugin_Base, Observable):
+    icon_chr = chr(0xEC14)
+    icon_font = "pupil_icons"
+
+    def __init__(self, g_pool):
+        super().__init__(g_pool)
+
+        self.inject_plugin_dependencies()
+
+        self._task_manager = PluginTaskManager(plugin=self)
+
+        self._reference_location_storage = ReferenceLocationStorage(
+            self.g_pool.rec_dir, plugin=self
+        )
+
+        self._reference_detection_controller = ReferenceDetectionController(
+            self._task_manager, self._reference_location_storage
+        )
+        self._reference_edit_controller = ReferenceEditController(
+            self._reference_location_storage,
+            plugin=self,
+            all_timestamps=self.g_pool.timestamps,
+            get_current_frame_index=self.g_pool.capture.get_frame_index,
+            seek_to_frame=self._seek_to_frame,
+        )
+
+        self._reference_location_renderer = ReferenceLocationRenderer(
+            self._reference_location_storage,
+            plugin=self,
+            frame_size=self.g_pool.capture.frame_size,
+            get_current_frame_index=self.g_pool.capture.get_frame_index,
+        )
+        self._reference_location_menu = ReferenceLocationMenu(
+            self._reference_detection_controller,
+            self._reference_location_storage,
+            self._reference_edit_controller,
+        )
+
+        plugin_timeline = PluginTimeline(
+            title="Offline Calibration",
+            plugin=self,
+            user_timelines=self.g_pool.user_timelines,
+            time_start=self.g_pool.timestamps[0],
+            time_end=self.g_pool.timestamps[-1],
+        )
+        self._timeline = Timeline(
+            plugin_timeline,
+            self._reference_detection_controller,
+            self._reference_location_storage,
+            plugin=self,
+        )
+
+    def inject_plugin_dependencies(self):
+        from gaze_producer.worker.detect_circle_markers import CircleMarkerDetectionTask
+
+        CircleMarkerDetectionTask.zmq_ctx = self.g_pool.zmq_ctx
+        CircleMarkerDetectionTask.capture_source_path = self.g_pool.capture.source_path
+        CircleMarkerDetectionTask.notify_all = self.notify_all
+
+    def init_ui(self):
+        super().init_ui()
+        self.add_menu()
+        self.menu.label = "Gaze From Offline Calibration"
+        self._reference_location_menu.render()
+        self.menu.append(self._reference_location_menu.menu)
+
+    def _seek_to_frame(self, frame_index):
+        self.notify_all({"subject": "seek_control.should_seek", "index": frame_index})

--- a/pupil_src/shared_modules/gaze_producer/model/reference_location.py
+++ b/pupil_src/shared_modules/gaze_producer/model/reference_location.py
@@ -1,0 +1,27 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+
+class ReferenceLocation:
+    version = 1
+
+    def __init__(self, screen_pos, frame_index, timestamp):
+        self.screen_pos = screen_pos  # 2D tuple
+        self.frame_index = frame_index
+        self.timestamp = timestamp
+
+    @property
+    def screen_x(self):
+        return self.screen_pos[0]
+
+    @property
+    def screen_y(self):
+        return self.screen_pos[1]

--- a/pupil_src/shared_modules/gaze_producer/model/reference_location_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/reference_location_storage.py
@@ -1,0 +1,84 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+import logging
+import os
+
+import file_methods as fm
+from gaze_producer.model.reference_location import ReferenceLocation
+from observable import Observable
+
+logger = logging.getLogger(__name__)
+
+
+class ReferenceLocationStorage(Observable):
+    def __init__(self, rec_dir, plugin):
+        self._rec_dir = rec_dir
+        self._reference_locations = {}
+        self.load_from_disk()
+        plugin.add_observer("cleanup", self._on_cleanup)
+
+    def add(self, screen_pos, frame_index, timestamp):
+        reference_location = ReferenceLocation(screen_pos, frame_index, timestamp)
+        self._reference_locations[reference_location.frame_index] = reference_location
+
+    def get_or_none(self, frame_index):
+        return self._reference_locations.get(frame_index, None)
+
+    def get_next(self, frame_index):
+        found_index = min(
+            idx for idx in self._reference_locations.keys() if idx > frame_index
+        )
+        return self._reference_locations[found_index]
+
+    def get_previous(self, frame_index):
+        found_index = max(
+            idx for idx in self._reference_locations.keys() if idx < frame_index
+        )
+        return self._reference_locations[found_index]
+
+    def delete(self, reference_location):
+        del self._reference_locations[reference_location.frame_index]
+
+    def delete_all(self):
+        self._reference_locations = {}
+
+    def __iter__(self):
+        return iter(self._reference_locations.values())
+
+    def _on_cleanup(self):
+        self.save_to_disk()
+
+    def save_to_disk(self):
+        data = [
+            (ref.timestamp, ref.frame_index, ref.screen_pos)
+            for ref in self._reference_locations.values()
+        ]
+        dict_representation = {"version": ReferenceLocation.version, "data": data}
+        fm.save_object(dict_representation, self._reference_locations_file)
+
+    def load_from_disk(self):
+        try:
+            dict_representation = fm.load_object(self._reference_locations_file)
+        except FileNotFoundError:
+            return
+        if dict_representation.get("version", None) != ReferenceLocation.version:
+            logger.warning(
+                "Found reference locations in old file format. Will not load these!"
+            )
+            return
+        for datum in dict_representation["data"]:
+            timestamp, frame_index, screen_pos = datum
+            self.add(screen_pos, frame_index, timestamp)
+
+    @property
+    def _reference_locations_file(self):
+        return os.path.join(self._rec_dir, "offline_data", "reference_locations")

--- a/pupil_src/shared_modules/gaze_producer/ui/reference_location_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/reference_location_menu.py
@@ -1,0 +1,94 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+from pyglui import ui
+
+
+class ReferenceLocationMenu:
+    def __init__(self, reference_detection_controller, reference_location_storage,
+                 reference_edit_controller):
+        self._reference_detection_controller = reference_detection_controller
+        self._reference_location_storage = reference_location_storage
+        self._reference_edit_controller = reference_edit_controller
+        self.menu = ui.Growing_Menu("Reference Locations")
+
+    def render(self):
+        self.menu.elements.clear()
+        self._render_auto_detection_section()
+        self.menu.append(ui.Separator())
+        self._render_manual_edit_section()
+        self.menu.append(ui.Separator())
+        self._render_clear_all_section()
+
+    def _render_auto_detection_section(self):
+        self.menu.append(self._make_button_toggle_reference_detection())
+
+    def _make_button_toggle_reference_detection(self):
+        if self._reference_detection_controller.is_running_detection:
+            return ui.Button(
+                "Cancel Detection", self._on_click_cancel_reference_detection
+            )
+        else:
+            return ui.Button(
+                "Detect Circle Markers in Recording",
+                self._on_click_start_reference_detection,
+            )
+
+    def _render_manual_edit_section(self):
+        self.menu.append(
+            ui.Switch(
+                "edit_mode_active",
+                self._reference_edit_controller,
+                label="Manual Edit Mode",
+            )
+        )
+        self.menu.append(
+            ui.Button(
+                outer_label="Jump to",
+                label="Next Reference Location",
+                function=self._on_jump_to_next_ref,
+            )
+        )
+        self.menu.append(
+            ui.Button(
+                outer_label="Jump to",
+                label="Previous Reference Location",
+                function=self._on_jump_to_prev_ref,
+            )
+        )
+
+    def _render_clear_all_section(self):
+        self.menu.append(
+            ui.Button("Clear All Reference Locations", self._on_clear_all_refs)
+        )
+
+    def _on_click_start_reference_detection(self):
+        task = self._reference_detection_controller.start_detection()
+        task.add_observer("on_started", self._on_started_reference_detection)
+        task.add_observer("on_ended", self._on_ended_reference_detection)
+
+    def _on_click_cancel_reference_detection(self):
+        self._reference_detection_controller.cancel_detection()
+
+    def _on_started_reference_detection(self):
+        self.render()
+
+    def _on_ended_reference_detection(self):
+        self.render()
+
+    def _on_jump_to_next_ref(self):
+        self._reference_edit_controller.jump_to_next_ref()
+
+    def _on_jump_to_prev_ref(self):
+        self._reference_edit_controller.jump_to_prev_ref()
+
+    def _on_clear_all_refs(self):
+        self._reference_location_storage.delete_all()

--- a/pupil_src/shared_modules/gaze_producer/ui/reference_location_renderer.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/reference_location_renderer.py
@@ -1,0 +1,87 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+import pyglui.cygl.utils as cygl_utils
+
+import gl_utils
+
+
+class ReferenceLocationRenderer:
+    """
+    Renders reference locations in the world video.
+    """
+
+    # we not only draw reference locations in the current frame, but also from close
+    # frames in a certain range
+    close_ref_range = 4
+
+    def __init__(
+        self,
+        reference_location_storage,
+        plugin,
+        frame_size,
+        get_current_frame_index,
+    ):
+        self._reference_location_storage = reference_location_storage
+
+        self._frame_size = frame_size
+        self._get_current_frame_index = get_current_frame_index
+
+        plugin.add_observer("gl_display", self.on_gl_display)
+
+    def on_gl_display(self):
+        current_index = self._get_current_frame_index()
+        for index in range(
+            current_index - self.close_ref_range,
+            current_index + self.close_ref_range + 1,
+        ):
+            reference_location = self._reference_location_storage.get_or_none(index)
+            if reference_location:
+                diff_to_current = abs(current_index - index)
+                if diff_to_current == 0:
+                    self._draw_current_reference(reference_location)
+                else:
+                    self._draw_close_reference(reference_location, diff_to_current)
+
+    def _draw_current_reference(self, current_reference):
+        with self._frame_coordinate_system:
+            cygl_utils.draw_points(
+                [current_reference.screen_pos],
+                size=35,
+                color=cygl_utils.RGBA(0, 0.5, 0.5, 0.7),
+            )
+            self._draw_inner_dot(current_reference)
+
+    def _draw_close_reference(self, reference_location, diff_to_current):
+        with self._frame_coordinate_system:
+            alpha = 0.7 * (1.0 - diff_to_current / (self.close_ref_range + 1.0))
+            cygl_utils.draw_progress(
+                reference_location.screen_pos,
+                0.0,
+                0.999,
+                inner_radius=20.0,
+                outer_radius=35.0,
+                color=cygl_utils.RGBA(0, 0.5, 0.5, alpha),
+            )
+            self._draw_inner_dot(reference_location)
+
+    @property
+    def _frame_coordinate_system(self):
+        return gl_utils.Coord_System(
+            left=0, right=self._frame_size[0], bottom=self._frame_size[1], top=0
+        )
+
+    @staticmethod
+    def _draw_inner_dot(reference_location):
+        cygl_utils.draw_points(
+            [reference_location.screen_pos],
+            size=5,
+            color=cygl_utils.RGBA(0.0, 0.9, 0.0, 1.0),
+        )

--- a/pupil_src/shared_modules/gaze_producer/ui/timeline.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/timeline.py
@@ -1,0 +1,80 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+from plugin_timeline import Line, BarsElementTs, RangeElementPerc
+
+
+class Timeline:
+    def __init__(
+        self,
+        plugin_timeline,
+        reference_detection_controller,
+        reference_location_storage,
+        plugin,
+    ):
+        self._plugin_timeline = plugin_timeline
+        self._reference_detection_controller = reference_detection_controller
+        self._reference_location_storage = reference_location_storage
+
+        plugin.add_observer("init_ui", self._on_init_ui)
+        self._reference_detection_controller.add_observer(
+            "start_detection", self._on_start_reference_detection
+        )
+        self._reference_location_storage.add_observer(
+            "add", self._on_reference_storage_changed
+        )
+        self._reference_location_storage.add_observer(
+            "delete", self._on_reference_storage_changed
+        )
+        self._reference_location_storage.add_observer(
+            "delete_all", self._on_reference_storage_changed
+        )
+
+    def _on_init_ui(self):
+        self.render()
+
+    def _on_start_reference_detection(self):
+        self._reference_detection_controller.task.add_observer(
+            "update", self._on_reference_detection_update
+        )
+        self._reference_detection_controller.task.add_observer(
+            "on_ended", self._on_reference_detection_ended
+        )
+
+    def _on_reference_detection_update(self):
+        self.render()
+
+    def _on_reference_detection_ended(self):
+        self.render()
+
+    def _on_reference_storage_changed(self, *args, **kwargs):
+        self.render()
+
+    def render(self):
+        self._plugin_timeline.clear_lines()
+        self._plugin_timeline.add_line(self._render_references_timeline())
+        self._plugin_timeline.refresh()
+
+    def _render_references_timeline(self):
+        elements = []
+        if self._reference_detection_controller.is_running_detection:
+            elements.append(self._create_progress_indication())
+        elements.append(self._create_reference_location_bars())
+        return Line(label="References", elements=elements)
+
+    def _create_progress_indication(self):
+        progress = self._reference_detection_controller.task.progress
+        return RangeElementPerc(
+            from_perc=0, to_perc=progress, color_rgba=(1.0, 0.5, 0.5, 0.5)
+        )
+
+    def _create_reference_location_bars(self):
+        bar_positions = [ref.timestamp for ref in self._reference_location_storage]
+        return BarsElementTs(bar_positions, color_rgba=(1.0, 1.0, 1.0, 0.5))

--- a/pupil_src/shared_modules/gaze_producer/worker/detect_circle_markers.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/detect_circle_markers.py
@@ -1,0 +1,102 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+import logging
+
+import zmq_tools
+from gaze_producer.model.reference_location import ReferenceLocation
+from tasklib.interface import TaskInterface
+
+logger = logging.getLogger(__name__)
+
+
+class CircleMarkerDetectionTask(TaskInterface):
+    zmq_ctx = None
+    capture_source_path = None
+    notify_all = None
+
+    def __init__(self):
+        super().__init__()
+        self._process_pipe = None
+        self._progress = 0.0
+
+    @property
+    def progress(self):
+        return self._progress
+
+    def start(self):
+        super().start()
+        self._process_pipe = zmq_tools.Msg_Pair_Server(self.zmq_ctx)
+        self._request_start_of_detection(self._process_pipe.url)
+
+    def _request_start_of_detection(self, pair_url):
+        source_path = self.capture_source_path
+        self.notify_all(
+            {
+                "subject": "circle_detector_process.should_start",
+                "source_path": source_path,
+                "pair_url": pair_url,
+            }
+        )
+
+    def cancel_gracefully(self):
+        super().cancel_gracefully()
+        self._terminate_background_detection()
+        self.on_canceled_or_killed()
+
+    def kill(self, grace_period):
+        super().kill(grace_period)
+        # we cannot kill the detection, just ask it to terminate
+        self._terminate_background_detection()
+        self.on_canceled_or_killed()
+
+    def _terminate_background_detection(self):
+        self._process_pipe.send({"topic": "terminate"})
+        self._process_pipe.socket.close()
+        self._process_pipe = None
+
+    def update(self):
+        super().update()
+        try:
+            self._receive_detections()
+        except Exception as e:
+            self.on_exception(e)
+
+    def _receive_detections(self):
+        while self._process_pipe.new_data:
+            topic, msg = self._process_pipe.recv()
+            if topic == "progress":
+                progress_detection_pairs = msg.get("data", [])
+                progress, detections = zip(*progress_detection_pairs)
+                self._progress = progress[-1] / 100.0
+                detections_without_None_items = (d for d in detections if d)
+                for detection in detections_without_None_items:
+                    self._yield_detection(detection)
+            elif topic == "finished":
+                self.on_completed(return_value_or_none=None)
+                return
+            elif topic == "exception":
+                logger.warning(
+                    "Calibration marker detection raised exception:\n{}".format(
+                        msg["reason"]
+                    )
+                )
+                logger.info("Marker detection was interrupted")
+                logger.debug("Reason: {}".format(msg.get("reason", "n/a")))
+                self.on_canceled_or_killed()
+                return
+
+    def _yield_detection(self, detection):
+        screen_pos = tuple(detection["screen_pos"])
+        frame_index = detection["index"]
+        timestamp = detection["timestamp"]
+        reference_location = ReferenceLocation(screen_pos, frame_index, timestamp)
+        self.on_yield(reference_location)

--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -257,7 +257,14 @@ class _ObservableMethodWrapper:
             except _ReferenceNoLongerValidError:
                 self._observers.remove(observer)
             except Exception as e:
-                raise ObserverError("An observer raised an exception.") from e
+                # exceptions by observers are wrapped s.t. they cannot be confused
+                # with exceptions from the original method.
+                # If there is a chain of observers calling other observers, we wrap
+                # the exception only once, making the traceback a bit clearer
+                if isinstance(e, ObserverError):
+                    raise e
+                else:
+                    raise ObserverError("An observer raised an exception.") from e
 
 
 class _ReferenceNoLongerValidError(Exception):

--- a/pupil_src/shared_modules/plugin_timeline.py
+++ b/pupil_src/shared_modules/plugin_timeline.py
@@ -1,0 +1,106 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2018 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+import collections
+
+import OpenGL.GL as gl
+import pyglui.cygl.utils as cygl_utils
+from pyglui import ui
+from pyglui.pyfontstash import fontstash
+
+import gl_utils
+
+Line = collections.namedtuple("Line", ["label", "elements"])
+BarsElementTs = collections.namedtuple(
+    "BarsElementTs", ["bar_positions_ts", "color_rgba"]
+)
+RangeElementPerc = collections.namedtuple(
+    "HorBarElementPerc", ["from_perc", "to_perc", "color_rgba"]
+)
+
+
+class PluginTimeline:
+    timeline_line_height = 16
+
+    def __init__(self, title, plugin, user_timelines, time_start, time_end):
+        self._user_timelines = user_timelines
+        self._time_start = time_start
+        self._time_end = time_end
+
+        self._lines = []
+
+        # set to minimum height
+        self._timeline = ui.Timeline(title, self.draw_sections, self.draw_labels, 1)
+
+        self.glfont = fontstash.Context()
+        self.glfont.add_font("opensans", ui.get_opensans_font_path())
+        self.glfont.set_color_float((1.0, 1.0, 1.0, 1.0))
+        self.glfont.set_align_string(v_align="right", h_align="top")
+
+        plugin.add_observer("init_ui", self._on_init_ui)
+
+    def add_line(self, line):
+        self._lines.append(line)
+
+    def clear_lines(self):
+        self._lines = []
+
+    def refresh(self):
+        self._timeline.content_height = max(
+            0.001, self.timeline_line_height * len(self._lines)
+        )
+        self._timeline.refresh()
+
+    def _on_init_ui(self):
+        self._user_timelines.append(self._timeline)
+
+    def draw_sections(self, width, height, scale):
+        for line_index, line in enumerate(self._lines):
+            for element in line.elements:
+                if isinstance(element, BarsElementTs):
+                    self._draw_bars_element_ts(line_index, element, scale, height)
+                elif isinstance(element, RangeElementPerc):
+                    self._draw_range_element_perc(line_index, element, scale, height)
+                else:
+                    raise ValueError("Unknown element {}".format(element))
+
+    def _draw_bars_element_ts(self, line_index, element, scale, height):
+        with gl_utils.Coord_System(
+            left=self._time_start, right=self._time_end, bottom=height, top=0
+        ):
+            gl.glTranslatef(0, scale * self.timeline_line_height * line_index, 0)
+            gl.glTranslatef(0, 0.001 + scale * self.timeline_line_height / 2, 0)
+            color = cygl_utils.RGBA(*element.color_rgba)
+            cygl_utils.draw_bars(
+                [(ts, 0) for ts in element.bar_positions_ts],
+                height=15 * scale,
+                thickness=3 * scale,
+                color=color,
+            )
+
+    def _draw_range_element_perc(self, line_index, element, scale, height):
+        with gl_utils.Coord_System(left=0, right=1, bottom=height, top=0):
+            gl.glTranslatef(0, scale * self.timeline_line_height * line_index, 0)
+            gl.glTranslatef(0, 0.001 + scale * self.timeline_line_height / 2, 0)
+            color = cygl_utils.RGBA(*element.color_rgba)
+            cygl_utils.draw_rounded_rect(
+                (element.from_perc, -4 * scale),
+                (element.to_perc, 8 * scale),
+                corner_radius=0,
+                color=color,
+                sharpness=1.0,
+            )
+
+    def draw_labels(self, width, height, scale):
+        self.glfont.set_size(self.timeline_line_height * scale)
+        for line in self._lines:
+            self.glfont.draw_text(width, 0, line.label)
+            gl.glTranslatef(0, self.timeline_line_height * scale, 0)

--- a/pupil_src/shared_modules/tasklib/interface.py
+++ b/pupil_src/shared_modules/tasklib/interface.py
@@ -19,6 +19,9 @@ class TaskInterface(Observable, metaclass=abc.ABCMeta):
         self._completed = False
         self._canceled_or_killed = False
 
+    def on_started(self):
+        pass
+
     def on_yield(self, yield_value):
         """
         Add an observer to this to get notified every time a background task yields a
@@ -119,6 +122,7 @@ class TaskInterface(Observable, metaclass=abc.ABCMeta):
         if self.started:
             raise ValueError("Task already started!")
         self._started = True
+        self.on_started()
 
     @abc.abstractmethod
     def cancel_gracefully(self):


### PR DESCRIPTION
Main functionality for new gaze producer plugins:
- Detect circle markers and use them as reference locations
- Manual edit mode
- Jump to next / previous reference
- Timeline showing reference locations and progress of detection

New general functionality:
- `PluginTimeline`: Simple timeline to separate the `pyglui` stuff from the content of a timeline.

Additionally:
- `Observable`: Fix a little issue that `ObserverErrors` get wrapped into each other (and thus cluttering the traceback) when observers trigger more observers.
- `tasklib`: Expand with new event `on_started`