### PR TITLE
Remove all version parsing from Capture Software Version

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -151,12 +151,12 @@ class RecordingInfo(collections.abc.MutableMapping):
 
     @property
     @abc.abstractmethod
-    def recording_software_version(self) -> Version:
+    def recording_software_version(self) -> str:
         pass
 
     @recording_software_version.setter
     @abc.abstractmethod
-    def recording_software_version(self, value: Version):
+    def recording_software_version(self, value: str):
         pass
 
     @property

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_0.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_0.py
@@ -81,12 +81,12 @@ class _RecordingInfoFile_2_0(RecordingInfoFile):
         self["recording_software_name"] = str(value)
 
     @property
-    def recording_software_version(self) -> Version:
-        return Version(self["recording_software_version"])
+    def recording_software_version(self) -> str:
+        return self["recording_software_version"]
 
     @recording_software_version.setter
-    def recording_software_version(self, value: Version):
-        self["recording_software_version"] = utils.string_from_recording_version(value)
+    def recording_software_version(self, value: str):
+        self["recording_software_version"] = value
 
     @property
     def recording_name(self) -> str:

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -69,7 +69,7 @@ def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
     start_time_synced_ns = int(info_json["start_time"])
     duration_ns = int(info_json["duration"])
     recording_software_name = RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
-    recording_software_version = Version(info_json["app_version"])
+    recording_software_version = info_json["app_version"]
     recording_name = utils.default_recording_name(rec_dir)
     system_info = android_system_info(info_json)
 

--- a/pupil_src/shared_modules/pupil_recording/update/mobile.py
+++ b/pupil_src/shared_modules/pupil_recording/update/mobile.py
@@ -71,7 +71,7 @@ def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
     start_time_synced_s = float(info_csv["Start Time (Synced)"])
     duration_s = utils.parse_duration_string(info_csv["Duration Time"])
     recording_software_name = info_csv["Capture Software"]
-    recording_software_version = Version(info_csv["Capture Software Version"])
+    recording_software_version = info_csv["Capture Software Version"]
     recording_name = info_csv.get(
         "Recording Name", utils.default_recording_name(rec_dir)
     )

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -61,7 +61,7 @@ def _generate_pprf_2_0_info_file(rec_dir):
         recording_software_name = info_csv.get(
             "Capture Software", RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
         )
-        recording_software_version = Version(info_csv["Capture Software Version"])
+        recording_software_version = info_csv["Capture Software Version"]
         recording_name = info_csv.get(
             "Recording Name", rec_info_utils.default_recording_name(rec_dir)
         )

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -327,7 +327,7 @@ class Recorder(System_Plugin_Base):
         self.meta_info.recording_software_name = (
             RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
         )
-        self.meta_info.recording_software_version = Version(self.g_pool.version.vstring)
+        self.meta_info.recording_software_version = self.g_pool.version.vstring
         self.meta_info.recording_name = self.session_name
         self.meta_info.start_time_synced_s = start_time_synced
         self.meta_info.start_time_system_s = self.start_time


### PR DESCRIPTION
This is because we are using different underlying version formats, e.g. Pupil Invisible might use semantic versioning for it's app_version.
Since we don't know anything about the version format and we only use it for display, we can savely just treat it as a string.