### PR TITLE
background helper: Fix a type error when initialising Task_proxy

### DIFF
--- a/pupil_src/shared_modules/background_helper.py
+++ b/pupil_src/shared_modules/background_helper.py
@@ -73,7 +73,7 @@ class Task_Proxy:
             logger.debug("Exiting _wrapper")
 
     def _prepare_wrapper_args(self, *args):
-        return args
+        return list(args)
 
     def _change_logging_behavior(self):
         pass


### PR DESCRIPTION
Line 40 expects `wrapper_args` to be a list instead of a tuple.

```python
wrapper_args.extend(args)
```