### PR TITLE
Export pts in *_timstamps.csv file

### DIFF
--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -180,6 +180,10 @@ class AV_Writer(abc.ABC):
         video_packed_encoded = False
         for packet in self.encode_frame(input_frame, pts):
             if packet.stream is self.video_stream:
+                if video_packed_encoded:
+                    # NOTE: Assumption: Each frame is encoded into a single packet!
+                    # This is required for the frame.pts == packet.pts assumption below.
+                    logger.warning("Single frame yielded more than one packet")
                 video_packed_encoded = True
             self.container.mux(packet)
 

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -205,7 +205,9 @@ class AV_Writer(abc.ABC):
         self.container.close()
         self.closed = True
 
-        if timestamp_export_format is not None:
+        if self.configured and timestamp_export_format is not None:
+            # Requires self.container to be closed since we extract pts
+            # from the exported video file.
             write_timestamps(
                 self.output_file_path, self.timestamps, timestamp_export_format
             )

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -9,20 +9,20 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+import abc
+
 # logging
 import logging
 import multiprocessing as mp
 import os
-import platform
-from fractions import Fraction
-import abc
 import typing as T
+from fractions import Fraction
 
+import av
 import numpy as np
+from av.packet import Packet
 
 import audio_utils
-import av
-from av.packet import Packet
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #1680 

TODO:
- [ ] Ensure exported pts correspond to actual packet (not frame!) pts

In order to facilitate seeking to a given timestamp, Player now exports the video presentation timestamps (pts) for each exported frame. The data is stored in an additional `pts` column in the corresponding `*_timestamps.csv` file.