### PR TITLE
Pupil timeline sampling: Use pm.find_clostest to avoid IndexError

### DIFF
--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -140,7 +140,7 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
                         t0, t1, NUMBER_SAMPLES_TIMELINE, dtype=np.float32
                     )
 
-                    data_indeces = np.searchsorted(
+                    data_indeces = pm.find_closest(
                         pupil_positions.timestamps, timestamps_target
                     )
                     data_indeces = np.unique(data_indeces)


### PR DESCRIPTION
Follow up PR for #1563 to avoid
```
2019-07-31 18:09:06,760 - player - [ERROR] launchables.player: Process Player crashed with trace:
Traceback (most recent call last):
  File "launchables/player.py", line 504, in player
  File "shared_modules/plugin.py", line 319, in __init__
  File "shared_modules/plugin.py", line 361, in add
  File "shared_modules/pupil_producers.py", line 255, in init_ui
  File "shared_modules/pupil_producers.py", line 86, in init_ui
  File "shared_modules/pupil_producers.py", line 149, in cache_pupil_timeline_data
IndexError: index 3580 is out of bounds for axis 0 with size 3580
```