### PR TITLE
Use PluginList in eye process

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -76,6 +76,7 @@ def eye(
        ``recording.stopped``: Stops recording eye video
        ``frame_publishing.started``: Starts frame publishing
        ``frame_publishing.stopped``: Stops frame publishing
+        ``start_eye_plugin``: Start plugins in eye process
 
     Emits notifications:
         ``eye_process.started``: Eye process started
@@ -559,13 +560,16 @@ def eye(
                     should_publish_frames = False
                     frame_publish_format = "jpeg"
                 elif (
-                    subject.startswith("start_eye_capture")
+                    subject.startswith("start_eye_plugin")
                     and notification["target"] == g_pool.process
                 ):
-                    g_pool.plugins.add(
-                        g_pool.plugin_by_name[notification["name"]],
-                        notification.get("args", {}),
-                    )
+                    try:
+                        g_pool.plugins.add(
+                            g_pool.plugin_by_name[notification["name"]],
+                            notification.get("args", {}),
+                        )
+                    except KeyError as err:
+                        logger.error(f"Attempt to load unknown plugin: {err}")
                 elif notification["subject"].startswith("pupil_detector.set_property"):
                     target_process = notification.get("target", g_pool.process)
                     should_apply = target_process == g_pool.process

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -70,12 +70,12 @@ def eye(
     Streams Pupil coordinates.
 
     Reacts to notifications:
-       ``set_detection_mapping_mode``: Sets detection method
-       ``eye_process.should_stop``: Stops the eye process
-       ``recording.started``: Starts recording eye video
-       ``recording.stopped``: Stops recording eye video
-       ``frame_publishing.started``: Starts frame publishing
-       ``frame_publishing.stopped``: Stops frame publishing
+        ``set_detection_mapping_mode``: Sets detection method
+        ``eye_process.should_stop``: Stops the eye process
+        ``recording.started``: Starts recording eye video
+        ``recording.stopped``: Stops recording eye video
+        ``frame_publishing.started``: Starts frame publishing
+        ``frame_publishing.stopped``: Stops frame publishing
         ``start_eye_plugin``: Start plugins in eye process
 
     Emits notifications:

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -266,8 +266,7 @@ def eye(
 
         def on_drop(window, count, paths):
             paths = [paths[x].decode("utf-8") for x in range(count)]
-            plugins = (g_pool.capture_manager, g_pool.capture)
-            for plugin in plugins:
+            for plugin in g_pool.plugins:
                 if plugin.on_drop(paths):
                     break
 
@@ -283,7 +282,6 @@ def eye(
 
         g_pool.iconified = False
         g_pool.capture = None
-        g_pool.capture_manager = None
         g_pool.flip = session_settings.get("flip", False)
         g_pool.display_mode = session_settings.get("display_mode", "camera_image")
         g_pool.display_mode_info_text = {
@@ -634,14 +632,14 @@ def eye(
                             **props,  # add properties to broadcast
                         }
                         ipc_socket.notify(properties_broadcast)
-                g_pool.capture.on_notify(notification)
-                g_pool.capture_manager.on_notify(notification)
+                for plugin in g_pool.plugins:
+                    plugin.on_notify(notification)
 
-            # Get an image from the grabber
             event = {}
-            g_pool.capture.recent_events(event)
+            for plugin in g_pool.plugins:
+                plugin.recent_events(event)
+
             frame = event.get("frame")
-            g_pool.capture_manager.recent_events(event)
             if frame:
                 f_width, f_height = g_pool.capture.frame_size
                 if (g_pool.u_r.array_shape[0], g_pool.u_r.array_shape[1]) != (

--- a/pupil_src/shared_modules/video_capture/base_backend.py
+++ b/pupil_src/shared_modules/video_capture/base_backend.py
@@ -200,14 +200,16 @@ class Base_Manager(Plugin):
             self.auto_activate_source()
 
     def replace_backend_manager(self, manager_class, auto_activate=False):
-        if self.g_pool.process.startswith("eye"):
-            if not isinstance(self.g_pool.capture_manager, manager_class):
-                self.g_pool.capture_manager.deinit_ui()
-                self.g_pool.capture_manager.cleanup()
-                self.g_pool.capture_manager = manager_class(self.g_pool)
-                self.g_pool.capture_manager.init_ui()
-        else:
-            if not isinstance(self, manager_class):
+        if not isinstance(self, manager_class):
+            if self.g_pool.process.startswith("eye"):
+                self.notify_all(
+                    {
+                        "subject": "start_eye_plugin",
+                        "target": self.g_pool.process,
+                        "name": manager_class.__name__,
+                    }
+                )
+            else:
                 self.notify_all(
                     {"subject": "start_plugin", "name": manager_class.__name__}
                 )

--- a/pupil_src/shared_modules/video_capture/base_backend.py
+++ b/pupil_src/shared_modules/video_capture/base_backend.py
@@ -186,6 +186,7 @@ class Base_Manager(Plugin):
 
         Emmits notifications (indirectly):
             ``start_plugin``: For world thread
+            ``start_eye_plugin``: For eye thread
             ``backend.auto_activate_source``
         """
 

--- a/pupil_src/shared_modules/video_capture/fake_backend.py
+++ b/pupil_src/shared_modules/video_capture/fake_backend.py
@@ -367,7 +367,7 @@ class Fake_Manager(Base_Manager):
         else:
             self.notify_all(
                 {
-                    "subject": "start_eye_capture",
+                    "subject": "start_eye_plugin",
                     "target": self.g_pool.process,
                     "name": "Fake_Source",
                     "args": settings,

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -688,7 +688,7 @@ class File_Manager(Base_Manager):
         else:
             self.notify_all(
                 {
-                    "subject": "start_eye_capture",
+                    "subject": "start_eye_plugin",
                     "target": self.g_pool.process,
                     "name": "File_Source",
                     "args": settings,

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -570,10 +570,7 @@ class NDSI_Manager(Base_Manager):
 
     def activate_source(self, settings={}):
         settings["network"] = self.network
-        if hasattr(self.g_pool, "plugins"):
-            self.g_pool.plugins.add(NDSI_Source, args=settings)
-        else:
-            self.g_pool.replace_source(NDSI_Source.__name__, source_settings=settings)
+        self.g_pool.plugins.add(NDSI_Source, args=settings)
 
     def recover(self):
         self.g_pool.capture.recover(self.network)

--- a/pupil_src/shared_modules/video_capture/realsense2_backend.py
+++ b/pupil_src/shared_modules/video_capture/realsense2_backend.py
@@ -895,7 +895,7 @@ class Realsense2_Manager(Base_Manager):
             else:
                 self.notify_all(
                     {
-                        "subject": "start_eye_capture",
+                        "subject": "start_eye_plugin",
                         "target": self.g_pool.process,
                         "name": "Realsense2_Source",
                         "args": settings,

--- a/pupil_src/shared_modules/video_capture/realsense_backend.py
+++ b/pupil_src/shared_modules/video_capture/realsense_backend.py
@@ -914,7 +914,7 @@ class Realsense_Manager(Base_Manager):
             else:
                 self.notify_all(
                     {
-                        "subject": "start_eye_capture",
+                        "subject": "start_eye_plugin",
                         "target": self.g_pool.process,
                         "name": "Realsense_Source",
                         "args": settings,

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -899,7 +899,7 @@ class UVC_Manager(Base_Manager):
         else:
             self.notify_all(
                 {
-                    "subject": "start_eye_capture",
+                    "subject": "start_eye_plugin",
                     "target": self.g_pool.process,
                     "name": "UVC_Source",
                     "args": settings,


### PR DESCRIPTION
Eye already uses a couple of plugins but has to manage them manually.
This results in a lot of duplicate code that is all over the place but belongs together.
World uses the PluginList to extract this logic.

I added a PluginList to eye and extracted the plugins into it.
Some refactoring was required for resolving order-of-execution issues.

This will also allow us to make plugins out of the detectors and integrate them more cleanly,