### PR TITLE
Add option to freeze current 3d eye model

### DIFF
--- a/pupil_src/shared_cpp/include/common/types.h
+++ b/pupil_src/shared_cpp/include/common/types.h
@@ -125,6 +125,7 @@ namespace singleeyefitter {
 
     struct Detector3DProperties {
         float model_sensitivity;
+        bool model_is_frozen;
     };
 
 } // singleeyefitter namespace

--- a/pupil_src/shared_modules/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
+++ b/pupil_src/shared_modules/pupil_detectors/Tests/SphereCircleTests/VisualizeSphere.py
@@ -18,7 +18,7 @@ sys.path.append(pupil_base_dir)
 pupil_base_dir = os.path.abspath(__file__).rsplit('pupil_src', 1)[0]
 sys.path.append(os.path.join(pupil_base_dir, 'pupil_src', 'shared_modules'))
 
-from visualizer_3d import Visualizer
+from pupil_detectors.visualizer_3d import Visualizer
 from glfw import *
 from OpenGL.GL import *
 from OpenGL.GLU import gluOrtho2D

--- a/pupil_src/shared_modules/pupil_detectors/__init__.py
+++ b/pupil_src/shared_modules/pupil_detectors/__init__.py
@@ -10,14 +10,16 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 try:
-    from .detector_2d import Detector_2D
+    from pupil_detectors.detector_2d import Detector_2D
 except ModuleNotFoundError:
     # when running from source compile cpp extension if necessary.
-    from .build import build_cpp_extension
-    build_cpp_extension()
-    from .detector_2d import Detector_2D
+    from pupil_detectors.build import build_cpp_extension
 
-from .detector_3d import Detector_3D
-from .detector_dummy import Detector_Dummy
+    build_cpp_extension()
+    from pupil_detectors.detector_2d import Detector_2D
+
+from pupil_detectors.detector_3d import Detector_3D
+from pupil_detectors.detector_dummy import Detector_Dummy
+
 # explicit import here for pyinstaller because it will not search .pyx source files.
-from .visualizer_3d import Eye_Visualizer
+from pupil_detectors.visualizer_3d import Eye_Visualizer

--- a/pupil_src/shared_modules/pupil_detectors/coarse_pupil.pxd
+++ b/pupil_src/shared_modules/pupil_detectors/coarse_pupil.pxd
@@ -66,8 +66,8 @@ cdef inline center_surround(int[:,::1] img, int min_w,int max_w):
     cdef point_t img_size
     img_size.r =  img.shape[0]
     img_size.c =  img.shape[1]
-    cdef int min_h = min_w/3
-    cdef int max_h = max_w/3
+    cdef int min_h = min_w // 3
+    cdef int max_h = max_w // 3
     cdef int h=0, i=0, j=0
     cdef float best_response = -10000
     cdef point_t best_pos

--- a/pupil_src/shared_modules/pupil_detectors/detector.pxd
+++ b/pupil_src/shared_modules/pupil_detectors/detector.pxd
@@ -9,10 +9,12 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libc.stdint cimport int32_t
+
 
 cdef extern from '<opencv2/core.hpp>':
 
@@ -148,7 +150,7 @@ cdef extern from 'common/types.h':
 
     cdef struct Detector3DProperties:
         float model_sensitivity
-
+        bool model_is_frozen
 
 
 

--- a/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_2d.pyx
@@ -1,3 +1,4 @@
+# cython: profile=False, language_level=3
 """
 (*)~---------------------------------------------------------------------------
 Pupil - eye tracking platform
@@ -9,7 +10,6 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-# cython: profile=False
 import math
 import sys
 

--- a/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
@@ -32,8 +32,7 @@ from gl_utils import (
     make_coord_system_pixel_based,
 )
 from plugin import Plugin
-from visualizer_3d import Eye_Visualizer
-
+from pupil_detectors.visualizer_3d import Eye_Visualizer
 
 cdef class Detector_3D:
 
@@ -100,6 +99,9 @@ cdef class Detector_3D:
 
         if not self.detectProperties3D:
             self.detectProperties3D["model_sensitivity"] = 0.997
+
+        # Never freeze model in the beginning to allow initial model fitting.
+        self.detectProperties3D["model_is_frozen"] = False
 
     def get_settings(self):
         return {'2D_Settings': self.detectProperties2D , '3D_Settings' : self.detectProperties3D }
@@ -223,8 +225,23 @@ cdef class Detector_3D:
         self.menu.append(info_3d)
         self.menu.append(ui.Button('Reset 3D model', self.reset_3D_Model ))
         self.menu.append(ui.Button('Open debug window',self.toggle_window))
-        self.menu.append(ui.Slider('model_sensitivity',self.detectProperties3D,label='Model sensitivity',min=0.990,max=1.0,step=0.0001))
-        self.menu[-1].display_format = '%0.4f'
+        model_sensitivity_slider = ui.Slider(
+            'model_sensitivity',
+            self.detectProperties3D,
+            label='Model sensitivity',
+            min=0.990,
+            max=1.0,
+            step=0.0001,
+        )
+        model_sensitivity_slider.display_format = '%0.4f'
+        self.menu.append(model_sensitivity_slider)
+        self.menu.append(
+            ui.Switch(
+                'model_is_frozen',
+                self.detectProperties3D,
+                label='Freeze model',
+            )
+        )
         # self.menu.append(ui.Slider('pupil_radius_min',self.detectProperties3D,label='Pupil min radius', min=1.0,max= 8.0,step=0.1))
         # self.menu.append(ui.Slider('pupil_radius_max',self.detectProperties3D,label='Pupil max radius', min=1.0,max=8.0,step=0.1))
         # self.menu.append(ui.Slider('max_fit_residual',self.detectProperties3D,label='3D fit max residual', min=0.00,max=0.1,step=0.0001))

--- a/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
+++ b/pupil_src/shared_modules/pupil_detectors/detector_3d.pyx
@@ -1,3 +1,4 @@
+# cython: profile=False, language_level=3
 """
 (*)~---------------------------------------------------------------------------
 Pupil - eye tracking platform
@@ -9,7 +10,6 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-# cython: profile=False
 import math
 from collections import namedtuple
 

--- a/pupil_src/shared_modules/pupil_detectors/setup.py
+++ b/pupil_src/shared_modules/pupil_detectors/setup.py
@@ -168,7 +168,7 @@ extensions = [
 if __name__ == "__main__":
     setup(
         name="pupil_detectors",
-        version="0.1",
+        version="0.2",
         url="https://github.com/pupil-labs/pupil",
         author="Pupil Labs",
         author_email="info@pupil-labs.com",

--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.cpp
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.cpp
@@ -93,7 +93,7 @@ EyeModel::~EyeModel(){
 }
 
 
-std::pair<Circle,ConfidenceValue> EyeModel::presentObservation(const ObservationPtr newObservationPtr, double averageFramerate )
+std::pair<Circle,ConfidenceValue> EyeModel::presentObservation(const ObservationPtr newObservationPtr, double averageFramerate, bool model_is_frozen)
 {
 
     if (mBirthTimestamp == -1){
@@ -140,7 +140,7 @@ std::pair<Circle,ConfidenceValue> EyeModel::presentObservation(const Observation
     }
      mModelMutex.unlock();
 
-    if (shouldAddObservation) {
+    if (!model_is_frozen && shouldAddObservation) {
         //if the observation passed all tests we can add it
         mSupportingPupilsToAdd.emplace_back( newObservationPtr );
 

--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.h
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModel.h
@@ -72,7 +72,7 @@ class EyeModel {
         ~EyeModel();
 
 
-        std::pair<Circle,ConfidenceValue> presentObservation(const ObservationPtr observation, double averageFramerate  );
+        std::pair<Circle,ConfidenceValue> presentObservation(const ObservationPtr observation, double averageFramerate, bool model_is_frozen);
         Sphere getSphere() const;
         Sphere getInitialSphere() const;
 

--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
@@ -72,6 +72,14 @@ Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResul
     result.timestamp = observation2D->timestamp;
 
     float modelSensitivity = props.model_sensitivity;
+    bool model_is_frozen = props.model_is_frozen;
+
+    if(model_is_frozen && mAlternativeModelsPtrs.size() > 0) {
+        // Model has been frozen. Remove any alternative models.
+        // They would not be updated during the freeze and just
+        // be out-of-date when the freeze is cancelled.
+        mAlternativeModelsPtrs.clear();
+    }
 
     double deltaTime = observation2D->timestamp - mLastFrameTimestamp;
     if( mLastFrameTimestamp != 0.0 ){
@@ -109,7 +117,8 @@ Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResul
     if (observation2D->confidence >= 0.7) {
 
         // allow each model to decide by themself if the new observation supports the model or not
-        auto circleAndFit = mActiveModelPtr->presentObservation(observation3DPtr, mAverageFramerate.getAverage()  );
+        // TODO: Pass freeze argument
+        auto circleAndFit = mActiveModelPtr->presentObservation(observation3DPtr, mAverageFramerate.getAverage(), model_is_frozen);
         auto circle = circleAndFit.first;
         auto observationFit = circleAndFit.second;
 
@@ -133,7 +142,7 @@ Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResul
         }
 
         for (auto& modelPtr : mAlternativeModelsPtrs) {
-             modelPtr->presentObservation(observation3DPtr, mAverageFramerate.getAverage() );
+             modelPtr->presentObservation(observation3DPtr, mAverageFramerate.getAverage(), model_is_frozen);
         }
 
     }
@@ -203,8 +212,10 @@ Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResul
         result.ellipse = Ellipse::Null;
    }
 
-    // contains the logic for building alternative models if the current one is bad
-    checkModels(modelSensitivity,observation2D->timestamp );
+    if (!model_is_frozen) {
+        // contains the logic for building alternative models if the current one is bad
+        checkModels(modelSensitivity,observation2D->timestamp );
+    }
     result.modelID = mActiveModelPtr->getModelID();
     result.modelBirthTimestamp = mActiveModelPtr->getBirthTimestamp();
     result.modelConfidence = mActiveModelPtr->getConfidence();

--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
@@ -117,7 +117,6 @@ Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResul
     if (observation2D->confidence >= 0.7) {
 
         // allow each model to decide by themself if the new observation supports the model or not
-        // TODO: Pass freeze argument
         auto circleAndFit = mActiveModelPtr->presentObservation(observation3DPtr, mAverageFramerate.getAverage(), model_is_frozen);
         auto circle = circleAndFit.first;
         auto observationFit = circleAndFit.second;


### PR DESCRIPTION
In some cases, one does not want the current eye model to change. This PR adds such an option to the 3d detector menu ("Freeze model") and the Pupil Detector Network API (#1390, `model_is_frozen` property).

**Warning**: Freezing the eye model will disable its ability to compensate for any kind of slippage.

You can freeze the eye model remotely by sending this notification to Pupil Capture:
```py
{
    "subject": "pupil_detector.set_property.3d",
    "name": "model_is_frozen",
    "value": True,  # set to False to unfreeze
    "target": "eye0",  # remove this line if you want to freeze the model both eyes
}
```