### PR TITLE
Even running from source, do not build modules unless required.

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
+++ b/pupil_src/shared_modules/calibration_routines/optimization_calibration/__init__.py
@@ -9,13 +9,10 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-# when running from source compile cpp extension if nessesary.
-
-import sys
-
-if not getattr(sys, "frozen", False):
+try:
+    from .calibration_methods import bundle_adjust_calibration
+except ModuleNotFoundError:
+    # when running from source compile cpp extension if necessary.
     from .build import build_cpp_extension
-
     build_cpp_extension()
-
-from .calibration_methods import bundle_adjust_calibration
+    from .calibration_methods import bundle_adjust_calibration

--- a/pupil_src/shared_modules/cython_methods/__init__.py
+++ b/pupil_src/shared_modules/cython_methods/__init__.py
@@ -9,13 +9,10 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-# when running from source compile cpp extension if necessary.
-
-import sys
-
-if not getattr(sys, "frozen", False):
+try:
+    from .methods import *
+except ModuleNotFoundError:
+    # when running from source compile cpp extension if necessary.
     from .build import build_cpp_extension
-
     build_cpp_extension()
-
-from .methods import *
+    from .methods import *

--- a/pupil_src/shared_modules/pupil_detectors/__init__.py
+++ b/pupil_src/shared_modules/pupil_detectors/__init__.py
@@ -9,18 +9,15 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-# when running from source compile cpp extension if necessary.
-import sys
-
-if not getattr(sys, "frozen", False):
+try:
+    from .detector_2d import Detector_2D
+except ModuleNotFoundError:
+    # when running from source compile cpp extension if necessary.
     from .build import build_cpp_extension
-
     build_cpp_extension()
+    from .detector_2d import Detector_2D
 
-from .detector_2d import Detector_2D
 from .detector_3d import Detector_3D
 from .detector_dummy import Detector_Dummy
-
-
 # explicit import here for pyinstaller because it will not search .pyx source files.
 from .visualizer_3d import Eye_Visualizer


### PR DESCRIPTION
Currently, when running from source, the built modules will be rebuilt (no-op) every time. This is problematic for a couple reasons. First, it means that the RUN environment has to have all of the includes and libs required to build the modules, even though they aren't all required to run the modules. Second, PyCharm debug mangles in-line Cython commands; see the bug report [here](https://youtrack.jetbrains.com/issue/PY-27833).

There is a work around available to the PyCharm-specific issue, but this disables automatic attaching to sub-processes, and this is a desirable feature given how pupil makes use of multiprocessing.

So this PR simply tries to import the compiled modules then if it fails, and if it's not the bundle, it then tries to build the required modules.