### PR TITLE
Correctly calculate different mean for all negative timejumps

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -335,7 +335,7 @@ class VideoSet:
         time_diff = np.diff(timestamps)
         invalid_idc = np.flatnonzero(time_diff < 0)
         timestamps[invalid_idc + 1] = np.mean(
-            (timestamps[invalid_idc + 2], timestamps[invalid_idc])
+            (timestamps[invalid_idc + 2], timestamps[invalid_idc]), axis=0
         )
         return timestamps
 


### PR DESCRIPTION
Before we calculated A SINGLE mean for all points.

This lead to a user-reported crash when using offline pupil detection with 3 negative time jumps in the eye video.