### PR TITLE
Forward CLI args of windows run_*.bat files appropriately

### DIFF
--- a/pupil_src/run_capture.bat
+++ b/pupil_src/run_capture.bat
@@ -1,2 +1,2 @@
 SET PATH=%PATH%;%~dp0..\pupil_external
-python main.py capture
+python main.py capture %*

--- a/pupil_src/run_player.bat
+++ b/pupil_src/run_player.bat
@@ -1,2 +1,2 @@
 SET PATH=%PATH%;%~dp0..\pupil_external
-python main.py player %1%
+python main.py player %*

--- a/pupil_src/run_service.bat
+++ b/pupil_src/run_service.bat
@@ -1,2 +1,2 @@
 SET PATH=%PATH%;%~dp0..\pupil_external
-python main.py service
+python main.py service %*


### PR DESCRIPTION
Not sure if this worked at some point before, but we want to be able to pass our CLI args also when running the apps on Windows, e.g. with `run_capture.bat --hide-ui`