### PR TITLE
Fix circle color change crash

### DIFF
--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -324,7 +324,8 @@ class Pupil_Recording:
 
 def transparent_circle(img, center, radius, color, thickness):
     center = tuple(map(int, center))
-    assert len(color) == 4 and all(type(c) == float and 0.0 <= c <= 1.0 for c in color)
+    assert len(color) == 4 and all(type(c) == float for c in color)
+    color = np.clip(color, 0.0, 1.0)  # sometimes the sliders returns values > 1.0
     bgr = [255 * c for c in color[:3]]  # convert to 0-255 scale for OpenCV
     alpha = color[-1]
     radius = int(radius)


### PR DESCRIPTION
Player crashed when moving the slider for the circle viz color to the limits.
pyglui seems to return values > 1.0 sometimes!

Fixes #1571 