### PR TITLE
Sample pupil timelines with float32 precision

### DIFF
--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -136,7 +136,9 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
                         pupil_positions.timestamps[0],
                         pupil_positions.timestamps[-1],
                     )
-                    timestamps_target = np.linspace(t0, t1, NUMBER_SAMPLES_TIMELINE)
+                    timestamps_target = np.linspace(
+                        t0, t1, NUMBER_SAMPLES_TIMELINE, dtype=np.float32
+                    )
 
                     data_indeces = np.searchsorted(
                         pupil_positions.timestamps, timestamps_target


### PR DESCRIPTION
Since the `pylgui.cygl.draw_points` shader does not support float64 precision, the sampled timestamps will be converted to float32. In cases in which float32 precision is not enough to sample a given number of distinct timestamps, the `pylgui.cygl.draw_points` function draws multiple (in float64 precision distinct timestamps) as a stack above each other.

This PR does not solve the issue of the float32 precision itself, but is just a work-around to avoid the stacked point drawings.