### PR TITLE
Fix offline gaze mapper crash when using a recorded calibration

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -125,7 +125,10 @@ class CalibrationStorage(Storage, Observable):
                 try:
                     calib_result = model.CalibrationResult(
                         mapping_plugin_name=data["mapper_name"],
-                        mapper_args=data["mapper_args"],
+                        # data["mapper_args"] is a fm.Frozen_Dict and causes
+                        # https://github.com/pupil-labs/pupil/issues/1498
+                        # if not converted to a normal dict
+                        mapper_args=dict(data["mapper_args"]),
                     )
                 except KeyError:
                     # notifications from old recordings will not have these fields!


### PR DESCRIPTION
Fixes #1498

The Calibration Storage looks for recorded calibrations in `notify.pldata`. The resulting notifications are of type `file_methods.Frozen_Dict`. Consequently, the `mapper_args` dictionary of `notify.calibration.calibration_data` notifications is also a `Frozen_Dict`. If this `Frozen_Dict` is saved as is and later passed to the mapping process then it will be pickled on systems that spawn processes (macOS and Windows). Unpickling such `Frozen_Dict`s will call the `__setitem__()` function which will raise a `NotImplementedError` in this case.

The problem can be worked around by storing a normal dict instance of `mapper_args` instead.