### PR TITLE
Generate all lookup tables directly after updating a recording

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -717,7 +717,7 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_v
             assert_valid_recording_type,
             InvalidRecordingException,
         )
-        from pupil_recording import update_recording
+        from pupil_recording.update import update_recording
 
         def on_drop(window, count, paths):
             nonlocal rec_dir

--- a/pupil_src/shared_modules/pupil_recording/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/__init__.py
@@ -3,4 +3,3 @@ from packaging.version import Version
 from .info import RecordingInfoFile
 from .recording import PupilRecording
 from .recording_utils import InvalidRecordingException, assert_valid_recording_type
-from .update import update_recording


### PR DESCRIPTION
This is to improve the user experience as the UI will then still display "Recording is being updated" while possibly computing a large lookup table.
Otherwise this happened after the pre-drop windows closes and then there is no feedback when generating the lookup tables takes a long time.

The import changes in player.py and pupil_recording/__init__.py were necessary to avoid circular imports.