### PR TITLE
Set JPEG_Writer packets.stream to videostream

### DIFF
--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -294,6 +294,7 @@ class JPEG_Writer(AV_Writer):
     def encode_frame(self, input_frame, pts: int) -> T.Iterator[Packet]:
         # for JPEG we only get a single packet per frame
         packet = Packet()
+        packet.stream = self.video_stream
         packet.payload = input_frame.jpeg_buffer
         packet.time_base = self.time_base
         packet.pts = pts


### PR DESCRIPTION
This is because we are checking the packet's stream in AV_Writer now.