### PR TITLE
Surface tracker - fix GUI bugs

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -391,7 +391,7 @@ class GUI:
 
     def _on_click_menu_buttons(self, action, pos):
         if action == glfw.GLFW_PRESS:
-            for surface in self.tracker.surfaces:
+            for surface in reversed(self.tracker.surfaces):
 
                 if not surface.detected:
                     continue

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -385,7 +385,9 @@ class GUI:
             self._on_click_menu_buttons,
             self._on_click_marker_toggles,
         ]
-        _ = any(handler(action, pos) for handler in click_handlers_sorted_by_precedence)
+        for handler in click_handlers_sorted_by_precedence:
+            if handler(action, pos):
+                return
 
     def _on_click_menu_buttons(self, action, pos):
         if action == glfw.GLFW_PRESS:

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -380,12 +380,12 @@ class GUI:
 
     def on_click(self, pos, button, action):
         pos = np.array(pos, dtype=np.float32)
-        click_handlers = [
-            self._on_click_menu_buttons,
+        click_handlers_sorted_by_precedence = [
             self._on_click_corner_handles,
+            self._on_click_menu_buttons,
             self._on_click_marker_toggles,
         ]
-        _ = any(handler(action, pos) for handler in click_handlers)
+        _ = any(handler(action, pos) for handler in click_handlers_sorted_by_precedence)
 
     def _on_click_menu_buttons(self, action, pos):
         if action == glfw.GLFW_PRESS:

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -417,6 +417,7 @@ class GUI:
         return False  # click event not consumed
 
     def _on_click_corner_handles(self, action, pos):
+        was_event_consumed = False
         for surface in self._edit_surf_corners:
             if surface.detected and surface.defined:
                 img_corners = surface.map_from_surf(
@@ -428,7 +429,8 @@ class GUI:
                     dist = np.linalg.norm(corner - pos)
                     if action == glfw.GLFW_PRESS and dist < self.button_click_radius:
                         self.tracker._edit_surf_verts.append((surface, idx))
-                        return True  # click event consumed
+                        # click event consumed; give a chance for other surfaces' corners to react to it
+                        was_event_consumed = True
                     elif action == glfw.GLFW_RELEASE and self.tracker._edit_surf_verts:
                         self.tracker.notify_all(
                             {
@@ -438,9 +440,9 @@ class GUI:
                             }
                         )
                         self.tracker._edit_surf_verts = []
-                        return True  # click event consumed
+                        return True  # click event consumed; exit immediately
 
-        return False  # click event not consumed
+        return was_event_consumed
 
     def _on_click_marker_toggles(self, action, pos):
         if action == glfw.GLFW_PRESS:

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -424,20 +424,19 @@ class GUI:
                 )
                 for idx, corner in enumerate(img_corners):
                     dist = np.linalg.norm(corner - pos)
-                    if dist < self.button_click_radius:
-                        if action == glfw.GLFW_PRESS:
-                            self.tracker._edit_surf_verts.append((surface, idx))
-                            return True  # click event consumed
-                        elif action == glfw.GLFW_RELEASE:
-                            self.tracker.notify_all(
-                                {
-                                    "subject": "surface_tracker.surfaces_changed",
-                                    "name": surface.name,
-                                    "delay": SURFACE_TRACKER_CHANGED_DELAY,
-                                }
-                            )
-                            self.tracker._edit_surf_verts = []
-                            return True  # click event consumed
+                    if action == glfw.GLFW_PRESS and dist < self.button_click_radius:
+                        self.tracker._edit_surf_verts.append((surface, idx))
+                        return True  # click event consumed
+                    elif action == glfw.GLFW_RELEASE and self.tracker._edit_surf_verts:
+                        self.tracker.notify_all(
+                            {
+                                "subject": "surface_tracker.surfaces_changed",
+                                "name": surface.name,
+                                "delay": SURFACE_TRACKER_CHANGED_DELAY,
+                            }
+                        )
+                        self.tracker._edit_surf_verts = []
+                        return True  # click event consumed
 
         return False  # click event not consumed
 

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -380,9 +380,12 @@ class GUI:
 
     def on_click(self, pos, button, action):
         pos = np.array(pos, dtype=np.float32)
-        self._on_click_menu_buttons(action, pos)
-        self._on_click_corner_handles(action, pos)
-        self._on_click_marker_toggles(action, pos)
+        click_handlers = [
+            self._on_click_menu_buttons,
+            self._on_click_corner_handles,
+            self._on_click_marker_toggles,
+        ]
+        _ = any(handler(action, pos) for handler in click_handlers)
 
     def _on_click_menu_buttons(self, action, pos):
         if action == glfw.GLFW_PRESS:
@@ -400,12 +403,16 @@ class GUI:
                         self._edit_surf_corners.remove(surface)
                     else:
                         self._edit_surf_corners.add(surface)
+                    return True  # click event consumed
 
                 if marker_edit_pressed:
                     if surface in self._edit_surf_markers:
                         self._edit_surf_markers.remove(surface)
                     else:
                         self._edit_surf_markers.add(surface)
+                    return True  # click event consumed
+
+        return False  # click event not consumed
 
     def _on_click_corner_handles(self, action, pos):
         for surface in self._edit_surf_corners:
@@ -420,6 +427,7 @@ class GUI:
                     if dist < self.button_click_radius:
                         if action == glfw.GLFW_PRESS:
                             self.tracker._edit_surf_verts.append((surface, idx))
+                            return True  # click event consumed
                         elif action == glfw.GLFW_RELEASE:
                             self.tracker.notify_all(
                                 {
@@ -429,6 +437,9 @@ class GUI:
                                 }
                             )
                             self.tracker._edit_surf_verts = []
+                            return True  # click event consumed
+
+        return False  # click event not consumed
 
     def _on_click_marker_toggles(self, action, pos):
         if action == glfw.GLFW_PRESS:
@@ -452,6 +463,9 @@ class GUI:
                                 "delay": SURFACE_TRACKER_CHANGED_DELAY,
                             }
                         )
+                        return True  # click event consumed
+
+        return False  # click event not consumed
 
     def _check_surface_button_pressed(self, surface, pos):
         (


### PR DESCRIPTION
- Fixes issue (#1589) where it was impossible to separate overlapping surfaces, because enabling edit mode for one surface would enable it for both, and moving the corner of one surface would move both corners of the overlapping surfaces.
- Fixes issue (#1590) where attempting to move a surface's corner would result in that corner being stuck to the mouse pointer.
- Fixes issue where moving the corner of surface A under the "edit" button of surface B would then make it impossible to move that corner elsewhere.
