### PR TITLE
Improve ui responsiveness

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -784,6 +784,7 @@ def eye(
                                 )
 
                     glViewport(0, 0, *camera_render_size)
+                    glfw.glfwPollEvents()
                     make_coord_system_pixel_based((f_height, f_width, 3), g_pool.flip)
                     # render the ROI
                     g_pool.u_r.draw(g_pool.gui.scale)
@@ -807,7 +808,6 @@ def eye(
 
                     # update screen
                     glfw.glfwSwapBuffers(main_window)
-                glfw.glfwPollEvents()
 
         # END while running
 

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -596,6 +596,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
             g_pool.plugins.clean()
 
             glfw.glfwMakeContextCurrent(main_window)
+            glfw.glfwPollEvents()
             # render visual feedback from loaded plugins
             if gl_utils.is_window_visible(main_window):
 
@@ -642,8 +643,6 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
                 # present frames at appropriate speed
                 g_pool.seek_control.wait(events["frame"].timestamp)
                 glfw.glfwSwapBuffers(main_window)
-
-            glfw.glfwPollEvents()
 
         session_settings["loaded_plugins"] = g_pool.plugins.get_initializers()
         session_settings["min_data_confidence"] = g_pool.min_data_confidence

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -639,6 +639,7 @@ def world(
 
             glfw.glfwMakeContextCurrent(main_window)
             # render visual feedback from loaded plugins
+            glfw.glfwPollEvents()
             if window_should_update() and gl_utils.is_window_visible(main_window):
 
                 gl_utils.glViewport(0, 0, *camera_render_size)
@@ -680,7 +681,6 @@ def world(
                     any(p.on_char(char_) for p in g_pool.plugins)
 
                 glfw.glfwSwapBuffers(main_window)
-            glfw.glfwPollEvents()
 
         glfw.glfwRestoreWindow(main_window)  # need to do this for windows os
         session_settings["loaded_plugins"] = g_pool.plugins.get_initializers()

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -177,6 +177,7 @@ class Service_UI(System_Plugin_Base):
     def update_ui(self):
         if not glfw.glfwWindowShouldClose(self.g_pool.main_window):
             gl_utils.glViewport(0, 0, *self.window_size)
+            glfw.glfwPollEvents()
             self.gl_display()
             try:
                 clipboard = glfw.glfwGetClipboardString(
@@ -193,7 +194,6 @@ class Service_UI(System_Plugin_Base):
                 )
 
             glfw.glfwSwapBuffers(self.g_pool.main_window)
-            glfw.glfwPollEvents()
         else:
             self.notify_all({"subject": "service_process.should_stop"})
 


### PR DESCRIPTION
By polling glfw events before updating pyglui we ensure that pyglui can react as fast as possible to ui events instead of waiting for a full processing cycle.