### PR TITLE
Raw Data Exporter: Clarify timestamp column names

### DIFF
--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -167,7 +167,7 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
 
                 csv_writer.writerow(
                     (
-                        "world_timestamp",
+                        "pupil_timestamp",
                         "world_index",
                         "eye_id",
                         "confidence",
@@ -273,7 +273,7 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
                 csv_writer = csv.writer(csvfile, delimiter=",")
                 csv_writer.writerow(
                     (
-                        "world_timestamp",
+                        "gaze_timestamp",
                         "world_index",
                         "confidence",
                         "norm_pos_x",


### PR DESCRIPTION
Fixes regression from 8119d620b4d153de37479fa021029b8671b87106

The `timestamp` column in `pupil_positions.csv` and `gaze_positions.csv` do not refer to world frame timestamps but to pupil and gaze timestamps (inferred from eye frame timestamps) respectively.