### PR TITLE
Fix unstable surface outlines

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface.py
+++ b/pupil_src/shared_modules/surface_tracker/surface.py
@@ -94,6 +94,9 @@ class Surface(abc.ABC):
         self.surf_to_dist_img_trans = None
         self.num_detected_markers = 0
 
+        # TODO: The aggregation over neighbors for REQUIRED_OBS_PER_MARKER can lead to
+        # inaccurate surface definitions. By setting this to 1 we disable the
+        # aggregation for now. Need to refactor this in the future.
         self._REQUIRED_OBS_PER_MARKER = 1
         self._avg_obs_per_marker = 0
         self.build_up_status = build_up_status if build_up_status is not None else 0

--- a/pupil_src/shared_modules/surface_tracker/surface.py
+++ b/pupil_src/shared_modules/surface_tracker/surface.py
@@ -94,7 +94,7 @@ class Surface(abc.ABC):
         self.surf_to_dist_img_trans = None
         self.num_detected_markers = 0
 
-        self._REQUIRED_OBS_PER_MARKER = 5
+        self._REQUIRED_OBS_PER_MARKER = 1
         self._avg_obs_per_marker = 0
         self.build_up_status = build_up_status if build_up_status is not None else 0
 


### PR DESCRIPTION
When defining a new surface, markers from a few frames before and after are aggregated to ensure more stable marker mappings.

This is a problem when the surface is defined in a section where the markers flicker a lot. The bounding boxes are not mapped appropriately and thus the surface definition contains erroneous marker locations. This error will bleed over into the whole mapping. Most importantly it can result in jumping boundaries when only a subset of the markers is visible of which a majority was incorrectly mapped at definition.

The quick fix is here to just don't scan neighboring markers on surface definition. Especially with the new apriltags there is no need to do temporal smoothing anymore.

@papr In the long run we should refactor the surface tracker to get rid of all the code supporting the marker aggregates. This makes sense because there's a lot of complexity only for this use case and we should get rid of it if we are not intending to use it. Since this is a bit more work, I'd say we do this in a separate refactor.