### PR TITLE
Fix old info references

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -261,7 +261,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         File_Source(
             g_pool,
             timing="external",
-            source_path=str(video_path),
+            source_path=video_path,
             buffered_decoding=True,
             fill_gaps=True,
         )

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -257,11 +257,11 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         g_pool.plugin_by_name = {p.__name__: p for p in plugins}
         g_pool.camera_render_size = None
 
-        video_path = recording.files().core().world().videos()[0]
+        video_path = recording.files().core().world().videos()[0].resolve()
         File_Source(
             g_pool,
             timing="external",
-            source_path=video_path,
+            source_path=str(video_path),
             buffered_decoding=True,
             fill_gaps=True,
         )

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -17,6 +17,7 @@ from gaze_producer.gaze_producer_base import GazeProducerBase
 from observable import Observable
 from plugin_timeline import PluginTimeline
 from tasklib.manager import PluginTaskManager
+from pupil_recording import PupilRecording
 
 
 # IMPORTANT: GazeProducerBase needs to be THE LAST in the list of bases, otherwise
@@ -33,7 +34,7 @@ class GazeFromOfflineCalibration(Observable, GazeProducerBase):
 
         self._task_manager = PluginTaskManager(plugin=self)
 
-        self._recording_uuid = self._load_recording_uuid_from_info_csv()
+        self._recording_uuid = PupilRecording(g_pool.rec_dir).meta_info.recording_uuid
 
         self._setup_storages()
         self._setup_controllers()
@@ -209,9 +210,3 @@ class GazeFromOfflineCalibration(Observable, GazeProducerBase):
         minutes = abs(time // 60)  # abs because it's sometimes -0
         seconds = round(time % 60)
         return "{:02.0f}:{:02.0f}".format(minutes, seconds)
-
-    def _load_recording_uuid_from_info_csv(self):
-        info_csv_path = os.path.join(self.g_pool.rec_dir, "info.csv")
-        with open(info_csv_path, "r", encoding="utf-8") as csv_file:
-            recording_info = csv_utils.read_key_value_file(csv_file)
-            return recording_info["Recording UUID"]

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -8,16 +8,14 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import os
-
-import csv_utils
 import data_changed
-from gaze_producer import ui as plugin_ui, controller, model
+from gaze_producer import controller, model
+from gaze_producer import ui as plugin_ui
 from gaze_producer.gaze_producer_base import GazeProducerBase
 from observable import Observable
 from plugin_timeline import PluginTimeline
-from tasklib.manager import PluginTaskManager
 from pupil_recording import PupilRecording
+from tasklib.manager import PluginTaskManager
 
 
 # IMPORTANT: GazeProducerBase needs to be THE LAST in the list of bases, otherwise

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -29,7 +29,7 @@ class CalibrationStorage(Storage, Observable):
         super().__init__(plugin)
         self._rec_dir = rec_dir
         self._get_recording_index_range = get_recording_index_range
-        self._recording_uuid = recording_uuid
+        self._recording_uuid = str(recording_uuid)
         self._calibrations = []
         self._load_from_disk()
         if not self._calibrations:

--- a/pupil_src/shared_modules/head_pose_tracker/offline_head_pose_tracker.py
+++ b/pupil_src/shared_modules/head_pose_tracker/offline_head_pose_tracker.py
@@ -9,12 +9,11 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import os
-
-import csv_utils
 import player_methods as pm
-from head_pose_tracker import ui as plugin_ui, controller, storage
+from head_pose_tracker import controller, storage
+from head_pose_tracker import ui as plugin_ui
 from plugin_timeline import PluginTimeline
+from pupil_recording import PupilRecording
 from tasklib.manager import PluginTaskManager
 
 from .base_head_pose_tracker import Head_Pose_Tracker_Base
@@ -30,7 +29,9 @@ class Offline_Head_Pose_Tracker(Head_Pose_Tracker_Base):
         super().__init__(g_pool)
 
         self._task_manager = PluginTaskManager(plugin=self)
-        self._current_recording_uuid = self._load_recording_uuid_from_info_csv()
+        self._current_recording_uuid = str(
+            PupilRecording(g_pool.rec_dir).meta_info.recording_uuid
+        )
 
         self._setup_storages()
         self._setup_controllers()
@@ -200,12 +201,6 @@ class Offline_Head_Pose_Tracker(Head_Pose_Tracker_Base):
         minutes = abs(time // 60)  # abs because it's sometimes -0
         seconds = round(time % 60)
         return "{:02.0f}:{:02.0f}".format(minutes, seconds)
-
-    def _load_recording_uuid_from_info_csv(self):
-        info_csv_path = os.path.join(self.g_pool.rec_dir, "info.csv")
-        with open(info_csv_path, "r", encoding="utf-8") as csv_file:
-            recording_info = csv_utils.read_key_value_file(csv_file)
-            return recording_info["Recording UUID"]
 
     def get_current_frame_index(self):
         return self.g_pool.capture.get_frame_index()

--- a/pupil_src/shared_modules/pupil_recording/update/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/update/__init__.py
@@ -95,8 +95,9 @@ def _generate_all_lookup_tables(rec_dir: str):
     for videos in videosets:
         if not videos:
             continue
+        source_path = str(videos[0].resolve())
         File_Source(
-            SimpleNamespace(), source_path=videos[0], fill_gaps=True, timing=None
+            SimpleNamespace(), source_path=source_path, fill_gaps=True, timing=None
         )
 
 

--- a/pupil_src/shared_modules/pupil_recording/update/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/update/__init__.py
@@ -95,7 +95,7 @@ def _generate_all_lookup_tables(rec_dir: str):
     for videos in videosets:
         if not videos:
             continue
-        source_path = str(videos[0].resolve())
+        source_path = videos[0].resolve()
         File_Source(
             SimpleNamespace(), source_path=source_path, fill_gaps=True, timing=None
         )

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -213,14 +213,13 @@ class File_Source(Playback_Source, Base_Source):
         *args,
         **kwargs,
     ):
-        assert isinstance(source_path, str), "source_path needs to be 'str'"
         super().__init__(g_pool, *args, **kwargs)
         if self.timing == "external":
             self.recent_events = self.recent_events_external_timing
         else:
             self.recent_events = self.recent_events_own_timing
         # minimal attribute set
-        self.source_path = source_path
+        self.source_path = str(source_path)
         self.loop = loop
         self.fill_gaps = fill_gaps
         rec, set_name = self.get_rec_set_name(self.source_path)

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -213,6 +213,7 @@ class File_Source(Playback_Source, Base_Source):
         *args,
         **kwargs,
     ):
+        assert isinstance(source_path, str), "source_path needs to be 'str'"
         super().__init__(g_pool, *args, **kwargs)
         if self.timing == "external":
             self.recent_events = self.recent_events_external_timing

--- a/pupil_src/shared_modules/video_export/plugins/imotions_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/imotions_exporter.py
@@ -145,7 +145,7 @@ def _copy_info_csv(source_folder, destination_folder):
         logger.error("Error while exporting iMotions data. World video not found!")
         return
 
-    cap = File_Source(SimpleNamespace(), str(world_video))
+    cap = File_Source(SimpleNamespace(), world_video)
     world_frames = cap.get_frame_count()
     world_resolution = f"{cap.frame_size[0]}x{cap.frame_size[1]}"
 

--- a/pupil_src/shared_modules/video_export/plugins/imotions_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/imotions_exporter.py
@@ -10,14 +10,16 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import csv
+import datetime
 import logging
 import os
-from shutil import copy2
+from types import SimpleNamespace
 
 import csv_utils
 import player_methods as pm
 from methods import denormalize
 from pupil_recording import PupilRecording
+from video_capture.file_backend import File_Source
 from video_export.plugin_base.isolated_frame_exporter import IsolatedFrameExporter
 
 logger = logging.getLogger(__name__)
@@ -64,10 +66,11 @@ class iMotions_Exporter(IsolatedFrameExporter):
     def export_data(self, export_range, export_dir):
 
         pupil_recording = PupilRecording(rec_dir=self.g_pool.rec_dir)
+        meta = pupil_recording.meta_info
 
-        if pupil_recording.is_pupil_invisible:
+        if meta.recording_software_name == meta.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
             logger.error(
-                "Currently, the iMotions export doesn't support Pupil Invisible recordings"
+                "The iMotions exporter does not yet support Pupil Invisible recordings!"
             )
             return
 
@@ -118,18 +121,60 @@ def _process_frame(capture, frame):
 
 
 def _copy_info_csv(source_folder, destination_folder):
-    info_src = os.path.join(source_folder, "info.csv")
+    # TODO: The iMotions export still relies on the old-style info.csv, so we have to
+    # generate this here manually. We should clarify with iMotions whether we can update
+    # this to our new recording format.
+    recording = PupilRecording(source_folder)
+    meta = recording.meta_info
+
+    # NOTE: This is potentially incorrect, since we don't know the timezone. But we are
+    # keeping this format for backwards compatibility with the old-style info.csv.
+    start_datetime = datetime.datetime.fromtimestamp(meta.start_time_system_s)
+    start_date = start_datetime.strftime("%d.%m.%Y")
+    start_time = start_datetime.strftime("%H:%M:%S")
+
+    duration_full_s = meta.duration_s
+    duration_h = int(duration_full_s // 3600)
+    duration_m = int((duration_full_s % 3600) // 60)
+    duration_s = int(round(duration_full_s % 3600 % 60))
+    duration_time = f"{duration_h:02}:{duration_m:02}:{duration_s:02}"
+
+    try:
+        world_video = recording.files().core().world().videos()[0]
+    except IndexError:
+        logger.error("Error while exporting iMotions data. World video not found!")
+        return
+
+    cap = File_Source(SimpleNamespace(), str(world_video))
+    world_frames = cap.get_frame_count()
+    world_resolution = f"{cap.frame_size[0]}x{cap.frame_size[1]}"
+
+    data = {}
+    data["Recording Name"] = meta.recording_name
+    data["Start Data"] = start_date
+    data["Start Time"] = start_time
+    data["Start Time (System)"] = meta.start_time_system_s
+    data["Start Time (Synced)"] = meta.start_time_synced_s
+    data["Recording UUID"] = str(meta.recording_uuid)
+    data["Duration Time"] = duration_time
+    data["World Camera Frames"] = world_frames
+    data["World Camera Resolution"] = world_resolution
+    data["Capture Software Version"] = meta.recording_software_version
+    data["Data Format Version"] = str(meta.min_player_version)
+    data["System Info"] = meta.system_info
+
     info_dest = os.path.join(destination_folder, "iMotions_info.csv")
-    copy2(info_src, info_dest)
+    with open(info_dest, "w", newline="", encoding="utf-8") as f:
+        csv_utils.write_key_value_file(f, data)
 
 
 def _get_recording_start_date(source_folder):
-    csv_loc = os.path.join(source_folder, "info.csv")
-    with open(csv_loc, "r", encoding="utf-8") as csv_file:
-        rec_info = csv_utils.read_key_value_file(csv_file)
-        date = rec_info["Start Date"].replace(".", "_").replace(":", "_")
-        time = rec_info["Start Time"].replace(":", "_")
-    return "{}_{}".format(date, time)
+    recording = PupilRecording(source_folder)
+    meta = recording.meta_info
+    # NOTE: This is potentially incorrect, since we don't know the timezone. But we are
+    # keeping this format for backwards compatibility with the old-style info.csv.
+    start_datetime = datetime.datetime.fromtimestamp(meta.start_time_system_s)
+    return start_datetime.strftime("%d_%m_%Y_%H_%M_%S")
 
 
 class _iMotionsExporterNo3DGazeDataError(Exception):

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -169,7 +169,7 @@ def _export_world_video(
         if not videos:
             raise FileNotFoundError("No world video found")
 
-        source_path = str(videos[0].resolve())
+        source_path = videos[0].resolve()
         cap = File_Source(g_pool, source_path=source_path, fill_gaps=True, timing=None)
         if not cap.initialised:
             warn = "Trying to export zero-duration world video."

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -169,7 +169,8 @@ def _export_world_video(
         if not videos:
             raise FileNotFoundError("No world video found")
 
-        cap = File_Source(g_pool, source_path=videos[0], fill_gaps=True, timing=None)
+        source_path = str(videos[0].resolve())
+        cap = File_Source(g_pool, source_path=source_path, fill_gaps=True, timing=None)
         if not cap.initialised:
             warn = "Trying to export zero-duration world video."
             logger.warning(warn)


### PR DESCRIPTION
When updating our recording format to the new info.player.json, we forgot to cleanup some references to the old-style info.csv that would crash when ran.

I patched up the offline calibration and head pose tracker quickly to use the new interface.
Some adjustments were required in order to make the new info data serializeable for background tasks.

The iMotions exporter needed some more work though since it requires to export an old-style info.csv which we now generate on export.