### PR TITLE
Fix missing info crash

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -112,7 +112,10 @@ def _is_pupil_invisible_recording(rec_dir: str) -> bool:
 
 
 def _is_pupil_mobile_recording(rec_dir: str) -> bool:
-    info_csv = recording_info_utils.read_info_csv_file(rec_dir)
+    try:
+        info_csv = recording_info_utils.read_info_csv_file(rec_dir)
+    except FileNotFoundError:
+        return False
     try:
         return (
             info_csv["Capture Software"] == "Pupil Mobile"

--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -114,14 +114,11 @@ def _is_pupil_invisible_recording(rec_dir: str) -> bool:
 def _is_pupil_mobile_recording(rec_dir: str) -> bool:
     try:
         info_csv = recording_info_utils.read_info_csv_file(rec_dir)
-    except FileNotFoundError:
-        return False
-    try:
         return (
             info_csv["Capture Software"] == "Pupil Mobile"
             and "Data Format Version" not in info_csv
         )
-    except KeyError:
+    except (KeyError, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
We forgot to handle the case where info.csv does not exist.
Returning False will just handle this gracefully via a UI message.