### PR TITLE
Offline Calibration: Compare uuids correctly

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
@@ -27,7 +27,7 @@ class CalibrationController(Observable):
         self._reference_location_storage = reference_location_storage
         self._task_manager = task_manager
         self._get_current_trim_mark_range = get_current_trim_mark_range
-        self._recording_uuid = recording_uuid
+        self._recording_uuid = str(recording_uuid)
 
     def calculate(self, calibration):
         def on_calibration_completed(status_and_result):


### PR DESCRIPTION
Fixes #1656

Problem:
`calibration.recording_uuid == self._recording_uuid` evaluates to `False` if one object is an UUID object, and the other a string. `calibration.recording_uuid` is a string for serialization reasons.

/cc @pfaion 