### PR TITLE
Gracefully terminate running recordings when eye process ends

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -828,6 +828,7 @@ def eye(
         # in case eye recording was still runnnig: Save&close
         if g_pool.writer:
             logger.info("Done recording eye.")
+            g_pool.writer.release()
             g_pool.writer = None
 
         glfw.glfwRestoreWindow(main_window)  # need to do this for windows os


### PR DESCRIPTION
When closing the eye windows while recording, the process stopped without closing the writer.
This resulted in a broken recording for the stopped eye process.

The fix is to correctly close the writer on eye process end.