### PR TITLE
Fix `None` port in Pupil Service

### DIFF
--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -25,6 +25,7 @@ default_args = {
     "profile": False,
     "version": False,
     "hide_ui": False,
+    "port": 50020,
 }
 parsed_args, unknown_args = PupilArgParser().parse(running_from_bundle, **default_args)
 

--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -73,7 +73,7 @@ class Pupil_Remote(Plugin):
     icon_chr = chr(0xE307)
     icon_font = "pupil_icons"
 
-    def __init__(self, g_pool, port=50020, host="*", use_primary_interface=True):
+    def __init__(self, g_pool, host="*", use_primary_interface=True):
         super().__init__(g_pool)
         self.order = 0.01  # excecute first
         self.context = g_pool.zmq_ctx
@@ -81,9 +81,8 @@ class Pupil_Remote(Plugin):
 
         self.use_primary_interface = use_primary_interface
         assert type(host) == str
-        assert type(port) == int
         self.host = host
-        self.port = g_pool.preferred_remote_port or port
+        self.port = g_pool.preferred_remote_port
 
         self.start_server("tcp://{}:{}".format(host, self.port))
         self.menu = None
@@ -301,7 +300,6 @@ class Pupil_Remote(Plugin):
 
     def get_init_dict(self):
         return {
-            "port": self.port,
             "host": self.host,
             "use_primary_interface": self.use_primary_interface,
         }


### PR DESCRIPTION
### Set remote port only via CLI, not from session settings

In most cases you don't want the port to get saved in the settings anyway, especially since capture will generate a random free port when the default port is in use.

* Removes port interface of Pupil_Remote
* Moves default port settings to CLI arg defaults

Note that the argparser ensures that the **port** arg is an int, so no need for the typecheck anymore.

Fixes #1462 