### PR TITLE
Fix gaze data uniqueness accross gaze mappers

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -10,7 +10,7 @@ See COPYING and COPYING.LESSER for license details.
 """
 import logging
 from itertools import chain
-
+import numpy as np
 import player_methods
 import tasklib
 from gaze_producer import worker
@@ -131,6 +131,11 @@ class GazeMapperController(Observable):
                 )
             )
         )
+
+        #Only keep unique gaze_data (according to gaze_ts)
+        gaze_ts, indices = np.unique(gaze_ts, return_index=True)
+        gaze_data = np.asarray(gaze_data, dtype=object)[indices]
+
         return player_methods.Bisector(gaze_data, gaze_ts)
 
     def on_gaze_mapping_calculated(self, gaze_mapper):

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -42,7 +42,7 @@ class Bisector(object):
                     " timestamp in `data_ts`"
                 )
             )
-        elif not data:
+        elif len(data) == 0:
             self.data = []
             self.data_ts = np.asarray([])
             self.sorted_idc = []


### PR DESCRIPTION
When combining gaze data from different mappers, it's possible to have duplicate data for the same timestamp. Currently, this causes problems with eye movement classification, which expects unique and monotonically increasing timestamps.

The solution is to filter out duplicate gaze datums (by timestamp) after combining all data from enabled gaze mappers, but before publishing it. This shouldn't affect any other part of the system.

---
##### Alternative solutions considered

1. Performing the gaze data filtering inside the eye movement detector, since this is the only part that assumes unique timestamps. This solution, however, is problematic because the detector outputs a classification for each input gaze data. This one-to-one mapping will no longer hold, if the input gaze data is filtered for classification.

2. Enforcing timestamp uniqueness inside `Bisector`. This approach has the potential of breaking existing code which assumes that the length of the data that `Bisector` holds is the same as the length of the data used to initialize it.
