### PR TITLE
Add gaze data input validation for NSLR-HMM classification

### DIFF
--- a/pupil_src/shared_modules/eye_movement/controller/eye_movement_offline_controller.py
+++ b/pupil_src/shared_modules/eye_movement/controller/eye_movement_offline_controller.py
@@ -119,6 +119,7 @@ class Eye_Movement_Offline_Controller:
 
     def _on_task_exception(self, exception: Exception):
         self._on_exception(exception)
+        self._on_task_completed(None)
 
     def _on_task_completed(self, _: None):
         self.storage.finalize()

--- a/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
+++ b/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
@@ -106,7 +106,7 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
 
     def on_task_exception(self, exception: Exception):
         error_message = f"{exception}"
-        logger.exception(error_message)
+        logger.error(error_message)
         self.menu_content.update_error_text(error_message)
 
     def on_task_completed(self):

--- a/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
+++ b/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
@@ -58,6 +58,7 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
         self.offline_controller = controller.Eye_Movement_Offline_Controller(
             plugin=self,
             storage=self.storage,
+            on_started=self.on_task_started,
             on_status=self.on_task_status,
             on_progress=self.on_task_progress,
             on_exception=self.on_task_exception,
@@ -94,6 +95,9 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
     def seek_to_timestamp(self, timestamp):
         self.notify_all({"subject": "seek_control.should_seek", "timestamp": timestamp})
 
+    def on_task_started(self):
+        self.menu_content.update_error_text("")
+
     def on_task_progress(self, progress: float):
         self.menu_content.update_progress(progress)
 
@@ -101,7 +105,9 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
         self.menu_content.update_status(status)
 
     def on_task_exception(self, exception: Exception):
-        raise exception
+        error_message = f"{exception}"
+        logger.exception(error_message)
+        self.menu_content.update_error_text(error_message)
 
     def on_task_completed(self):
         self._eye_movement_changed_announcer.announce_new()

--- a/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
+++ b/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
@@ -8,7 +8,7 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import typing
+import logging
 import random
 from .eye_movement_detector_base import Eye_Movement_Detector_Base
 import eye_movement.utils as utils
@@ -17,6 +17,9 @@ import eye_movement.controller as controller
 import eye_movement.ui as ui
 from observable import Observable
 from data_changed import Listener, Announcer
+
+
+logger = logging.getLogger(__name__)
 
 
 class Notification_Subject:
@@ -191,6 +194,6 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
                 ts_segment_class_pairs, export_dir=export_dir
             )
         else:
-            utils.logger.warning(
+            logger.warning(
                 "The selected export range does not include eye movement detections"
             )

--- a/pupil_src/shared_modules/eye_movement/ui/menu_content.py
+++ b/pupil_src/shared_modules/eye_movement/ui/menu_content.py
@@ -24,6 +24,7 @@ class Menu_Content:
         self._show_segmentation_switch = None
         self._current_segment_details = None
         self._detection_status_input = None
+        self._error_text = None
 
     #
 
@@ -50,6 +51,7 @@ class Menu_Content:
             "show_segmentation", self, label="Show segmentation"
         )
 
+        self._error_text = gl_ui.Info_Text("")
         self._current_segment_details = gl_ui.Info_Text("")
 
         menu.label = self.label_text
@@ -58,8 +60,9 @@ class Menu_Content:
             paragraph_ui = gl_ui.Info_Text(paragraph)
             menu.append(paragraph_ui)
 
-        menu.append(self._detection_status_input)
         menu.append(self._show_segmentation_switch)
+        menu.append(self._detection_status_input)
+        menu.append(self._error_text)
         menu.append(self._current_segment_details)
 
     def update_status(self, new_status: str):
@@ -69,6 +72,10 @@ class Menu_Content:
         plugin = self.plugin()
         if plugin and plugin.menu_icon:
             plugin.menu_icon.indicator_stop = new_progress
+
+    def update_error_text(self, error_message: str):
+        error_message = f"Error: {error_message}" if error_message else ""
+        self._error_text.text = error_message
 
     def update_detail_text(
         self,

--- a/pupil_src/shared_modules/eye_movement/utils.py
+++ b/pupil_src/shared_modules/eye_movement/utils.py
@@ -93,4 +93,4 @@ def validate_nslr_data(eye_positions: np.ndarray, eye_timestamps: np.ndarray):
     if not is_monotonic(eye_timestamps):
         raise ValueError("Gaze timestamps are not monotonic")
     if not is_unique(eye_timestamps):
-        raise ValueError("Gaze timestamps are not unique. Please recalculate gaze mapping with only 1 mapper enabled")
+        raise ValueError("Gaze timestamps are not unique. If you are using Offline Calibration, please disable all but one gaze mapping section.")

--- a/pupil_src/shared_modules/eye_movement/utils.py
+++ b/pupil_src/shared_modules/eye_movement/utils.py
@@ -67,4 +67,30 @@ def gaze_data_to_nslr_data(capture, gaze_data, gaze_timestamps, use_pupil: bool)
     angles = np.rad2deg(angles)
 
     nslr_data = np.column_stack(angles)
+
+    validate_nslr_data(
+        eye_positions=nslr_data,
+        eye_timestamps=gaze_timestamps,
+    )
+
     return nslr_data
+
+
+def validate_nslr_data(eye_positions: np.ndarray, eye_timestamps: np.ndarray):
+    def has_nan(arr: np.ndarray):
+        return np.any(np.isnan(arr))
+
+    def is_monotonic(arr: np.ndarray):
+        return np.all(arr[:-1] <= arr[1:])
+
+    def is_unique(arr: np.ndarray):
+        return arr.shape == np.unique(arr, axis=0).shape
+
+    if has_nan(eye_positions):
+        raise ValueError("Gaze data contains NaN values")
+    if not is_monotonic(eye_timestamps):
+        raise ValueError("Gaze timestamps contains NaN values")
+    if not is_monotonic(eye_timestamps):
+        raise ValueError("Gaze timestamps are not monotonic")
+    if not is_unique(eye_timestamps):
+        raise ValueError("Gaze timestamps are not unique. Please recalculate gaze mapping with only 1 mapper enabled")

--- a/pupil_src/shared_modules/eye_movement/utils.py
+++ b/pupil_src/shared_modules/eye_movement/utils.py
@@ -48,7 +48,7 @@ def np_denormalize(points_2d, frame_size):
     return points_2d
 
 
-def gaze_data_to_nslr_data(capture, gaze_data, use_pupil: bool):
+def gaze_data_to_nslr_data(capture, gaze_data, gaze_timestamps, use_pupil: bool):
 
     if use_pupil:
         assert can_use_3d_gaze_mapping(gaze_data)

--- a/pupil_src/shared_modules/eye_movement/utils.py
+++ b/pupil_src/shared_modules/eye_movement/utils.py
@@ -89,7 +89,7 @@ def validate_nslr_data(eye_positions: np.ndarray, eye_timestamps: np.ndarray):
     if has_nan(eye_positions):
         raise ValueError("Gaze data contains NaN values")
     if not is_monotonic(eye_timestamps):
-        raise ValueError("Gaze timestamps contains NaN values")
+        raise ValueError("Gaze timestamps contain NaN values")
     if not is_monotonic(eye_timestamps):
         raise ValueError("Gaze timestamps are not monotonic")
     if not is_unique(eye_timestamps):

--- a/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
+++ b/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
@@ -69,7 +69,7 @@ def eye_movement_detection_generator(
 
     yield EYE_MOVEMENT_DETECTION_STEP_PROCESSING_LOCALIZED_STRING, ()
     eye_positions = utils.gaze_data_to_nslr_data(
-        capture, gaze_data, use_pupil=use_pupil
+        capture, gaze_data, gaze_time, use_pupil=use_pupil
     )
 
     yield EYE_MOVEMENT_DETECTION_STEP_CLASSIFYING_LOCALIZED_STRING, ()

--- a/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
+++ b/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
@@ -77,7 +77,7 @@ class Real_Time_Buffered_Detector:
         gaze_time = np.array([gp["timestamp"] for gp in gaze_data])
 
         eye_positions = utils.gaze_data_to_nslr_data(
-            capture, gaze_data, use_pupil=use_pupil
+            capture, gaze_data, gaze_time, use_pupil=use_pupil
         )
 
         gaze_classification, segmentation, segment_classification = nslr_hmm.classify_gaze(


### PR DESCRIPTION
Calling `nslr_hmm.classify_gaze` function with invalid eye positions and/or timestamps causes the function to hang in an invalid state. This PR prevents calling this function with invalid data, and shows the user a message with the cause of the validation error.

This addresses the same problem as #1528 but specifically targets the manifestation of the problem.
