### PR TITLE
Fix camera models

### DIFF
--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -380,12 +380,15 @@ class Fisheye_Dist_Camera(Camera_Model):
             image_points.shape = (-1, 1, 2)
         return image_points
 
-    def undistortPoints(self, points):
+    def undistort_points_to_ideal_point_coordinates(self, points):
+        return cv2.fisheye.undistortPoints(points, self.K, self.D)
+
+    def undistort_points_on_image_plane(self, points):
         points = self.unprojectPoints(points, use_distortion=True)
         points = self.projectPoints(points, use_distortion=False)
         return points
 
-    def distortPoints(self, points):
+    def distort_points_on_image_plane(self, points):
         points = self.unprojectPoints(points, use_distortion=False)
         points = self.projectPoints(points, use_distortion=True)
         return points
@@ -417,7 +420,7 @@ class Fisheye_Dist_Camera(Camera_Model):
         if xy.ndim == 2:
             xy = np.expand_dims(xy, 0)
 
-        xy_undist = self.undistortPoints(xy.astype(np.float32))
+        xy_undist = self.undistort_points_on_image_plane(xy)
         xy_undist = np.squeeze(xy_undist)
 
         res = cv2.solvePnP(
@@ -544,12 +547,15 @@ class Radial_Dist_Camera(Camera_Model):
             image_points.shape = (-1, 1, 2)
         return image_points
 
-    def undistortPoints(self, points):
+    def undistort_points_to_ideal_point_coordinates(self, points):
+        return cv2.undistortPoints(points, self.K, self.D)
+
+    def undistort_points_on_image_plane(self, points):
         points = self.unprojectPoints(points, use_distortion=True)
         points = self.projectPoints(points, use_distortion=False)
         return points
 
-    def distortPoints(self, points):
+    def distort_points_on_image_plane(self, points):
         points = self.unprojectPoints(points, use_distortion=False)
         points = self.projectPoints(points, use_distortion=True)
         return points

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -285,10 +285,10 @@ class Fisheye_Dist_Camera(Camera_Model):
         self.name = name
 
     def update_camera_matrix(self, camera_matrix):
-        self.K = np.array(camera_matrix).reshape(self.K.shape)
+        self.K = np.asanyarray(camera_matrix).reshape(self.K.shape)
 
     def update_dist_coefs(self, dist_coefs):
-        self.D = np.array(dist_coefs).reshape(self.D.shape)
+        self.D = np.asanyarray(dist_coefs).reshape(self.D.shape)
 
     def undistort(self, img):
         """
@@ -482,10 +482,10 @@ class Radial_Dist_Camera(Camera_Model):
         self.name = name
 
     def update_camera_matrix(self, camera_matrix):
-        self.K = np.array(camera_matrix).reshape(self.K.shape)
+        self.K = np.asanyarray(camera_matrix).reshape(self.K.shape)
 
     def update_dist_coefs(self, dist_coefs):
-        self.D = np.array(dist_coefs).reshape(self.D.shape)
+        self.D = np.asanyarray(dist_coefs).reshape(self.D.shape)
 
     def undistort(self, img):
         """

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -432,12 +432,14 @@ class Fisheye_Dist_Camera(Camera_Model):
     ):
         try:
             uv3d = np.reshape(uv3d, (1, -1, 3))
+        except ValueError:
+            raise ValueError("uv3d is not 3d points")
+        try:
             xy = np.reshape(xy, (1, -1, 2))
         except ValueError:
-            raise ValueError
-
+            raise ValueError("xy is not 2d points")
         if uv3d.shape[1] != xy.shape[1]:
-            raise ValueError
+            raise ValueError("the number of 3d points and 2d points are not the same")
 
         xy_undist = self.undistort_points_on_image_plane(xy)
 
@@ -588,12 +590,14 @@ class Radial_Dist_Camera(Camera_Model):
     ):
         try:
             uv3d = np.reshape(uv3d, (1, -1, 3))
+        except ValueError:
+            raise ValueError("uv3d is not 3d points")
+        try:
             xy = np.reshape(xy, (1, -1, 2))
         except ValueError:
-            raise ValueError
-
+            raise ValueError("xy is not 2d points")
         if uv3d.shape[1] != xy.shape[1]:
-            raise ValueError
+            raise ValueError("the number of 3d points and 2d points are not the same")
 
         res = cv2.solvePnP(
             uv3d,

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -427,7 +427,7 @@ class Fisheye_Dist_Camera(Camera_Model):
             uv3d,
             xy_undist,
             self.K,
-            np.array([[0, 0, 0, 0, 0]]),
+            None,
             flags=flags,
             useExtrinsicGuess=useExtrinsicGuess,
             rvec=rvec,

--- a/pupil_src/shared_modules/head_pose_tracker/function/bundle_adjustment.py
+++ b/pupil_src/shared_modules/head_pose_tracker/function/bundle_adjustment.py
@@ -32,7 +32,7 @@ class BundleAdjustment:
         self._camera_intrinsics = camera_intrinsics
         self._optimize_camera_intrinsics = optimize_camera_intrinsics
         self._enough_samples = False
-        self._camera_intrinsics_params_size = 7
+        self._camera_intrinsics_params_size = 4 + camera_intrinsics.D.size
 
         self._tol = 1e-8
         self._diff_step = 1e-3
@@ -137,10 +137,10 @@ class BundleAdjustment:
         ).ravel()
 
         if self._optimize_camera_intrinsics and self._enough_samples:
-            camera_matrix_lower_bound = np.full((4,), 0)
-            camera_matrix_upper_bound = np.full((4,), 2000)
-            dist_coefs_lower_bound = np.full((3,), -1)
-            dist_coefs_upper_bound = np.full((3,), 1)
+            camera_matrix_lower_bound = np.full(4, 0)
+            camera_matrix_upper_bound = np.full(4, 2000)
+            dist_coefs_lower_bound = np.full(self._camera_intrinsics.D.size, -1)
+            dist_coefs_upper_bound = np.full(self._camera_intrinsics.D.size, 1)
             lower_bound = np.hstack(
                 (lower_bound, camera_matrix_lower_bound, dist_coefs_lower_bound)
             )
@@ -324,33 +324,25 @@ class BundleAdjustment:
         return frame_indices_failed, marker_indices_failed
 
     def _load_camera_intrinsics_params(self, camera_matrix, dist_coefs):
-        assert camera_matrix.shape == (3, 3) and dist_coefs.shape == (1, 5)
-        camera_intrinsics_params = np.zeros((self._camera_intrinsics_params_size,))
+        camera_intrinsics_params = np.zeros(self._camera_intrinsics_params_size)
 
         camera_intrinsics_params[0] = camera_matrix[0, 0]  # fx
         camera_intrinsics_params[1] = camera_matrix[1, 1]  # fy
         camera_intrinsics_params[2] = camera_matrix[0, 2]  # cx
         camera_intrinsics_params[3] = camera_matrix[1, 2]  # cy
 
-        camera_intrinsics_params[4] = dist_coefs[0, 0]
-        camera_intrinsics_params[5] = dist_coefs[0, 1]
-        camera_intrinsics_params[6] = dist_coefs[0, 4]
+        camera_intrinsics_params[4:] = dist_coefs.ravel()
 
         return camera_intrinsics_params
 
     def _unload_camera_intrinsics_params(self, camera_intrinsics_params):
-        assert camera_intrinsics_params.size == self._camera_intrinsics_params_size
-
         camera_matrix = np.eye(3)
         camera_matrix[0, 0] = camera_intrinsics_params[0]  # fx
         camera_matrix[1, 1] = camera_intrinsics_params[1]  # fy
         camera_matrix[0, 2] = camera_intrinsics_params[2]  # cx
         camera_matrix[1, 2] = camera_intrinsics_params[3]  # cy
 
-        dist_coefs = np.zeros((1, 5))
-        dist_coefs[0, 0] = camera_intrinsics_params[4]
-        dist_coefs[0, 1] = camera_intrinsics_params[5]
-        dist_coefs[0, 4] = camera_intrinsics_params[6]
+        dist_coefs = camera_intrinsics_params[4:]
 
         self._camera_intrinsics.update_camera_matrix(camera_matrix)
         self._camera_intrinsics.update_dist_coefs(dist_coefs)

--- a/pupil_src/shared_modules/head_pose_tracker/function/triangulate_marker.py
+++ b/pupil_src/shared_modules/head_pose_tracker/function/triangulate_marker.py
@@ -46,8 +46,12 @@ def _prepare_data_for_triangulation(
 
     points1 = np.array(detection_1["verts"], dtype=np.float32).reshape((4, 1, 2))
     points2 = np.array(detection_2["verts"], dtype=np.float32).reshape((4, 1, 2))
-    undistort_points1 = camera_intrinsics.undistortPoints(points1)
-    undistort_points2 = camera_intrinsics.undistortPoints(points2)
+    undistort_points1 = camera_intrinsics.undistort_points_to_ideal_point_coordinates(
+        points1
+    )
+    undistort_points2 = camera_intrinsics.undistort_points_to_ideal_point_coordinates(
+        points2
+    )
 
     data_for_triangulation = proj_mat1, proj_mat2, undistort_points1, undistort_points2
     return data_for_triangulation

--- a/pupil_src/shared_modules/surface_tracker/surface.py
+++ b/pupil_src/shared_modules/surface_tracker/surface.py
@@ -107,7 +107,7 @@ class Surface(abc.ABC):
 
         if compensate_distortion:
             orig_shape = points.shape
-            points = camera_model.undistortPoints(points)
+            points = camera_model.undistort_points_on_image_plane(points)
             points.shape = orig_shape
 
         points_on_surf = self._perspective_transform_points(points, trans_matrix)
@@ -253,7 +253,9 @@ class Surface(abc.ABC):
             registered_verts_dist, visible_verts_dist
         )
 
-        visible_verts_undist = camera_model.undistortPoints(visible_verts_dist)
+        visible_verts_undist = camera_model.undistort_points_on_image_plane(
+            visible_verts_dist
+        )
         img_to_surf_trans, surf_to_img_trans = Surface._find_homographies(
             registered_verts_undist, visible_verts_undist
         )
@@ -287,7 +289,7 @@ class Surface(abc.ABC):
             [m.verts_px for m in visible_markers.values()], dtype=np.float32
         )
         all_verts_dist.shape = (-1, 2)
-        all_verts_undist = camera_model.undistortPoints(all_verts_dist)
+        all_verts_undist = camera_model.undistort_points_on_image_plane(all_verts_dist)
 
         hull_undist = self._bounding_quadrangle(all_verts_undist)
         undist_img_to_surf_trans_candidate = self._get_trans_to_norm_corners(

--- a/pupil_src/shared_modules/update_methods.py
+++ b/pupil_src/shared_modules/update_methods.py
@@ -423,7 +423,7 @@ def update_recording_v111_v113(rec_dir):
 
         verts += 100
 
-        verts = intrinsics.undistortPoints(verts)
+        verts = intrinsics.undistort_points_on_image_plane(verts)
 
         verts -= 100
 


### PR DESCRIPTION
1. During [Merge branch 'master' into marc_surfaces_revamp](https://github.com/pupil-labs/pupil/commit/90b9be0), the definition of the function [undistortPoints](https://github.com/pupil-labs/pupil/blob/90b9be015759144469c7ecefb11a32730d9bbeee/pupil_src/shared_modules/camera_models.py#L547) was changed to fit Surfaces Revamp's usage. That would cause crush in head pose tracker during optimization of 3d markers model.
Therefore, `undistortPoints` is renamed as `undistort_points_on_image_plane` (for usages in e.g. Surfaces Revamp) and a new function `undistort_points_to_ideal_point_coordinates` is defined for the usages in head pose tracker.
1. Fix #1399: correct fisheye camera's solvePNP with None distortion.
1. Fix the intrinsic parameters in bundle adjustment for head pose tracker so that it can support the fisheye camera.

