### PR TITLE
Catch pi duplicate world videos

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -773,9 +773,11 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_v
                     tip = "This may take a while!"
                 except InvalidRecordingException as err:
                     logger.error(str(err))
-                    tip = err.reason
                     if err.recovery:
-                        tip += " " + err.recovery + "."
+                        text = err.reason
+                        tip = err.recovery
+                    else:
+                        tip = err.reason
                     rec_dir = None
 
             gl_utils.clear_gl_screen()
@@ -803,9 +805,11 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_v
                     rec_dir = None
                 except InvalidRecordingException as err:
                     logger.error(str(err))
-                    tip = err.reason
                     if err.recovery:
-                        tip += " " + err.recovery + "."
+                        text = err.reason
+                        tip = err.recovery
+                    else:
+                        tip = err.reason
                     rec_dir = None
                 else:
                     glfw.glfwSetWindowShouldClose(window, True)

--- a/pupil_src/shared_modules/pupil_recording/update/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/update/__init__.py
@@ -36,27 +36,21 @@ def update_recording(rec_dir: str):
         # The recording is un-usable in this case, since the time information is lost.
         # Trying to open the recording will crash in the lookup-table generation. We
         # just gracefully exit here and display an error message.
-        PI_world_videos = PupilRecording.FileFilter(rec_dir).pi().world().videos()
-        name_stems = [path.stem for path in PI_world_videos]
-        unique_name_stems = set(name_stems)
-        # the assumption here is that we should have only one file per name stem
-        if len(name_stems) != len(unique_name_stems):
-            duplicate_stems = [
-                unique_stem
-                for unique_stem in unique_name_stems
-                if name_stems.count(unique_stem) > 1
-            ]
-            duplicate_videos = [
-                path.name for path in PI_world_videos if path.stem in duplicate_stems
+        mjpeg_world_videos = (
+            PupilRecording.FileFilter(rec_dir).pi().world().filter_patterns(".mjpeg$")
+        )
+        if mjpeg_world_videos:
+            videos = [
+                path.name
+                for path in PupilRecording.FileFilter(rec_dir).pi().world().videos()
             ]
             logger.error(
-                "Found duplicate video stems for this Pupil Invisible recording!"
-                " Please each out to info@pupil-labs.com for support!\n"
-                f"Duplicate videos: {', '.join(duplicate_videos)}"
+                "Found mjpeg world videos for this Pupil Invisible recording! Videos:\n"
+                + ",\n".join(videos)
             )
             raise InvalidRecordingException(
                 "This recording cannot be opened in Player.",
-                "Please each out to info@pupil-labs.com for support!",
+                recovery="Please reach out to info@pupil-labs.com for support!",
             )
 
     if recording_type in _transformations_to_new_style:


### PR DESCRIPTION
There is a known issue where multipart PI recordings sometimes have a world.mp4 and world.mjpeg file for the same part. Since the time information is lost, we cannot open these recordings.
Still we can gracefully handle this case and display an error message instead of crashing.