### PR TITLE
Fix corrupted gaze data from latest PI recordings

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/info/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/info/__init__.py
@@ -12,5 +12,7 @@ See COPYING and COPYING.LESSER for license details.
 from .. import Version
 from .recording_info import RecordingInfoFile
 from .recording_info_2_0 import _RecordingInfoFile_2_0
+from .recording_info_2_1 import _RecordingInfoFile_2_1
 
 RecordingInfoFile.register_child_class(Version("2.0"), _RecordingInfoFile_2_0)
+RecordingInfoFile.register_child_class(Version("2.1"), _RecordingInfoFile_2_1)

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -207,14 +207,14 @@ class RecordingInfo(collections.abc.MutableMapping):
             return False
 
     def copy_from(self, other):
-        x, y = self, other
+        dest, src = self, other
 
         for (
             property_name,
-            ((_, x_setter), (y_getter, _)),
-        ) in self.__matching_public_properties(x, y).items():
-            value = y_getter(y)
-            x_setter(x, value)
+            ((_, dest_setter), (src_getter, _)),
+        ) in self.__matching_public_properties(dest, src).items():
+            value = src_getter(src)
+            dest_setter(dest, value)
 
         self._assert_property_equality(self, other)  # Sanity check
 

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -213,6 +213,9 @@ class RecordingInfo(collections.abc.MutableMapping):
             property_name,
             ((_, dest_setter), (src_getter, _)),
         ) in self.__matching_public_properties(dest, src).items():
+            if dest_setter is None:
+                # readonly property
+                continue
             value = src_getter(src)
             dest_setter(dest, value)
 

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -313,7 +313,7 @@ class RecordingInfo(collections.abc.MutableMapping):
         if x_property_names == y_property_names:
             property_names = x_property_names
         else:
-            property_names = x_property_names.union(y_property_names)
+            property_names = x_property_names.intersection(y_property_names)
             logger.debug(
                 "Public property mismatch; will only check the following properties: "
                 f"{property_names}"

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info.py
@@ -206,7 +206,7 @@ class RecordingInfo(collections.abc.MutableMapping):
         except AssertionError:
             return False
 
-    def copy_from(self, other):
+    def update_writeable_properties_from(self, other):
         dest, src = self, other
 
         for (
@@ -218,8 +218,6 @@ class RecordingInfo(collections.abc.MutableMapping):
                 continue
             value = src_getter(src)
             dest_setter(dest, value)
-
-        self._assert_property_equality(self, other)  # Sanity check
 
     @classmethod
     def _assert_property_equality(cls, x: "RecordingInfo", y: "RecordingInfo") -> bool:

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_1.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_1.py
@@ -29,7 +29,7 @@ class _RecordingInfoFile_2_1(_RecordingInfoFile_2_0):
     @property
     def _private_key_schema(self) -> RecordingInfoFile._KeyValueSchema:
         return {
-            **super()._private_key_schema(),
+            **super()._private_key_schema,
             # overwrite meta_version key from parent
             "meta_version": (utils.validator_version_string, lambda _: "2.1"),
         }

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_1.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_1.py
@@ -1,0 +1,35 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2019 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+from . import RecordingInfoFile, Version
+from .recording_info_2_0 import _RecordingInfoFile_2_0
+from . import recording_info_utils as utils
+
+
+class _RecordingInfoFile_2_1(_RecordingInfoFile_2_0):
+
+    # Used for differentiating between < v1.18 and >= v1.18 because of a bug in the
+    # upgrade of PI recordings to newstyle. The data format is the same. Note that
+    # min_player_version stays the same, as recordings that have been transformed to
+    # meta version 2.0 can still be opened with v1.16, but PI recordings opened with
+    # meta version 2.0 have to be re-transformed.
+
+    @property
+    def meta_version(self) -> Version:
+        return Version("2.1")
+
+    @property
+    def _private_key_schema(self) -> RecordingInfoFile._KeyValueSchema:
+        return {
+            **super()._private_key_schema(),
+            # overwrite meta_version key from parent
+            "meta_version": (utils.validator_version_string, lambda _: "2.1"),
+        }

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -47,11 +47,11 @@ def transform_invisible_to_corresponding_new_style(rec_dir: str):
     #     ...
 
     else:
-        _transform_invisible_v1_0_to_pprf_2_0(rec_dir)
+        _transform_invisible_v1_0_to_pprf_2_1(rec_dir)
 
 
-def _transform_invisible_v1_0_to_pprf_2_0(rec_dir: str):
-    _generate_pprf_2_0_info_file(rec_dir)
+def _transform_invisible_v1_0_to_pprf_2_1(rec_dir: str):
+    _generate_pprf_2_1_info_file(rec_dir)
 
     # rename info.json file to info.invisible.json
     info_json = Path(rec_dir) / "info.json"
@@ -71,7 +71,7 @@ def _transform_invisible_v1_0_to_pprf_2_0(rec_dir: str):
     _convert_gaze(recording)
 
 
-def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
+def _generate_pprf_2_1_info_file(rec_dir: str) -> RecordingInfoFile:
     info_json = utils.read_info_json_file(rec_dir)
 
     # Get information about recording from info.csv and info.json
@@ -86,7 +86,7 @@ def _generate_pprf_2_0_info_file(rec_dir: str) -> RecordingInfoFile:
 
     # Create a recording info file with the new format,
     # fill out the information, validate, and return.
-    new_info_file = RecordingInfoFile.create_empty_file(rec_dir, Version("2.0"))
+    new_info_file = RecordingInfoFile.create_empty_file(rec_dir, Version("2.1"))
     new_info_file.recording_uuid = recording_uuid
     new_info_file.start_time_system_ns = start_time_system_ns
     new_info_file.start_time_synced_ns = start_time_synced_ns

--- a/pupil_src/shared_modules/pupil_recording/update/new_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/new_style.py
@@ -54,13 +54,11 @@ def recording_update_to_latest_new_style(rec_dir: str):
                     )
                     path.unlink()
             invisible._convert_gaze(PupilRecording(rec_dir))
+            # Bump info file version to 2.1
             new_info_file = RecordingInfoFile.create_empty_file(
                 rec_dir, fixed_version=Version("2.1")
             )
-            # TODO: This does not work yet! Need to build a way of upgrading the
-            # recording info to a new version! And possibly fix or delete this method
-            # which does not seem to function:
-            new_info_file.copy_from(info_file)
+            new_info_file.update_writeable_properties_from(info_file)
             info_file = new_info_file
             info_file.save_file()
 

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -466,7 +466,7 @@ def pi_gaze_items(root_dir):
     # - starts with "gaze"
     # - is followed by one or more characters
     # - is followed by "_timestamps.npy"
-    gaze_timestamp_pattern = "gaze?*_timestamps.npy"
+    gaze_timestamp_pattern = "gaze ps?*_timestamps.npy"
 
     for timestamps_path in pl.Path(root_dir).glob(gaze_timestamp_pattern):
         raw_path = find_raw_path(timestamps_path)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -463,10 +463,10 @@ def pi_gaze_items(root_dir):
         return np.asarray(raw_data, dtype=raw_data_dtype)
 
     # This pattern will match any filename that:
-    # - starts with "gaze"
-    # - is followed by one or more characters
+    # - starts with "gaze ps"
+    # - is followed by one or more digits
     # - is followed by "_timestamps.npy"
-    gaze_timestamp_pattern = "gaze ps?*_timestamps.npy"
+    gaze_timestamp_pattern = "gaze ps[0-9]*_timestamps.npy"
 
     for timestamps_path in pl.Path(root_dir).glob(gaze_timestamp_pattern):
         raw_path = find_raw_path(timestamps_path)


### PR DESCRIPTION
This is important because there was an additional debug file introduced to PI recordings, called `gaze_right ps*_timestamps.npy` which (currently) only contains zeros.

With the previous pattern we intended to match all gaze files for multipart recordings, but now we would include these erroneous zeros, leading to jumps in the gaze data. Specifically these files were corrupted:
* `gaze.pldata`
* `gaze_timestamps.npy`

**So currently when opening a normal single-part PI recording, every second gaze point will be (0,0)!**

Even worse: the gaze timestamps are only generated once upon upgrading of the PI recording to newstyle. This cache is now incorrect and we will have to create an update mechanism for all PI recordings that have been opened once with Player < v1.18.

## To Do:
- [x] Fix corrupted gaze data cache from conversion.