### PR TITLE
Surface Tracker Heatmap Resolution

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface.py
+++ b/pupil_src/shared_modules/surface_tracker/surface.py
@@ -528,7 +528,7 @@ class Surface(abc.ABC):
             hist *= (255.0 / hist_max) if hist_max else 0.0
             hist = hist.astype(np.uint8)
         else:
-            self.within_surface_heatmap = self.get_uniform_heatmap()
+            self.within_surface_heatmap = self.get_uniform_heatmap(grid)
             return
 
         color_map = cv2.applyColorMap(hist, cv2.COLORMAP_JET)
@@ -538,8 +538,11 @@ class Surface(abc.ABC):
             self.within_surface_heatmap[:, :, 3] = 125
         self.within_surface_heatmap[:, :, :3] = color_map
 
-    def get_uniform_heatmap(self):
-        hm = np.zeros((1, 1, 4), dtype=np.uint8)
+    def get_uniform_heatmap(self, resolution):
+        if len(resolution) != 2:
+            raise ValueError("resolution has to be two dimensional but found dimension {}!".format(len(resolution)))
+
+        hm = np.zeros((*resolution, 4), dtype=np.uint8)
         hm[:, :, :3] = cv2.applyColorMap(hm[:, :, :3], cv2.COLORMAP_JET)
         hm[:, :, 3] = 125
         return hm

--- a/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
@@ -312,7 +312,7 @@ class Surface_Tracker_Offline(Surface_Tracker, Analysis_Plugin_Base):
                 surface.across_surface_heatmap = heatmap
         else:
             for surface in self.surfaces:
-                surface.across_surface_heatmap = surface.get_uniform_heatmap()
+                surface.across_surface_heatmap = surface.get_uniform_heatmap((1,1))
 
     def _fill_gaze_on_surf_buffer(self):
         in_mark = self.g_pool.seek_control.trim_left


### PR DESCRIPTION
If no gaze data is available on a surface (either there is none or it is still being mapped in the background) the generated heatmap used to have resolution 1x1px. This PR changes this to always use the resolution implied by the smoothness value.