### PR TITLE
Fix eye movement frame indices

### DIFF
--- a/pupil_src/shared_modules/eye_movement/model/immutable_capture.py
+++ b/pupil_src/shared_modules/eye_movement/model/immutable_capture.py
@@ -24,4 +24,4 @@ class Immutable_Capture:
         try:
             self.timestamps: np.ndarray = capture.timestamps
         except AttributeError:
-            self.timestamps: np.ndarray = np.ndarray([])
+            self.timestamps: np.ndarray = np.asarray([])

--- a/pupil_src/shared_modules/eye_movement/model/segment.py
+++ b/pupil_src/shared_modules/eye_movement/model/segment.py
@@ -16,6 +16,7 @@ import eye_movement.utils as utils
 from storage import StorageItem
 import methods as mt
 import file_methods as fm
+import player_methods as pm
 import numpy as np
 import nslr_hmm
 
@@ -429,7 +430,7 @@ class Classified_Segment_Factory:
         self._segment_id = start_id
 
     def create_segment(
-        self, gaze_data, gaze_time, use_pupil, nslr_segment, nslr_segment_class
+        self, gaze_data, gaze_time, use_pupil, nslr_segment, nslr_segment_class, capture_time
     ) -> t.Optional[Classified_Segment]:
         segment_id = self._get_id_postfix_increment()
 
@@ -443,11 +444,17 @@ class Classified_Segment_Factory:
         segment_class = Segment_Class.from_nslr_class(nslr_segment_class)
         topic = utils.EYE_MOVEMENT_TOPIC_PREFIX + segment_class.value
 
-        start_frame_index, end_frame_index = nslr_segment.i  # [i_0, i_1)
         start_frame_timestamp, end_frame_timestamp = (
             segment_time[0],
             segment_time[-1],
         )  # [t_0, t_1]
+
+        if capture_time is not None and len(capture_time) > 0:
+            time_range = [start_frame_timestamp, end_frame_timestamp]
+            start_frame_index, end_frame_index = pm.find_closest(capture_time, time_range)
+            start_frame_index, end_frame_index = int(start_frame_index), int(end_frame_index)
+        else:
+            start_frame_index, end_frame_index = None, None
 
         segment = Classified_Segment.from_attrs(
             id=segment_id,

--- a/pupil_src/shared_modules/eye_movement/model/segment.py
+++ b/pupil_src/shared_modules/eye_movement/model/segment.py
@@ -456,7 +456,7 @@ class Classified_Segment_Factory:
             segment_time[-1],
         )  # [t_0, t_1]
 
-        if isinstance(capture_time, np.ndarray) and capture_time.size > 1:
+        if len(capture_time) > 1:
             time_range = [start_frame_timestamp, end_frame_timestamp]
             start_frame_index, end_frame_index = pm.find_closest(capture_time, time_range)
             start_frame_index, end_frame_index = int(start_frame_index), int(end_frame_index)

--- a/pupil_src/shared_modules/eye_movement/model/segment.py
+++ b/pupil_src/shared_modules/eye_movement/model/segment.py
@@ -437,7 +437,7 @@ class Classified_Segment_Factory:
         self._segment_id = start_id
 
     def create_segment(
-        self, gaze_data, gaze_time, use_pupil, nslr_segment, nslr_segment_class, capture_time
+        self, gaze_data, gaze_time, use_pupil, nslr_segment, nslr_segment_class, world_timestamps
     ) -> t.Optional[Classified_Segment]:
         segment_id = self._get_id_postfix_increment()
 
@@ -456,9 +456,9 @@ class Classified_Segment_Factory:
             segment_time[-1],
         )  # [t_0, t_1]
 
-        if len(capture_time) > 1:
+        if len(world_timestamps) > 1:
             time_range = [start_frame_timestamp, end_frame_timestamp]
-            start_frame_index, end_frame_index = pm.find_closest(capture_time, time_range)
+            start_frame_index, end_frame_index = pm.find_closest(world_timestamps, time_range)
             start_frame_index, end_frame_index = int(start_frame_index), int(end_frame_index)
         else:
             start_frame_index, end_frame_index = None, None

--- a/pupil_src/shared_modules/eye_movement/model/segment.py
+++ b/pupil_src/shared_modules/eye_movement/model/segment.py
@@ -135,7 +135,7 @@ class Classified_Segment(StorageItem):
 
     # StorageItem API
 
-    version = 1
+    version = 2
 
     @staticmethod
     def from_tuple(segment_tuple: tuple) -> "Classified_Segment":

--- a/pupil_src/shared_modules/eye_movement/ui/menu_content.py
+++ b/pupil_src/shared_modules/eye_movement/ui/menu_content.py
@@ -112,7 +112,7 @@ class Menu_Content:
             current_segment.duration
         )
         text += ident + "Frame range: {}-{}\n".format(
-            current_segment.start_frame_index + 1, current_segment.end_frame_index + 1
+            current_segment.start_frame_index, current_segment.end_frame_index
         )
         text += ident + "2d gaze pos: x={:.3f}, y={:.3f}\n".format(
             *current_segment.norm_pos

--- a/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
+++ b/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
@@ -90,6 +90,7 @@ def eye_movement_detection_generator(
             use_pupil=use_pupil,
             nslr_segment=nslr_segment,
             nslr_segment_class=nslr_segment_class,
+            capture_time=capture.timestamps,
         )
 
         if not segment:

--- a/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
+++ b/pupil_src/shared_modules/eye_movement/worker/offline_detection_task.py
@@ -90,7 +90,7 @@ def eye_movement_detection_generator(
             use_pupil=use_pupil,
             nslr_segment=nslr_segment,
             nslr_segment_class=nslr_segment_class,
-            capture_time=capture.timestamps,
+            world_timestamps=capture.timestamps,
         )
 
         if not segment:

--- a/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
+++ b/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
@@ -108,7 +108,7 @@ class Real_Time_Buffered_Detector:
                 use_pupil=use_pupil,
                 nslr_segment=nslr_segment,
                 nslr_segment_class=nslr_segment_class,
-                capture_time=capture.timestamps,
+                world_timestamps=capture.timestamps,
             )
 
             if not segment:

--- a/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
+++ b/pupil_src/shared_modules/eye_movement/worker/real_time_buffered_detector.py
@@ -108,6 +108,7 @@ class Real_Time_Buffered_Detector:
                 use_pupil=use_pupil,
                 nslr_segment=nslr_segment,
                 nslr_segment_class=nslr_segment_class,
+                capture_time=capture.timestamps,
             )
 
             if not segment:


### PR DESCRIPTION
Currently, the eye movement segment's `start_frame_index` and `end_frame_index` properties point inside the input buffer for `nslr_hmm.classify_gaze`. This PR updates these properties to represent indices into the capture video frame buffer.
