### PR TITLE
Fix frameless recordings in Capture

### DIFF
--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -183,16 +183,17 @@ class AV_Writer(abc.ABC):
             logger.warning("Trying to close container multiple times!")
             return
 
-        # flush stream
-        for packet in self.video_stream.encode(None):
-            self.container.mux(packet)
+        if self.configured:
+            # at least one frame has been written, flush stream
+            for packet in self.video_stream.encode(None):
+                self.container.mux(packet)
+
+            if timestamp_export_format is not None:
+                write_timestamps(
+                    self.output_file_path, self.timestamps, timestamp_export_format
+                )
 
         self.container.close()
-
-        if timestamp_export_format is not None:
-            write_timestamps(
-                self.output_file_path, self.timestamps, timestamp_export_format
-            )
         self.closed = True
 
     def release(self):


### PR DESCRIPTION
AV_Writer crashes on closing if the stream has not been configured correctly. Since AV_Writer only configures itself, after receiving at least one frame, a frameless recording resulted in an incorrectly configured stream and crashed Capture.

This PR only flushes the stream and writes timestamps if there was at least one frame.