### PR TITLE
Fix audio playback in cases where the audio is shorter than the world video

### DIFF
--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -343,7 +343,10 @@ class Audio_Playback(System_Plugin_Base):
                 audio_idx = bisect(
                     self.audio.timestamps, self.g_pool.timestamps[frame_idx]
                 )
-                self.seek_to_audio_frame(audio_idx)
+                if audio_idx < len(self.audio.timestamps):
+                    self.seek_to_audio_frame(audio_idx)
+                else:
+                    start_stream = False
 
             if self.filter_graph_list is None:
                 self.current_audio_volume = self.req_audio_volume


### PR DESCRIPTION
Else the software crashes with

```py
Traceback (most recent call last):
  File "/Users/papr/work/pupil/pupil_src/launchables/player.py", line 595, in player
    p.recent_events(events)
  File "/Users/papr/work/pupil/pupil_src/shared_modules/audio_playback.py", line 405, in recent_events
    self.audio.timestamps[audio_idx]
IndexError: index 1534 is out of bounds for axis 0 with size 1534
```