### PR TITLE
Add missing license headers

### DIFF
--- a/pupil_src/shared_modules/head_pose_tracker/worker/export_worker.py
+++ b/pupil_src/shared_modules/head_pose_tracker/worker/export_worker.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import csv
 import os
 import logging

--- a/pupil_src/shared_modules/pupil_recording/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/__init__.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 from packaging.version import Version
 
 from .info import RecordingInfoFile

--- a/pupil_src/shared_modules/pupil_recording/info/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/info/__init__.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 from .. import Version
 from .recording_info import RecordingInfoFile
 from .recording_info_2_0 import _RecordingInfoFile_2_0

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 import collections
 import json

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_0.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_0.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import uuid
 
 from . import RecordingInfoFile, Version

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_test.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_test.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import uuid
 

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import json
 import os
 import typing as T

--- a/pupil_src/shared_modules/pupil_recording/recording.py
+++ b/pupil_src/shared_modules/pupil_recording/recording.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import collections
 import enum
 import logging

--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import enum
 from pathlib import Path
 

--- a/pupil_src/shared_modules/pupil_recording/test_fixtures/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/test_fixtures/__init__.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import enum
 import json
 import os

--- a/pupil_src/shared_modules/pupil_recording/update/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/update/__init__.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 from types import SimpleNamespace
 

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 import re
 from pathlib import Path

--- a/pupil_src/shared_modules/pupil_recording/update/mobile.py
+++ b/pupil_src/shared_modules/pupil_recording/update/mobile.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 import re
 import uuid

--- a/pupil_src/shared_modules/pupil_recording/update/new_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/new_style.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 from pathlib import Path
 

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -8,6 +8,7 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
+
 import collections
 import glob
 import logging

--- a/pupil_src/shared_modules/pupil_recording/update/update_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/update/update_utils.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 import typing as T
 from pathlib import Path

--- a/pupil_src/shared_modules/stdlib_utils.py
+++ b/pupil_src/shared_modules/stdlib_utils.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import typing
 import functools
 import itertools

--- a/pupil_src/shared_modules/surface_tracker/surface_file_store.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_file_store.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 import functools
 import logging

--- a/pupil_src/shared_modules/surface_tracker/surface_file_store_test.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_file_store_test.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import sys
 import numpy as np

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 import functools
 import logging

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer_test.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer_test.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import sys
 

--- a/pupil_src/shared_modules/surface_tracker/test_fixtures/__init__.py
+++ b/pupil_src/shared_modules/surface_tracker/test_fixtures/__init__.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import typing
 from surface_tracker.surface import Surface
 from surface_tracker.surface_marker_aggregate import Surface_Marker_Aggregate

--- a/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_definition_files.py
+++ b/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_definition_files.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import tempfile
 import typing

--- a/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v00_square.py
+++ b/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v00_square.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import typing
 import numpy as np
 

--- a/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v01_apriltag.py
+++ b/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v01_apriltag.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import typing
 import numpy as np
 

--- a/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v01_square.py
+++ b/pupil_src/shared_modules/surface_tracker/test_fixtures/fixtures_surface_v01_square.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import typing
 import numpy as np
 

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 
 import numpy as np

--- a/pupil_src/shared_modules/video_capture/tests/common.py
+++ b/pupil_src/shared_modules/video_capture/tests/common.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 
 broken_data = os.path.join(

--- a/pupil_src/shared_modules/video_capture/tests/conftest.py
+++ b/pupil_src/shared_modules/video_capture/tests/conftest.py
@@ -1,1 +1,12 @@
-pytest_plugins = 'pytester'
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+pytest_plugins = "pytester"

--- a/pupil_src/shared_modules/video_capture/tests/file_backend/test_file_backend.py
+++ b/pupil_src/shared_modules/video_capture/tests/file_backend/test_file_backend.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 from multiprocessing import cpu_count
 from types import SimpleNamespace

--- a/pupil_src/shared_modules/video_capture/tests/utils/test_utils.py
+++ b/pupil_src/shared_modules/video_capture/tests/utils/test_utils.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import pytest
 from video_capture.utils import RenameSet

--- a/pupil_src/shared_modules/video_overlay/__init__.py
+++ b/pupil_src/shared_modules/video_overlay/__init__.py
@@ -1,0 +1,10 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""

--- a/pupil_src/shared_modules/video_overlay/controllers/overlay_manager.py
+++ b/pupil_src/shared_modules/video_overlay/controllers/overlay_manager.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 from storage import SingleFileStorage
 from video_overlay.models.config import Configuration

--- a/pupil_src/shared_modules/video_overlay/models/config.py
+++ b/pupil_src/shared_modules/video_overlay/models/config.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 from storage import StorageItem
 
 from video_overlay.utils.constraints import (

--- a/pupil_src/shared_modules/video_overlay/plugins/__init__.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/__init__.py
@@ -1,2 +1,13 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 from video_overlay.plugins.generic_overlay import Video_Overlay
 from video_overlay.plugins.eye_overlay import Eye_Overlay

--- a/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import os
 import glob
 

--- a/pupil_src/shared_modules/video_overlay/plugins/generic_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/generic_overlay.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import collections
 import os
 

--- a/pupil_src/shared_modules/video_overlay/ui/interactions.py
+++ b/pupil_src/shared_modules/video_overlay/ui/interactions.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 from glfw import getHDPIFactor, glfwGetCurrentContext, glfwGetCursorPos, GLFW_PRESS
 from methods import normalize, denormalize
 

--- a/pupil_src/shared_modules/video_overlay/ui/management.py
+++ b/pupil_src/shared_modules/video_overlay/ui/management.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 import weakref
 from collections import OrderedDict

--- a/pupil_src/shared_modules/video_overlay/ui/menu.py
+++ b/pupil_src/shared_modules/video_overlay/ui/menu.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 import os
 import weakref

--- a/pupil_src/shared_modules/video_overlay/utils/constraints.py
+++ b/pupil_src/shared_modules/video_overlay/utils/constraints.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 
 INF = float("inf")

--- a/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
+++ b/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import abc
 
 import cv2

--- a/pupil_src/shared_modules/video_overlay/workers/frame_fetcher.py
+++ b/pupil_src/shared_modules/video_overlay/workers/frame_fetcher.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 from types import SimpleNamespace
 

--- a/pupil_src/shared_modules/video_overlay/workers/overlay_renderer.py
+++ b/pupil_src/shared_modules/video_overlay/workers/overlay_renderer.py
@@ -1,3 +1,14 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
 import logging
 from collections import OrderedDict
 


### PR DESCRIPTION
I added the license headers we forgot when creating the pupil_recording submodule.
I also searched across the codebase and added license headers in places where they were missing so far as well.