### PR TITLE
Support pre v1.3/r0.21.0 recordings in v1.16

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/mobile.py
+++ b/pupil_src/shared_modules/pupil_recording/update/mobile.py
@@ -9,10 +9,13 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+import datetime
 import logging
 import re
 import uuid
 from pathlib import Path
+
+import numpy as np
 
 from .. import Version
 from ..info import RecordingInfoFile
@@ -76,17 +79,34 @@ def _transform_mobile_v1_2_to_pprf_2_0(rec_dir: str):
 def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
     info_csv = utils.read_info_csv_file(rec_dir)
 
-    # Get information about recording from info.csv
-    recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
-    start_time_system_s = float(info_csv["Start Time (System)"])
-    start_time_synced_s = float(info_csv["Start Time (Synced)"])
-    duration_s = utils.parse_duration_string(info_csv["Duration Time"])
-    recording_software_name = info_csv["Capture Software"]
-    recording_software_version = info_csv["Capture Software Version"]
-    recording_name = info_csv.get(
-        "Recording Name", utils.default_recording_name(rec_dir)
-    )
-    system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
+    try:
+        # Get information about recording from info.csv
+        recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
+
+        # Allow inference of missing values in v1.16
+        # TODO: Remove value inference in v1.17
+        start_time_system_s = float(
+            info_csv.get(
+                "Start Time (System)", _infer_start_time_system_from_legacy(info_csv)
+            )
+        )
+        start_time_synced_s = float(
+            info_csv.get(
+                "Start Time (Synced)", _infer_start_time_synced_from_legacy(rec_dir)
+            )
+        )
+        duration_s = utils.parse_duration_string(info_csv["Duration Time"])
+        recording_software_name = info_csv["Capture Software"]
+        recording_software_version = info_csv["Capture Software Version"]
+        recording_name = info_csv.get(
+            "Recording Name", utils.default_recording_name(rec_dir)
+        )
+        system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
+    except KeyError as e:
+        logger.debug(f"KeyError while parsing old-style info.csv: {str(e)}")
+        raise InvalidRecordingException(
+            "This recording is too old to be opened with this version of Player!"
+        )
 
     # Create a recording info file with the new format, fill out
     # the information, validate, and return.
@@ -124,3 +144,73 @@ def _rename_mobile_files(recording: PupilRecording):
 
 def _rewrite_timestamps(recording: PupilRecording):
     update_utils._rewrite_times(recording, dtype=">f8")
+
+
+def _infer_start_time_system_from_legacy(info_csv):
+    _warn_imprecise_value_inference()
+    logger.warning(f"Missing meta info key: `Start Time (System)`.")
+
+    # Read date and time from info_csv
+    string_start_date = info_csv["Start Date"]
+    string_start_time = info_csv["Start Time"]
+
+    # Combine and parse to datetime.datetime
+    string_start_date_time = f"{string_start_date} {string_start_time}"
+    format_date_time = "%d:%m:%Y %H:%M:%S"
+    try:
+        date_time = datetime.datetime.strptime(string_start_date_time, format_date_time)
+    except ValueError as valerr:
+        raise InvalidRecordingException(
+            "Could not infer missing `Start Time (System)` value.\nUnexpected date time"
+            f" input format: {string_start_date_time}"
+        ) from valerr
+    # Convert to Unix timestamp
+    ts_start_date_time = date_time.timestamp()
+
+    logger.info(f"Using {date_time} as input for `Start Time (System)` inference.")
+    logger.info(f"Inferred `Start Time (System)`: {ts_start_date_time}")
+
+    return ts_start_date_time
+
+
+def _infer_start_time_synced_from_legacy(rec_dir):
+    _warn_imprecise_value_inference()
+    logger.warning(f"Missing meta info key: `Start Time (Synced)`.")
+
+    files = PupilRecording.FileFilter(rec_dir)
+    raw_time_files = files.mobile().raw_time()
+    first_ts_per_raw_time_file = []
+    for raw_time_file in raw_time_files:
+        raw_time = np.fromfile(str(raw_time_file), dtype=">f8")
+        if raw_time.size == 0:
+            continue
+        first_ts_per_raw_time_file.append(raw_time[0])
+    if not first_ts_per_raw_time_file:
+        raise InvalidRecordingException(
+            "Could not infer missing `Start Time (Synced)` value. No timestamps found."
+        )
+    inferred_start_time_synced = min(first_ts_per_raw_time_file)
+    logger.info(f"Inferred `Start Time (Synced)`: {inferred_start_time_synced}")
+    return inferred_start_time_synced
+
+
+# global variable to warn only once
+_SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = True
+
+
+def _warn_imprecise_value_inference():
+    global _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE
+    if not _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE:
+        return
+    logger.warning(
+        "\n\n!! Deprecation Warning !! Pupil Mobile recordings recorded with older"
+        " versions than r0.21.0 are deprecated and will not be supported by future"
+        " Pupil Player versions!\n"
+    )
+    logger.warning(
+        "\n\n!! Imprecise Value Inference !! In order to upgrade a deprecated"
+        " recording, Pupil Player needs to infer missing meta data from the existing"
+        " recording. This inference is imprecise and might cause issues when converting"
+        " recorded Pupil time to wall clock time.\n"
+    )
+    _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = False

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -821,7 +821,8 @@ def _warn_imprecise_value_inference():
         return
     logger.warning(
         "\n\n!! Deprecation Warning !! Pupil Mobile recordings recorded with older"
-        " versions than r0.21.0 are deprecated and will not be supported by future"
+        " versions than r0.21.0, or Pupil Capture recordings recorded with older"
+        " versions than v1.3, are deprecated and will not be supported by future"
         " Pupil Player versions!\n"
     )
     logger.warning(

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -10,6 +10,7 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import collections
+import datetime
 import glob
 import logging
 import os
@@ -26,7 +27,7 @@ import csv_utils
 import file_methods as fm
 from version_utils import VersionFormat
 
-from .. import Version
+from .. import Version, PupilRecording
 from ..info import RecordingInfoFile
 from ..info import recording_info_utils as rec_info_utils
 from ..recording_utils import InvalidRecordingException
@@ -56,12 +57,24 @@ def _generate_pprf_2_0_info_file(rec_dir):
     # Get information about recording from info.csv
     try:
         recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
-        start_time_system_s = float(info_csv["Start Time (System)"])
-        start_time_synced_s = float(info_csv["Start Time (Synced)"])
-        duration_s = rec_info_utils.parse_duration_string(info_csv["Duration Time"])
         recording_software_name = info_csv.get(
             "Capture Software", RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
         )
+
+        # Allow inference of missing values in v1.16
+        # TODO: Remove value inference in v1.17
+        start_time_system_s = float(
+            info_csv.get(
+                "Start Time (System)",
+                _infer_start_time_system_from_legacy(info_csv, recording_software_name),
+            )
+        )
+        start_time_synced_s = float(
+            info_csv.get(
+                "Start Time (Synced)", _infer_start_time_synced_from_legacy(rec_dir)
+            )
+        )
+        duration_s = rec_info_utils.parse_duration_string(info_csv["Duration Time"])
         recording_software_version = info_csv["Capture Software Version"]
         recording_name = info_csv.get(
             "Recording Name", rec_info_utils.default_recording_name(rec_dir)
@@ -733,3 +746,88 @@ def _read_rec_version_legacy(meta_info):
     version = VersionFormat(version)
     logger.debug("Recording version: {}".format(version))
     return version
+
+
+def _infer_start_time_system_from_legacy(info_csv, recording_software_name):
+    _warn_imprecise_value_inference()
+    logger.warning(f"Missing meta info key: `Start Time (System)`.")
+
+    # Read date and time from info_csv
+    string_start_date = info_csv["Start Date"]
+    string_start_time = info_csv["Start Time"]
+
+    # Combine and parse to datetime.datetime
+    string_start_date_time = f"{string_start_date} {string_start_time}"
+    if (
+        recording_software_name
+        == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
+    ):
+        format_date_time = "%d:%m:%Y %H:%M:%S"
+    elif (
+        recording_software_name
+        == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
+    ):
+        format_date_time = "%d.%m.%Y %H:%M:%S"
+    else:
+        raise InvalidRecordingException(
+            "Could not infer missing `Start Time (System)` value.\nUnexpected recording"
+            f" software name: {recording_software_name}"
+        )
+    try:
+        date_time = datetime.datetime.strptime(string_start_date_time, format_date_time)
+    except ValueError as valerr:
+        raise InvalidRecordingException(
+            "Could not infer missing `Start Time (System)` value.\nUnexpected date time"
+            f" input format: {string_start_date_time}"
+        ) from valerr
+    # Convert to Unix timestamp
+    ts_start_date_time = date_time.timestamp()
+
+    logger.info(f"Using {date_time} as input for `Start Time (System)` inference.")
+    logger.info(f"Inferred `Start Time (System)`: {ts_start_date_time}")
+
+    return ts_start_date_time
+
+
+def _infer_start_time_synced_from_legacy(rec_dir):
+    _warn_imprecise_value_inference()
+    logger.warning(f"Missing meta info key: `Start Time (Synced)`.")
+
+    files = PupilRecording.FileFilter(rec_dir)
+    timestamp_files = files.core().timestamps()
+    first_ts_per_timestamp_file = []
+    for timestamp_file in timestamp_files:
+        timestamps = np.load(str(timestamp_file))
+        if timestamps.size == 0:
+            continue
+        first_ts_per_timestamp_file.append(timestamps[0])
+        logger.info(f"First timestamp in {timestamp_file.name}: {timestamps[0]}")
+    if not first_ts_per_timestamp_file:
+        raise InvalidRecordingException(
+            "Could not infer missing `Start Time (Synced)` value. No timestamps found."
+        )
+    inferred_start_time_synced = min(first_ts_per_timestamp_file)
+    logger.info(f"Inferred `Start Time (Synced)`: {inferred_start_time_synced}")
+    return inferred_start_time_synced
+
+
+# global variable to warn only once
+_SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = True
+
+
+def _warn_imprecise_value_inference():
+    global _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE
+    if not _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE:
+        return
+    logger.warning(
+        "\n\n!! Deprecation Warning !! Pupil Mobile recordings recorded with older"
+        " versions than r0.21.0 are deprecated and will not be supported by future"
+        " Pupil Player versions!\n"
+    )
+    logger.warning(
+        "\n\n!! Imprecise Value Inference !! In order to upgrade a deprecated"
+        " recording, Pupil Player needs to infer missing meta data from the existing"
+        " recording. This inference is imprecise and might cause issues when converting"
+        " recorded Pupil time to wall clock time.\n"
+    )
+    _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = False


### PR DESCRIPTION
# Deprecated Recordings
Previously released versions of Pupil Player v1.16 do not support recordings created with
- Pupil Capture `v1.2` or earlier, and
- Pupil Mobile `r0.22.x` or earlier.

This was due to the fact that these recordings are missing meta information that is required for the upgrade to our new `Pupil Player Recording Format 2.0`. For details see "Missing Meta Information" below.

With this PR, instead of aborting with a "Recording too old" warning, Pupil Player will attempt to infer the missing values from other data in the recording. This inference is not perfect and results in imprecise values and might cause issues when converting recorded Pupil time to wall clock time. For details see "Missing Meta Information" below.

## Upgrading will only work in Player v1.16
Since this inference is limited, we will remove the upgrade functionality for deprecated recordings in v1.17. This means, that if you want to open a deprecated recording in v1.17 or later, you will have to convert them to the new format using v1.16 first.

## Missing Meta Information
Specifically the following keys in the `info.csv` file are missing:
- `Start Time (System)`: Recording start time in Unix epoch
- `Start Time (Synced)`: Recording start time in Pupil time

Pupil Player assumes that these timestamps were measured at the same time. This allows for the after-the-effect synchronization of Pupil data with externally recorded data that uses the Unix epoch.

Their value can be inferred from the existing recording, given a roughly known imprecision:

- **`Start Time (System)`**: The system start time can be inferred using the existing `Start Date` and `Start Time` fields (precision: one second). Unfortunately, the `Start Time` is subject to the system's timezone while `Start Time (System)` is not. Therefore, its inference is off by the recording's amount of timezone offset.
- **`Start Time (Synced)`**: This timestamp can be replaced by the earliest known recorded video timestamp in the given recording. In this case, the inference error depends on the startup delay of the cameras. This delay is typically less than a second for Pupil Capture recordings, and 2-5 seconds for Pupil Mobile recordings.

## Incorrect Playback
In some cases, deprecated recordings might not be played back correctly in Pupil Player. If this is the case for you, please contact `info@pupil-labs.com` for support.