### PR TITLE
Simplify build under Windows

### DIFF
--- a/pupil_src/shared_modules/pupil_detectors/setup.py
+++ b/pupil_src/shared_modules/pupil_detectors/setup.py
@@ -31,7 +31,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
 import numpy as np
-import os, sys, platform
+import os, sys, platform, glob, shutil
 
 dependencies = []
 # include all header files, to recognize changes
@@ -46,28 +46,70 @@ singleeyefitter_include_path = "singleeyefitter/"
 if platform.system() == "Windows":
     libs = []
     library_dirs = []
-    lib_spec = [
-        [np.get_include(), ""],
-        [
-            "C:\\work\\opencv\\build\\include",
-            "C:\\work\\opencv\\build\\x64\\vc14\\lib\\opencv_world345.lib",
-        ],
-        ["C:\\work\\ceres-windows\\Eigen", ""],
-        [
-            "C:\\work\\ceres-windows\\ceres-solver\\include",
-            "C:\\work\\ceres-windows\\x64\\Release\\ceres_static.lib",
-        ],
-        [
-            "C:\\work\\ceres-windows\\glog\\src\\windows",
-            "C:\\work\\ceres-windows\\x64\\Release\\libglog_static.lib",
-        ],
-        ["C:\\work\\ceres-windows", ""],
-    ]
+
+    # Check if the setup.py is running in a Conda environment
+    is_conda = os.path.exists(os.path.join(sys.prefix, "conda-meta"))
+    if is_conda:
+        # Deduct the include and library dir dynamically
+        include_dir = os.path.join(sys.prefix, "Library", "include")
+        lib_dir = os.path.join(sys.prefix, "Library", "lib")
+        if not os.path.exists(include_dir) or not os.path.exists(lib_dir):
+            raise EnvironmentError("Unable to locate Anaconda include or lib directory")
+
+        # When installing Eigen via Conda it is installed in a folder called 'eigen3'. Deal with that, if appropriate.
+        eigen_dir = os.path.join(include_dir, "Eigen")
+        custom_eigen_dir = os.path.join(include_dir, "eigen3")
+        if not os.path.exists(eigen_dir) and os.path.exists(custom_eigen_dir):
+            """
+            # Creating a junction might be the prettiest way - but it need extended rights.
+            import ctypes
+            kernel_dll = ctypes.windll.LoadLibrary("kernel32.dll")
+            if kernel_dll.CreateSymbolicLinkA(eigen_dir, custom_eigen_dir, 1) == 0:
+                raise EnvironmentError(f"Unable tio create junction between {eigen_dir} and {custom_eigen_dir}.")
+            """
+
+            # Use the ugly variant and simply copy the directory
+            shutil.copytree(src=custom_eigen_dir, dst=eigen_dir)
+
+        # Finally build lib_spec dynamically
+        lib_spec = [
+            [np.get_include(), ""],
+            [include_dir, ""],
+            [
+                os.path.join(include_dir, "opencv2"),
+                *glob.glob(os.path.join(lib_dir, "opencv_*.lib")),
+            ],
+            [os.path.join(include_dir, "Eigen"), ""],
+            [os.path.join(include_dir, "ceres"), os.path.join(lib_dir, "ceres.lib")],
+            [os.path.join(include_dir, "glog"), os.path.join(lib_dir, "glog.lib")],
+        ]
+    else:
+        lib_spec = [
+            [np.get_include(), ""],
+            [
+                "C:\\work\\opencv\\build\\include",
+                "C:\\work\\opencv\\build\\x64\\vc14\\lib\\opencv_world345.lib",
+            ],
+            ["C:\\work\\ceres-windows\\Eigen", ""],
+            [
+                "C:\\work\\ceres-windows\\ceres-solver\\include",
+                "C:\\work\\ceres-windows\\x64\\Release\\ceres_static.lib",
+            ],
+            [
+                "C:\\work\\ceres-windows\\glog\\src\\windows",
+                "C:\\work\\ceres-windows\\x64\\Release\\libglog_static.lib",
+            ],
+            ["C:\\work\\ceres-windows", ""],
+        ]
 
     include_dirs = [spec[0] for spec in lib_spec]
     include_dirs.append(shared_cpp_include_path)
     include_dirs.append(singleeyefitter_include_path)
-    xtra_obj2d = [spec[1] for spec in lib_spec]
+
+    # Handle multiple library entries, for example in the case of OpenCV
+    xtra_obj2d = []
+    for spec in lib_spec:
+        xtra_obj2d.extend(spec[1:])
 
 else:
     # opencv3 - highgui module has been split into parts: imgcodecs, videoio, and highgui itself
@@ -131,6 +173,7 @@ extensions = [
         extra_link_args=[],  # '-WL,-R/usr/local/lib'
         extra_compile_args=[
             "-D_USE_MATH_DEFINES",
+            "-D_ENABLE_EXTENDED_ALIGNED_STORAGE",  # Ensure correct compilation after update to Visual Studio 2017 v15.8
             "-std=c++11",
             "-w",
             "-O2",
@@ -155,6 +198,7 @@ extensions = [
         extra_link_args=[],  # '-WL,-R/usr/local/lib'
         extra_compile_args=[
             "-D_USE_MATH_DEFINES",
+            "-D_ENABLE_EXTENDED_ALIGNED_STORAGE",  # Ensure correct compilation after update to Visual Studio 2017 v15.8
             "-std=c++11",
             "-w",
             "-O2",

--- a/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
+++ b/pupil_src/shared_modules/pupil_detectors/singleeyefitter/EyeModelFitter.cpp
@@ -18,6 +18,9 @@
 #include <algorithm>
 #include <queue>
 
+// Ensure correct compilation after update to Visual Studio 2017 v15.8
+#define _ENABLE_EXTENDED_ALIGNED_STORAGE
+
 namespace singleeyefitter {
 
 


### PR DESCRIPTION
This pull request simplifies the building under Microsoft Windows significantly. When Conda is used as a virtual environment as proposed by @cboulay (https://github.com/pupil-labs/pupil/pull/1455), there is no longer the need for having a separate "C:\work". Instead, the linking against C++ dependencies like opencv, eigen and ceres-solver is handled automatically. Furthermore, the commit fixes #1331 without user intervention.

Unlike the far more complex approach mentioned above being a perfect start for a complete rewrite, this rather small patch is directly applicable. While I had no problems during the building process, due to the number of possible variations I'm really interested in additional test on different systems.

The "automatic workflow" follows exactly the current [building procedures](https://github.com/pupil-labs/pupil/blob/master/docs/dependencies-windows.md):

1. Create Conda environment
```
conda create -n pupil_env python=3.6
conda activate pupil_env
```

2. Install all the stuff
```
conda install -c conda-forge opencv boost eigen ceres-solver ffmpeg glfw glew

pip install cython
pip install msgpack==0.5.6
pip install numexpr
pip install packaging
pip install psutil
pip install pyaudio
pip install pyopengl
pip install pyzmq
pip install scipy
pip install win_inet_pton
pip install git+https://github.com/zeromq/pyre
pip install pupil_apriltags
pip install git+https://github.com/pupil-labs/nslr
pip install git+https://github.com/pupil-labs/nslr-hmm

Install pyTroch
Install pyglui, pyav, pyndsi, pyuvc
```

3. Run pupil
```
Download pupil
cd pupil/pupil_src
run_capture.bat
```