### PR TITLE
UVC Backend: Only call update_from_yuv_buffer if yuv subsampling is YUV422 

### DIFF
--- a/pupil_src/shared_modules/video_capture/base_backend.py
+++ b/pupil_src/shared_modules/video_capture/base_backend.py
@@ -9,15 +9,14 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+import logging
 from time import monotonic, sleep
-from plugin import Plugin
+
+import numpy as np
+from pyglui import cygl
 
 import gl_utils
-from pyglui import cygl
-import numpy as np
-
-
-import logging
+from plugin import Plugin
 
 logger = logging.getLogger(__name__)
 

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -9,15 +9,19 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import time
 import logging
-import uvc
-from version_utils import VersionFormat
-from .base_backend import InitialisationError, Base_Source, Base_Manager
-from camera_models import load_intrinsics
-from .utils import Check_Frame_Stripes, Exposure_Time
+import time
 
 import numpy as np
+import uvc
+from pyglui import cygl
+
+import gl_utils
+from camera_models import load_intrinsics
+from version_utils import VersionFormat
+
+from .base_backend import Base_Manager, Base_Source, InitialisationError
+from .utils import Check_Frame_Stripes, Exposure_Time
 
 # check versions for our own depedencies as they are fast-changing
 assert VersionFormat(uvc.__version__) >= VersionFormat("0.13")

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -9,6 +9,7 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+import enum
 import logging
 import time
 
@@ -29,6 +30,17 @@ assert VersionFormat(uvc.__version__) >= VersionFormat("0.13")
 # logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+class TJSAMP(enum.IntEnum):
+    """Reimplements turbojpeg.h TJSAMP"""
+
+    TJSAMP_444 = 0
+    TJSAMP_422 = 1
+    TJSAMP_420 = 2
+    TJSAMP_GRAY = 3
+    TJSAMP_440 = 4
+    TJSAMP_411 = 5
 
 
 class UVC_Source(Base_Source):

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -375,7 +375,6 @@ class UVC_Source(Base_Source):
     def recent_events(self, events):
         try:
             frame = self.uvc_capture.get_frame(0.05)
-            
             if np.isclose(frame.timestamp, 0):
                 # sometimes (probably only on windows) after disconnections, the first frame has 0 ts
                 logger.warning(
@@ -783,6 +782,30 @@ class UVC_Source(Base_Source):
             self.uvc_capture.close()
             self.uvc_capture = None
         super().cleanup()
+
+    def gl_display(self):
+        # Temporary copy of Base_Source.gl_display until proper frame class hierarchy
+        # is implemented
+        if self._recent_frame is not None:
+            frame = self._recent_frame
+            if (
+                # `frame.yuv_subsampling` is `None` without calling `frame.yuv_buffer`
+                frame.yuv_buffer is not None
+                and TJSAMP(frame.yuv_subsampling) == TJSAMP.TJSAMP_422
+            ):
+                self.g_pool.image_tex.update_from_yuv_buffer(
+                    frame.yuv_buffer, frame.width, frame.height
+                )
+            else:
+                self.g_pool.image_tex.update_from_ndarray(frame.bgr)
+            gl_utils.glFlush()
+        gl_utils.make_coord_system_norm_based()
+        self.g_pool.image_tex.draw()
+        if not self.online:
+            cygl.utils.draw_gl_texture(np.zeros((1, 1, 3), dtype=np.uint8), alpha=0.4)
+        gl_utils.make_coord_system_pixel_based(
+            (self.frame_size[1], self.frame_size[0], 3)
+        )
 
 
 class UVC_Manager(Base_Manager):


### PR DESCRIPTION
Previously, the uvc backend did not check the provided YUV subsampling if a YUV buffer was available. pyglui only supports YUV 422 subsampling. If `update_from_yuv_buffer` was called with a different subsampling than YUV 422 it resulted in instabilities and incorrect rendering.

The internal conversion from YUV to BGR takes the subsampling into account correctly. Therefore, `update_from_ndarray(frame.bgr)` works correctly.

This change was not implemented in `Base_Source` since not all backends provide the `yuv_subsampling` attribute.