### PR TITLE
Correctly shutdown Service if port is already in use

### DIFF
--- a/pupil_src/shared_modules/pupil_remote.py
+++ b/pupil_src/shared_modules/pupil_remote.py
@@ -105,7 +105,11 @@ class Pupil_Remote(Plugin):
         # for service we shut down
         if self.g_pool.app == "service":
             audio.say("Error: Port already in use.")
-            self.notify_all({"subject": "service_process.should_stop"})
+            # NOTE: We don't want a should_stop notification, but a hard termination at
+            # this point, because Service is still initializing at this point. This way
+            # we can prevent the eye processes from starting, where otherwise we would
+            # have to wait for them to be started until we can close them.
+            self.g_pool.service_should_run = False
             return
 
         # for capture we try to bind to a arbitrary port on the first external interface


### PR DESCRIPTION
The problem was that the shutdown of Service would be so fast that the eye processes were not started up completely.
Thus the cleanup at the end of Service was not received by the eye-processes yet and they would be kept alive.

Preventing the eye processes from starting in case of an initialization failure was way easier to implement and provides better UX than waiting for the eye processes to finish startup before shutting down Service.