### PR TITLE
Remove support for updating deprecated recordings

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -53,7 +53,7 @@ def get_recording_type(rec_dir: str) -> RecordingType:
     if RecordingInfoFile.does_recording_contain_info_file(rec_dir):
         return RecordingType.NEW_STYLE
 
-    elif _was_recording_opened_in_player_before(rec_dir):
+    elif _is_old_style_player_recording(rec_dir):
         return RecordingType.OLD_STYLE
 
     elif _is_pupil_invisible_recording(rec_dir):
@@ -133,9 +133,13 @@ def _is_pupil_mobile_recording(rec_dir: str) -> bool:
         return False
 
 
-def _was_recording_opened_in_player_before(rec_dir: str) -> bool:
+def _is_old_style_player_recording(rec_dir: str) -> bool:
     try:
         info_csv = recording_info_utils.read_info_csv_file(rec_dir)
     except FileNotFoundError:
         return False
-    return "Data Format Version" in info_csv
+    # We test if the "Data Format Version" or "Capture Software Version" field is
+    # present to differentiate untransformed Pupil Mobile recordings. These do not
+    # contain either of these keys. "Capture Software Version" is tested too for legacy
+    # reasons.
+    return "Data Format Version" in info_csv or "Capture Software Version" in info_csv

--- a/pupil_src/shared_modules/pupil_recording/update/mobile.py
+++ b/pupil_src/shared_modules/pupil_recording/update/mobile.py
@@ -9,13 +9,10 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import datetime
 import logging
 import re
 import uuid
 from pathlib import Path
-
-import numpy as np
 
 from .. import Version
 from ..info import RecordingInfoFile
@@ -79,34 +76,17 @@ def _transform_mobile_v1_2_to_pprf_2_0(rec_dir: str):
 def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
     info_csv = utils.read_info_csv_file(rec_dir)
 
-    try:
-        # Get information about recording from info.csv
-        recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
-
-        # Allow inference of missing values in v1.16
-        # TODO: Remove value inference in v1.17
-        start_time_system_s = float(
-            info_csv.get(
-                "Start Time (System)", _infer_start_time_system_from_legacy(info_csv)
-            )
-        )
-        start_time_synced_s = float(
-            info_csv.get(
-                "Start Time (Synced)", _infer_start_time_synced_from_legacy(rec_dir)
-            )
-        )
-        duration_s = utils.parse_duration_string(info_csv["Duration Time"])
-        recording_software_name = info_csv["Capture Software"]
-        recording_software_version = info_csv["Capture Software Version"]
-        recording_name = info_csv.get(
-            "Recording Name", utils.default_recording_name(rec_dir)
-        )
-        system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
-    except KeyError as e:
-        logger.debug(f"KeyError while parsing old-style info.csv: {str(e)}")
-        raise InvalidRecordingException(
-            "This recording is too old to be opened with this version of Player!"
-        )
+    # Get information about recording from info.csv
+    recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
+    start_time_system_s = float(info_csv["Start Time (System)"])
+    start_time_synced_s = float(info_csv["Start Time (Synced)"])
+    duration_s = utils.parse_duration_string(info_csv["Duration Time"])
+    recording_software_name = info_csv["Capture Software"]
+    recording_software_version = info_csv["Capture Software Version"]
+    recording_name = info_csv.get(
+        "Recording Name", utils.default_recording_name(rec_dir)
+    )
+    system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
 
     # Create a recording info file with the new format, fill out
     # the information, validate, and return.
@@ -144,73 +124,3 @@ def _rename_mobile_files(recording: PupilRecording):
 
 def _rewrite_timestamps(recording: PupilRecording):
     update_utils._rewrite_times(recording, dtype=">f8")
-
-
-def _infer_start_time_system_from_legacy(info_csv):
-    _warn_imprecise_value_inference()
-    logger.warning(f"Missing meta info key: `Start Time (System)`.")
-
-    # Read date and time from info_csv
-    string_start_date = info_csv["Start Date"]
-    string_start_time = info_csv["Start Time"]
-
-    # Combine and parse to datetime.datetime
-    string_start_date_time = f"{string_start_date} {string_start_time}"
-    format_date_time = "%d:%m:%Y %H:%M:%S"
-    try:
-        date_time = datetime.datetime.strptime(string_start_date_time, format_date_time)
-    except ValueError as valerr:
-        raise InvalidRecordingException(
-            "Could not infer missing `Start Time (System)` value.\nUnexpected date time"
-            f" input format: {string_start_date_time}"
-        ) from valerr
-    # Convert to Unix timestamp
-    ts_start_date_time = date_time.timestamp()
-
-    logger.info(f"Using {date_time} as input for `Start Time (System)` inference.")
-    logger.info(f"Inferred `Start Time (System)`: {ts_start_date_time}")
-
-    return ts_start_date_time
-
-
-def _infer_start_time_synced_from_legacy(rec_dir):
-    _warn_imprecise_value_inference()
-    logger.warning(f"Missing meta info key: `Start Time (Synced)`.")
-
-    files = PupilRecording.FileFilter(rec_dir)
-    raw_time_files = files.mobile().raw_time()
-    first_ts_per_raw_time_file = []
-    for raw_time_file in raw_time_files:
-        raw_time = np.fromfile(str(raw_time_file), dtype=">f8")
-        if raw_time.size == 0:
-            continue
-        first_ts_per_raw_time_file.append(raw_time[0])
-    if not first_ts_per_raw_time_file:
-        raise InvalidRecordingException(
-            "Could not infer missing `Start Time (Synced)` value. No timestamps found."
-        )
-    inferred_start_time_synced = min(first_ts_per_raw_time_file)
-    logger.info(f"Inferred `Start Time (Synced)`: {inferred_start_time_synced}")
-    return inferred_start_time_synced
-
-
-# global variable to warn only once
-_SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = True
-
-
-def _warn_imprecise_value_inference():
-    global _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE
-    if not _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE:
-        return
-    logger.warning(
-        "\n\n!! Deprecation Warning !! Pupil Mobile recordings recorded with older"
-        " versions than r0.21.0 are deprecated and will not be supported by future"
-        " Pupil Player versions!\n"
-    )
-    logger.warning(
-        "\n\n!! Imprecise Value Inference !! In order to upgrade a deprecated"
-        " recording, Pupil Player needs to infer missing meta data from the existing"
-        " recording. This inference is imprecise and might cause issues when converting"
-        " recorded Pupil time to wall clock time.\n"
-    )
-    _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = False

--- a/pupil_src/shared_modules/pupil_recording/update/mobile.py
+++ b/pupil_src/shared_modules/pupil_recording/update/mobile.py
@@ -77,17 +77,23 @@ def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
     info_csv = utils.read_info_csv_file(rec_dir)
 
     # Get information about recording from info.csv
-    recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
-    start_time_system_s = float(info_csv["Start Time (System)"])
-    start_time_synced_s = float(info_csv["Start Time (Synced)"])
-    duration_s = utils.parse_duration_string(info_csv["Duration Time"])
-    recording_software_name = info_csv["Capture Software"]
-    recording_software_version = info_csv["Capture Software Version"]
-    recording_name = info_csv.get(
-        "Recording Name", utils.default_recording_name(rec_dir)
-    )
-    system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
-
+    try:
+        recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
+        start_time_system_s = float(info_csv["Start Time (System)"])
+        start_time_synced_s = float(info_csv["Start Time (Synced)"])
+        duration_s = utils.parse_duration_string(info_csv["Duration Time"])
+        recording_software_name = info_csv["Capture Software"]
+        recording_software_version = info_csv["Capture Software Version"]
+        recording_name = info_csv.get(
+            "Recording Name", utils.default_recording_name(rec_dir)
+        )
+        system_info = info_csv.get("System Info", utils.default_system_info(rec_dir))
+    except KeyError as e:
+        logger.debug(f"KeyError while parsing mobile info.csv: {str(e)}")
+        raise InvalidRecordingException(
+            "This recording needs a data format update.\n"
+            "Open it once in Pupil Player v1.17 to perform the update."
+        )
     # Create a recording info file with the new format, fill out
     # the information, validate, and return.
     new_info_file = RecordingInfoFile.create_empty_file(rec_dir)

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -10,7 +10,6 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import collections
-import datetime
 import glob
 import logging
 import os
@@ -27,7 +26,7 @@ import csv_utils
 import file_methods as fm
 from version_utils import VersionFormat
 
-from .. import Version, PupilRecording
+from .. import Version
 from ..info import RecordingInfoFile
 from ..info import recording_info_utils as rec_info_utils
 from ..recording_utils import InvalidRecordingException
@@ -57,24 +56,12 @@ def _generate_pprf_2_0_info_file(rec_dir):
     # Get information about recording from info.csv
     try:
         recording_uuid = info_csv.get("Recording UUID", uuid.uuid4())
+        start_time_system_s = float(info_csv["Start Time (System)"])
+        start_time_synced_s = float(info_csv["Start Time (Synced)"])
+        duration_s = rec_info_utils.parse_duration_string(info_csv["Duration Time"])
         recording_software_name = info_csv.get(
             "Capture Software", RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
         )
-
-        # Allow inference of missing values in v1.16
-        # TODO: Remove value inference in v1.17
-        start_time_system_s = float(
-            info_csv.get(
-                "Start Time (System)",
-                _infer_start_time_system_from_legacy(info_csv, recording_software_name),
-            )
-        )
-        start_time_synced_s = float(
-            info_csv.get(
-                "Start Time (Synced)", _infer_start_time_synced_from_legacy(rec_dir)
-            )
-        )
-        duration_s = rec_info_utils.parse_duration_string(info_csv["Duration Time"])
         recording_software_version = info_csv["Capture Software Version"]
         recording_name = info_csv.get(
             "Recording Name", rec_info_utils.default_recording_name(rec_dir)
@@ -746,89 +733,3 @@ def _read_rec_version_legacy(meta_info):
     version = VersionFormat(version)
     logger.debug("Recording version: {}".format(version))
     return version
-
-
-def _infer_start_time_system_from_legacy(info_csv, recording_software_name):
-    _warn_imprecise_value_inference()
-    logger.warning(f"Missing meta info key: `Start Time (System)`.")
-
-    # Read date and time from info_csv
-    string_start_date = info_csv["Start Date"]
-    string_start_time = info_csv["Start Time"]
-
-    # Combine and parse to datetime.datetime
-    string_start_date_time = f"{string_start_date} {string_start_time}"
-    if (
-        recording_software_name
-        == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
-    ):
-        format_date_time = "%d:%m:%Y %H:%M:%S"
-    elif (
-        recording_software_name
-        == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
-    ):
-        format_date_time = "%d.%m.%Y %H:%M:%S"
-    else:
-        raise InvalidRecordingException(
-            "Could not infer missing `Start Time (System)` value.\nUnexpected recording"
-            f" software name: {recording_software_name}"
-        )
-    try:
-        date_time = datetime.datetime.strptime(string_start_date_time, format_date_time)
-    except ValueError as valerr:
-        raise InvalidRecordingException(
-            "Could not infer missing `Start Time (System)` value.\nUnexpected date time"
-            f" input format: {string_start_date_time}"
-        ) from valerr
-    # Convert to Unix timestamp
-    ts_start_date_time = date_time.timestamp()
-
-    logger.info(f"Using {date_time} as input for `Start Time (System)` inference.")
-    logger.info(f"Inferred `Start Time (System)`: {ts_start_date_time}")
-
-    return ts_start_date_time
-
-
-def _infer_start_time_synced_from_legacy(rec_dir):
-    _warn_imprecise_value_inference()
-    logger.warning(f"Missing meta info key: `Start Time (Synced)`.")
-
-    files = PupilRecording.FileFilter(rec_dir)
-    timestamp_files = files.core().timestamps()
-    first_ts_per_timestamp_file = []
-    for timestamp_file in timestamp_files:
-        timestamps = np.load(str(timestamp_file))
-        if timestamps.size == 0:
-            continue
-        first_ts_per_timestamp_file.append(timestamps[0])
-        logger.info(f"First timestamp in {timestamp_file.name}: {timestamps[0]}")
-    if not first_ts_per_timestamp_file:
-        raise InvalidRecordingException(
-            "Could not infer missing `Start Time (Synced)` value. No timestamps found."
-        )
-    inferred_start_time_synced = min(first_ts_per_timestamp_file)
-    logger.info(f"Inferred `Start Time (Synced)`: {inferred_start_time_synced}")
-    return inferred_start_time_synced
-
-
-# global variable to warn only once
-_SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = True
-
-
-def _warn_imprecise_value_inference():
-    global _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE
-    if not _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE:
-        return
-    logger.warning(
-        "\n\n!! Deprecation Warning !! Pupil Mobile recordings recorded with older"
-        " versions than r0.21.0, or Pupil Capture recordings recorded with older"
-        " versions than v1.3, are deprecated and will not be supported by future"
-        " Pupil Player versions!\n"
-    )
-    logger.warning(
-        "\n\n!! Imprecise Value Inference !! In order to upgrade a deprecated"
-        " recording, Pupil Player needs to infer missing meta data from the existing"
-        " recording. This inference is imprecise and might cause issues when converting"
-        " recorded Pupil time to wall clock time.\n"
-    )
-    _SHOULD_WARN_IMPRECISE_VALUE_INFERRENCE = False

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -72,7 +72,8 @@ def _generate_pprf_2_0_info_file(rec_dir):
     except KeyError as e:
         logger.debug(f"KeyError while parsing old-style info.csv: {str(e)}")
         raise InvalidRecordingException(
-            "This recording is too old to be opened with this version of Player!"
+            "This recording needs a data format update.\n"
+            "Open it once in Pupil Player v1.17 to perform the update."
         )
 
     # Create a recording info file with the new format,


### PR DESCRIPTION
This reverts commit 27f9153effd04cc160666416386e83989509a677, reversing changes made to 64a3ac418747b7789b7a1e2bf4d52bfc66ad91e9. Attempts to open deprecated recordings in Player v1.18 will show a notification asking the user to perform the required data format update in Pupil Player v1.17