### PR TITLE
Disable eye movement detector

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -102,7 +102,6 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
 
         # from marker_auto_trim_marks import Marker_Auto_Trim_Marks
         from fixation_detector import Offline_Fixation_Detector
-        from eye_movement import Offline_Eye_Movement_Detector
         from log_display import Log_Display
         from annotations import Annotation_Player
         from raw_data_exporter import Raw_Data_Exporter
@@ -154,7 +153,6 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
             Video_Overlay,
             # Vis_Scan_Path,
             Offline_Fixation_Detector,
-            Offline_Eye_Movement_Detector,
             Offline_Blink_Detection,
             Surface_Tracker_Offline,
             Raw_Data_Exporter,

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -152,7 +152,6 @@ def world(
             Gaze_Mapping_Plugin,
         )
         from fixation_detector import Fixation_Detector
-        from eye_movement import Eye_Movement_Detector_Real_Time
         from recorder import Recorder
         from display_recent_gaze import Display_Recent_Gaze
         from time_sync import Time_Sync
@@ -232,7 +231,6 @@ def world(
             Annotation_Capture,
             Log_History,
             Fixation_Detector,
-            Eye_Movement_Detector_Real_Time,
             Blink_Detection,
             Remote_Recorder,
             Accuracy_Visualizer,

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -115,7 +115,6 @@ def _export_world_video(
     # we are not importing manual gaze correction. In Player corrections have already been applied.
     # in batch exporter this plugin makes little sense.
     from fixation_detector import Offline_Fixation_Detector
-    from eye_movement import Offline_Eye_Movement_Detector
 
     # Plug-ins
     from plugin import Plugin_List, import_runtime_plugins
@@ -148,7 +147,7 @@ def _export_world_video(
             ],
             key=lambda x: x.__name__,
         )
-        analysis_plugins = [Offline_Fixation_Detector, Offline_Eye_Movement_Detector]
+        analysis_plugins = [Offline_Fixation_Detector]
         user_plugins = sorted(
             import_runtime_plugins(os.path.join(user_dir, "plugins")),
             key=lambda x: x.__name__,


### PR DESCRIPTION
The current implementation of the eye movement detector might not be doing what we actually want. Until we have time to review this, we disable the detector.