### PR TITLE
Allow any audio*.mp4 to be loaded for audio playback

### DIFF
--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -59,8 +59,6 @@ class Audio_Playback(System_Plugin_Base):
         self.pa_stream = None
         self.audio_sync = 0.0
         self.audio_delay = 0.0
-        self.audio_container = None
-        self.audio_stream = None
         self.next_audio_frame = None
         self.audio_start_pts = 0
         self.check_ts_consistency = False
@@ -68,117 +66,98 @@ class Audio_Playback(System_Plugin_Base):
         self.current_audio_volume = 1.0
         self.req_buffer_size_secs = 0.5
         self.audio_viz_trans = None
-        audio_file = os.path.join(self.g_pool.rec_dir, "audio.mp4")
-        if os.path.isfile(audio_file):
-            self.audio_container = av.open(str(audio_file))
-            try:
-                self.audio_stream = next(
-                    s for s in self.audio_container.streams if s.type == "audio"
-                )
-                logger.debug("loaded audiostream: %s" % self.audio_stream)
-            except StopIteration:
-                self.audio_stream = None
-                logger.debug("No audiostream found in media container")
-        else:
+
+        try:
+            self.audio = load_audio(self.g_pool.rec_dir)
+        except NoAudioLoadedError:
             return
-        if self.audio_stream is not None:
-            self.audio_bytes_fifo = []
-            audiots_path = os.path.splitext(audio_file)[0] + "_timestamps.npy"
-            try:
-                self.audio_timestamps = np.load(audiots_path)
-            except IOError:
-                self.audio_timestamps = None
-                logger.warning("Could not load audio timestamps")
-            self.next_audio_frame = self._next_audio_frame()
-            self.audio_resampler = av.audio.resampler.AudioResampler(
-                format=self.audio_stream.format.packed,
-                layout=self.audio_stream.layout,
-                rate=self.audio_stream.rate,
-            )
-            self.audio_paused = False
-            af0, af1 = next(self.next_audio_frame), next(self.next_audio_frame)
-            # Check pts
 
-            self.audio_pts_rate = af0.samples  # af1.pts - af0.pts
-            self.audio_start_pts = 0
-            logger.debug(
-                "audio_pts_rate = {} start_pts = {}".format(
-                    self.audio_pts_rate, self.audio_start_pts
-                )
-            )
+        self.audio_bytes_fifo = []
+        self.next_audio_frame = self._next_audio_frame()
+        self.audio_resampler = av.audio.resampler.AudioResampler(
+            format=self.audio.stream.format.packed,
+            layout=self.audio.stream.layout,
+            rate=self.audio.stream.rate,
+        )
+        self.audio_paused = False
+        af0, af1 = next(self.next_audio_frame), next(self.next_audio_frame)
+        # Check pts
 
-            if self.check_ts_consistency:
-                print("**** Checking stream")
-                for i, af in enumerate(self.next_audio_frame):
-                    fnum = i + 2
-                    if af.samples != af0.samples:
-                        print("fnum {} samples = {}".format(fnum, af.samples))
-                    if af.pts != self.audio_idx_to_pts(fnum):
-                        print(
-                            "af.pts = {} fnum = {} idx2pts = {}".format(
-                                af.pts, fnum, self.audio_idx_to_pts(fnum)
-                            )
+        self.audio_pts_rate = af0.samples  # af1.pts - af0.pts
+        self.audio_start_pts = 0
+        logger.debug(
+            "audio_pts_rate = {} start_pts = {}".format(
+                self.audio_pts_rate, self.audio_start_pts
+            )
+        )
+
+        if self.check_ts_consistency:
+            print("**** Checking stream")
+            for i, af in enumerate(self.next_audio_frame):
+                fnum = i + 2
+                if af.samples != af0.samples:
+                    print("fnum {} samples = {}".format(fnum, af.samples))
+                if af.pts != self.audio_idx_to_pts(fnum):
+                    print(
+                        "af.pts = {} fnum = {} idx2pts = {}".format(
+                            af.pts, fnum, self.audio_idx_to_pts(fnum)
                         )
-                    if (
-                        self.audio_timestamps[fnum]
-                        != self.audio_timestamps[0]
-                        + af.pts * self.audio_stream.time_base
-                    ):
-                        print(
-                            "ts[0] + af.pts = {} fnum = {} timestamp = {}".format(
-                                self.audio_timestamps[0]
-                                + af.pts * self.audio_stream.time_base,
-                                fnum,
-                                self.audio_timestamps[fnum],
-                            )
-                        )
-                print("**** Done")
-            self.seek_to_audio_frame(0)
-
-            logger.debug(
-                "Audio file format {} chans {} rate {} framesize {}".format(
-                    self.audio_stream.format.name,
-                    self.audio_stream.channels,
-                    self.audio_stream.rate,
-                    self.audio_stream.frame_size,
-                )
-            )
-            self.audio_start_time = 0
-            self.audio_measured_latency = -1.0
-            self.last_dac_time = 0
-            self.filter_graph = None
-            self.filter_graph_list = None
-            try:
-                self.pa = pa.PyAudio()
-                self.pa_stream = self.pa.open(
-                    format=self.pa.get_format_from_width(
-                        self.audio_stream.format.bytes
-                    ),
-                    channels=self.audio_stream.channels,
-                    rate=self.audio_stream.rate,
-                    frames_per_buffer=self.audio_stream.frame_size,
-                    stream_callback=self.audio_callback,
-                    output=True,
-                    start=False,
-                )
-                logger.debug(
-                    "Audio output latency: {}".format(
-                        self.pa_stream.get_output_latency()
                     )
-                )
-                self.audio_sync = self.pa_stream.get_output_latency()
-                self.audio_reported_latency = self.pa_stream.get_output_latency()
+                if (
+                    self.audio.timestamps[fnum]
+                    != self.audio.timestamps[0] + af.pts * self.audio.stream.time_base
+                ):
+                    print(
+                        "ts[0] + af.pts = {} fnum = {} timestamp = {}".format(
+                            self.audio.timestamps[0]
+                            + af.pts * self.audio.stream.time_base,
+                            fnum,
+                            self.audio.timestamps[fnum],
+                        )
+                    )
+            print("**** Done")
+        self.seek_to_audio_frame(0)
 
-            except ValueError:
-                self.pa_stream = None
+        logger.debug(
+            "Audio file format {} chans {} rate {} framesize {}".format(
+                self.audio.stream.format.name,
+                self.audio.stream.channels,
+                self.audio.stream.rate,
+                self.audio.stream.frame_size,
+            )
+        )
+        self.audio_start_time = 0
+        self.audio_measured_latency = -1.0
+        self.last_dac_time = 0
+        self.filter_graph = None
+        self.filter_graph_list = None
+        try:
+            self.pa = pa.PyAudio()
+            self.pa_stream = self.pa.open(
+                format=self.pa.get_format_from_width(self.audio.stream.format.bytes),
+                channels=self.audio.stream.channels,
+                rate=self.audio.stream.rate,
+                frames_per_buffer=self.audio.stream.frame_size,
+                stream_callback=self.audio_callback,
+                output=True,
+                start=False,
+            )
+            logger.debug(
+                "Audio output latency: {}".format(self.pa_stream.get_output_latency())
+            )
+            self.audio_sync = self.pa_stream.get_output_latency()
+            self.audio_reported_latency = self.pa_stream.get_output_latency()
 
-            self.audio_timeline = None
+        except ValueError:
+            self.pa_stream = None
 
-            self.audio_viz_trans = Audio_Viz_Transform(self.g_pool.rec_dir)
-            self.audio_viz_data = None
-            self.log_scale = False
-            self.xlim = (self.g_pool.timestamps[0], self.g_pool.timestamps[-1])
-            self.ylim = (0, 210)
+        self.audio_timeline = None
+
+        self.audio_viz_trans = Audio_Viz_Transform(self.g_pool.rec_dir)
+        self.audio_viz_data = None
+        self.log_scale = False
+        self.xlim = (self.g_pool.timestamps[0], self.g_pool.timestamps[-1])
+        self.ylim = (0, 210)
 
     def init_ui(self):
         if self.pa_stream is None:
@@ -220,10 +199,10 @@ class Audio_Playback(System_Plugin_Base):
         self.menu.append(ui.Switch("log_scale", self, label="Log scale"))
 
     def sec_to_frames(self, sec):
-        return int(np.ceil(sec * self.audio_stream.rate / self.audio_stream.frame_size))
+        return int(np.ceil(sec * self.audio.stream.rate / self.audio.stream.frame_size))
 
     def frames_to_sec(self, frames):
-        return frames * self.audio_stream.frame_size / self.audio_stream.rate
+        return frames * self.audio.stream.frame_size / self.audio.stream.rate
 
     def buffer_len_secs(self):
         return self.frames_to_sec(len(self.audio_bytes_fifo))
@@ -267,7 +246,7 @@ class Audio_Playback(System_Plugin_Base):
             return self.audio_sync
 
     def _next_audio_frame(self):
-        for packet in self.audio_container.demux(self.audio_stream):
+        for packet in self.audio.container.demux(self.audio.stream):
             for frame in packet.decode():
                 if frame:
                     yield frame
@@ -277,7 +256,7 @@ class Audio_Playback(System_Plugin_Base):
 
     def seek_to_audio_frame(self, seek_pos):
         try:
-            self.audio_stream.seek(
+            self.audio.stream.seek(
                 self.audio_start_pts + self.audio_idx_to_pts(seek_pos)
             )
         except av.AVError as e:
@@ -287,8 +266,8 @@ class Audio_Playback(System_Plugin_Base):
             self.audio_bytes_fifo.clear()
 
     def seek_to_frame(self, frame_idx):
-        if self.audio_stream is not None:
-            audio_idx = bisect(self.audio_timestamps, self.timestamps[frame_idx])
+        if self.audio.stream is not None:
+            audio_idx = bisect(self.audio.timestamps, self.timestamps[frame_idx])
             self.seek_to_audio_frame(audio_idx)
 
     def on_notify(self, notification):
@@ -312,11 +291,11 @@ class Audio_Playback(System_Plugin_Base):
                 try:
                     self.pa_stream = self.pa.open(
                         format=self.pa.get_format_from_width(
-                            self.audio_stream.format.bytes
+                            self.audio.stream.format.bytes
                         ),
-                        channels=self.audio_stream.channels,
-                        rate=self.audio_stream.rate,
-                        frames_per_buffer=self.audio_stream.frame_size,
+                        channels=self.audio.stream.channels,
+                        rate=self.audio.stream.rate,
+                        frames_per_buffer=self.audio.stream.frame_size,
                         stream_callback=self.audio_callback,
                         output=True,
                         start=False,
@@ -346,7 +325,7 @@ class Audio_Playback(System_Plugin_Base):
 
             #    self.filter_graph = av.filter.Graph()
             #    self.filter_graph_list = []
-            #    self.filter_graph_list.append(self.filter_graph.add_buffer(template=self.audio_stream))
+            #    self.filter_graph_list.append(self.filter_graph.add_buffer(template=self.audio.stream))
             #    args = "volume={}:precision=float".format(self.current_audio_volume)
             #    print("args = {}".format(args))
             #    self.filter_graph_list.append(
@@ -362,7 +341,7 @@ class Audio_Playback(System_Plugin_Base):
                 pbt = self.g_pool.seek_control.current_playback_time
                 frame_idx = self.g_pool.seek_control.ts_idx_from_playback_time(pbt)
                 audio_idx = bisect(
-                    self.audio_timestamps, self.g_pool.timestamps[frame_idx]
+                    self.audio.timestamps, self.g_pool.timestamps[frame_idx]
                 )
                 self.seek_to_audio_frame(audio_idx)
 
@@ -375,7 +354,7 @@ class Audio_Playback(System_Plugin_Base):
                 self.filter_graph = av.filter.Graph()
                 self.filter_graph_list = []
                 self.filter_graph_list.append(
-                    self.filter_graph.add_buffer(template=self.audio_stream)
+                    self.filter_graph.add_buffer(template=self.audio.stream)
                 )
                 args = "volume={}:precision=float".format(self.current_audio_volume)
                 print("args = {}".format(args))
@@ -385,7 +364,7 @@ class Audio_Playback(System_Plugin_Base):
                 self.filter_graph_list.append(
                     self.filter_graph.add(
                         "aresample",
-                        "osf={}".format(self.audio_stream.format.packed.name),
+                        "osf={}".format(self.audio.stream.format.packed.name),
                     )
                 )
                 self.filter_graph_list[-2].link_to(self.filter_graph_list[-1])
@@ -416,14 +395,14 @@ class Audio_Playback(System_Plugin_Base):
                     self.audio_bytes_fifo.append(
                         (
                             bytes(audio_frame.planes[0]),
-                            self.audio_timestamps[0]
-                            + audio_frame.pts * self.audio_stream.time_base,
+                            self.audio.timestamps[0]
+                            + audio_frame.pts * self.audio.stream.time_base,
                         )
                     )
             # print("Frames in buffer {}".format(len(self.audio_bytes_fifo)))
             if start_stream:
                 rt_delay = (
-                    self.audio_timestamps[audio_idx]
+                    self.audio.timestamps[audio_idx]
                     - self.g_pool.seek_control.current_playback_time
                 )
                 adj_delay = rt_delay - self.pa_stream.get_output_latency()

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -9,26 +9,26 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import numpy as np
-from plugin import System_Plugin_Base
-from pyglui import ui
-import gl_utils
-from pyglui.cygl.utils import *
-from audio_utils import Audio_Viz_Transform
-import os
-import av
-
-assert av.__version__ >= "0.4.0"
-import av.filter
-from bisect import bisect_left as bisect
-
-import pyaudio as pa
 import itertools
+import logging
+import os
+from bisect import bisect_left as bisect
 from threading import Timer
 from time import monotonic
 
-# logging
-import logging
+import numpy as np
+import pyaudio as pa
+from pyglui import ui
+from pyglui.cygl.utils import *
+
+import av
+import av.filter
+import gl_utils
+from audio_utils import Audio_Viz_Transform, load_audio, NoAudioLoadedError
+from plugin import System_Plugin_Base
+
+assert av.__version__ >= "0.4.0"
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logger.DEBUG)

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -8,10 +8,14 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import numpy as np
-import av
-import os
+import collections
+import glob
 import logging
+import os
+
+import numpy as np
+
+import av
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logger.DEBUG)

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -21,41 +21,56 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logger.DEBUG)
 
 
+class NoAudioLoadedError(Exception):
+    pass
+
+
+LoadedAudio = collections.namedtuple(
+    "LoadedAudio", ["container", "stream", "timestamps"]
+)
+
+
+def load_audio(rec_dir):
+    audio_pattern = os.path.join(rec_dir, "audio.mp4")
+    # sort matched files in order to prefer `audio.mp4` over `audio_xxxx.mp4`
+    for audio_file in sorted(glob.glob(audio_pattern)):
+        try:
+            container = av.open(audio_file)
+            stream = next(s for s in container.streams if s.type == "audio")
+            logger.debug("Loaded audiostream: %s" % stream)
+            break
+        except (av.AVError, StopIteration):
+            logger.debug(
+                "No audiostream found in media container {}".format(audio_file)
+            )
+    else:
+        raise NoAudioLoadedError("No valid audio file found")
+
+    audiots_path = os.path.splitext(audio_file)[0] + "_timestamps.npy"
+    try:
+        timestamps = np.load(audiots_path)
+    except IOError:
+        raise NoAudioLoadedError(
+            "Audio file found but could not load audio timestamps.", audio_file
+        )
+    return LoadedAudio(container, stream, timestamps)
+
+
 class Audio_Viz_Transform:
     def __init__(self, rec_dir, sps_rate=60):
         import av
         import os
         import errno
 
-        audio_file = os.path.join(rec_dir, "audio.mp4")
-        if os.path.isfile(audio_file):
-            self.audio_container = av.open(str(audio_file))
-            try:
-                self.audio_stream = next(
-                    s for s in self.audio_container.streams if s.type == "audio"
-                )
-                logger.debug("loaded audiostream: %s" % self.audio_stream)
-            except StopIteration:
-                self.audio_stream = None
-                logger.debug("No audiostream found in media container")
-                return
-        else:
-            raise FileNotFoundError(errno.ENOENT, audio_file)
-        if self.audio_stream is not None:
-            audiots_path = os.path.splitext(audio_file)[0] + "_timestamps.npy"
-            try:
-                self.audio_timestamps = np.load(audiots_path)
-            except IOError:
-                self.audio_timestamps = None
-                logger.warning("Could not load audio timestamps")
-                raise FileNotFoundError(errno.ENOENT, audiots_path)
+        self.audio = load_audio(rec_dir)
+
         self.sps_rate = sps_rate
-        self.start_ts = self.audio_timestamps[0]
+        self.start_ts = self.audio.timestamps[0]
 
         # Test lowpass filtering + viz
         # self.lp_graph = av.filter.Graph()
         # self.lp_graph_list = []
-        # self.lp_graph_list.append(self.lp_graph.add_buffer(template=self.audio_stream))
+        # self.lp_graph_list.append(self.lp_graph.add_buffer(template=self.audio.stream))
         # args = "f=10"
         # print("args = {}".format(args))
         ## lp_graph_list.append(lp_graph.add("lowpass", args))
@@ -72,7 +87,7 @@ class Audio_Viz_Transform:
         #                                                     layout=audio_stream.layout,
         #                                                     rate=audio_stream.rate)
         self.audio_resampler = av.audio.resampler.AudioResampler(
-            format=self.audio_stream.format, layout=self.audio_stream.layout, rate=60
+            format=self.audio.stream.format, layout=self.audio.stream.layout, rate=60
         )
         self.next_audio_frame = self._next_audio_frame()
         self.all_abs_samples = None
@@ -83,13 +98,13 @@ class Audio_Viz_Transform:
         self.log_scaling = False
 
     def _next_audio_frame(self):
-        for packet in self.audio_container.demux(self.audio_stream):
+        for packet in self.audio.container.demux(self.audio.stream):
             for frame in packet.decode():
                 if frame:
                     yield frame
 
     def sec_to_frames(self, sec):
-        return int(np.ceil(sec * self.audio_stream.rate / self.audio_stream.frame_size))
+        return int(np.ceil(sec * self.audio.stream.rate / self.audio.stream.frame_size))
 
     def get_data(self, seconds=30.0, height=210, log_scale=False):
         import itertools
@@ -158,7 +173,7 @@ class Audio_Viz_Transform:
                     np.arange(0, len(self.all_abs_samples), 1, dtype=np.float32)
                     / self.audio_resampler.rate
                 )
-                new_ts += self.audio_timestamps[0]
+                new_ts += self.audio.timestamps[0]
 
                 # self.all_abs_samples = np.log10(self.all_abs_samples)
                 self.all_abs_samples[-1] = 0.0

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -18,7 +18,7 @@ import numpy as np
 import av
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logger.DEBUG)
+logger.setLevel(logging.DEBUG)
 
 
 class NoAudioLoadedError(Exception):

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -31,7 +31,7 @@ LoadedAudio = collections.namedtuple(
 
 
 def load_audio(rec_dir):
-    audio_pattern = os.path.join(rec_dir, "audio.mp4")
+    audio_pattern = os.path.join(rec_dir, "audio*.mp4")
     # sort matched files in order to prefer `audio.mp4` over `audio_xxxx.mp4`
     for audio_file in sorted(glob.glob(audio_pattern)):
         try:

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -15,23 +15,22 @@ requires:
     -
 """
 
-import os, sys, platform
+# logging
+import logging
+import multiprocessing as mp
+import os
+import platform
+import sys
+from fractions import Fraction
+from threading import Event, Thread
+from time import time
+
+import numpy as np
+
 import av
 from av.packet import Packet
 
-import numpy as np
-from time import time
-from fractions import Fraction
-
-# logging
-import logging
-
 logger = logging.getLogger(__name__)
-
-
-from threading import Thread
-from threading import Event
-import multiprocessing as mp
 
 
 """

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -147,23 +147,32 @@ class AV_Writer(object):
 
     def write_video_frame(self, input_frame):
         if not self.configured:
-            self.video_stream.height = input_frame.height
-            self.video_stream.width = input_frame.width
-            self.configured = True
-            self.start_time = input_frame.timestamp
-            if input_frame.yuv_buffer is not None:
-                self.frame = av.VideoFrame(
-                    input_frame.width, input_frame.height, "yuv422p"
-                )
-            else:
-                self.frame = av.VideoFrame(
-                    input_frame.width, input_frame.height, "bgr24"
-                )
-            if self.use_timestamps:
-                self.frame.time_base = self.time_base
-            else:
-                self.frame.time_base = Fraction(1, self.fps)
+            self._configure_video(template_frame=input_frame)
 
+        self._update_frame_buffer(input_frame)
+        self._update_frame_pts(input_frame)
+        self._mux_video(input_frame)
+        self._mux_audio()
+
+    def _configure_video(self, template_frame):
+        self.video_stream.height = template_frame.height
+        self.video_stream.width = template_frame.width
+        self.configured = True
+        self.start_time = template_frame.timestamp
+        if template_frame.yuv_buffer is not None:
+            self.frame = av.VideoFrame(
+                template_frame.width, template_frame.height, "yuv422p"
+            )
+        else:
+            self.frame = av.VideoFrame(
+                template_frame.width, template_frame.height, "bgr24"
+            )
+        if self.use_timestamps:
+            self.frame.time_base = self.time_base
+        else:
+            self.frame.time_base = Fraction(1, self.fps)
+
+    def _update_frame_buffer(self, input_frame):
         if input_frame.yuv_buffer is not None:
             y, u, v = input_frame.yuv422
             self.frame.planes[0].update(y)
@@ -172,6 +181,7 @@ class AV_Writer(object):
         else:
             self.frame.planes[0].update(input_frame.img)
 
+    def _update_frame_pts(self, input_frame):
         if self.use_timestamps:
             self.frame.pts = int(
                 (input_frame.timestamp - self.start_time) / self.time_base
@@ -179,47 +189,44 @@ class AV_Writer(object):
         else:
             # our timebase is 1/30  so a frame idx is the correct pts for an fps recorded video.
             self.frame.pts = self.current_frame_idx
+
+    def _mux_video(self, input_frame):
         # send frame of to encoder
         for packet in self.video_stream.encode(self.frame):
             self.container.mux(packet)
         self.current_frame_idx += 1
         self.timestamps.append(input_frame.timestamp)
-        if self.audio:
-            for audio_packet in self.audio.container.demux():
-                if self.audio_packets_decoded >= len(self.audio.timestamps):
-                    logger.debug(
-                        "More audio frames decoded than there are timestamps: {} > {}".format(
-                            self.audio_packets_decoded, len(self.audio.timestamps)
-                        )
+
+    def _mux_audio(self):
+        if not self.audio:
+            return
+
+        for audio_packet in self.audio.container.demux():
+            if self.audio_packets_decoded >= len(self.audio.timestamps):
+                logger.debug(
+                    "More audio frames decoded than there are timestamps: {} > {}".format(
+                        self.audio_packets_decoded, len(self.audio.timestamps)
                     )
-                    break
-                audio_pts = int(
-                    (
-                        self.audio.timestamps[self.audio_packets_decoded]
-                        - self.start_time
-                    )
-                    / self.audio_export_stream.time_base
                 )
-                audio_packet.pts = audio_pts
-                audio_packet.dts = audio_pts
-                audio_packet.stream = self.audio_export_stream
-                self.audio_packets_decoded += 1
+                break
+            audio_pts = int(
+                (self.audio.timestamps[self.audio_packets_decoded] - self.start_time)
+                / self.audio_export_stream.time_base
+            )
+            audio_packet.pts = audio_pts
+            audio_packet.dts = audio_pts
+            audio_packet.stream = self.audio_export_stream
+            self.audio_packets_decoded += 1
 
-                if audio_pts * self.audio_export_stream.time_base < 0:
-                    logger.debug(
-                        "Seeking: {} -> {}".format(
-                            audio_pts * self.audio_export_stream.time_base,
-                            self.start_time,
-                        )
-                    )
-                    continue  # seek to start_time
+            audio_ts = audio_pts * self.audio_export_stream.time_base
+            if audio_ts < 0:
+                logger.debug("Seeking: {} -> {}".format(audio_ts, self.start_time))
+                continue  # seek to start_time
 
-                self.container.mux(audio_packet)
-                if (
-                    audio_pts * self.audio_export_stream.time_base
-                    > self.frame.pts * self.time_base
-                ):
-                    break  # wait for next image
+            self.container.mux(audio_packet)
+            frame_ts = self.frame.pts * self.time_base
+            if audio_ts > frame_ts:
+                break  # wait for next image
 
     def close(self, timestamp_export_format="npy"):
         # only flush encoder if there has been at least one frame

--- a/pupil_src/shared_modules/video_export/plugin_base/isolated_frame_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugin_base/isolated_frame_exporter.py
@@ -91,7 +91,7 @@ def _convert_video_file(
         input_source.timestamps, export_window
     )
     writer = AV_Writer(
-        output_file, fps=input_source.frame_rate, audio_loc=None, use_timestamps=True
+        output_file, fps=input_source.frame_rate, audio_dir=None, use_timestamps=True
     )
     input_source.seek_to_frame(export_from_index)
     next_update_idx = export_from_index + update_rate

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -153,8 +153,6 @@ def _export_world_video(
         name_by_index = [p.__name__ for p in available_plugins]
         plugin_by_name = dict(zip(name_by_index, available_plugins))
 
-        audio_path = os.path.join(rec_dir, "audio.mp4")
-
         meta_info = pm.load_meta_info(rec_dir)
 
         g_pool = GlobalContainer()
@@ -210,7 +208,7 @@ def _export_world_video(
 
         # setup of writer
         writer = AV_Writer(
-            out_file_path, fps=cap.frame_rate, audio_loc=audio_path, use_timestamps=True
+            out_file_path, fps=cap.frame_rate, audio_dir=rec_dir, use_timestamps=True
         )
 
         cap.seek_to_frame(start_frame)


### PR DESCRIPTION
Fixes #1475 by allowing any `audio*.mp4` to be loaded for audio playback.

- Uses `glob` to match potential audio files
- Prioritizes `audio.mp4` over `audio_xxxxx.mp4`
- Extracts loading of audio container, stream and timestamps into separate function and returns them as `LoadedAudio` namedtuple
- `Audio_Playback` and `Audio_Viz_Transform` make direct use of `LoadedAudio`