### PR TITLE
Fix heatmap history length setter not working

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface_online.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_online.py
@@ -20,7 +20,7 @@ class Surface_Online(Surface):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.GAZE_HISTORY_LENGTH = 1
+        self.gaze_history_length = 1
         self.gaze_history = collections.deque()
 
     def update_location(self, frame_idx, visible_markers, camera_model):
@@ -48,7 +48,7 @@ class Surface_Online(Surface):
         while (
             self.gaze_history
             and world_timestamp - self.gaze_history[0]["timestamp"]
-            > self.GAZE_HISTORY_LENGTH
+            > self.gaze_history_length
         ):
             self.gaze_history.popleft()
 

--- a/pupil_src/shared_modules/surface_tracker/surface_tracker_online.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker_online.py
@@ -87,7 +87,7 @@ class Surface_Tracker_Online(Surface_Tracker):
 
         surf_menu.append(
             pyglui.ui.Text_Input(
-                "GAZE_HISTORY_LENGTH",
+                "gaze_history_length",
                 surface,
                 label="Gaze History Length [seconds]",
                 setter=set_gaze_hist_len,


### PR DESCRIPTION
The setter function referred to `gaze_history_length`, while all other parts of the code referred to `GAZE_HISTORY_LENGTH`. I changed everything to lower-case since it's supposed to be modified and not constant.