### PR TITLE
Fix unopened Pupil Mobile recordings being detected as old-style

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -134,12 +134,23 @@ def _is_pupil_mobile_recording(rec_dir: str) -> bool:
 
 
 def _is_old_style_player_recording(rec_dir: str) -> bool:
+    """Return true if this is an old-style recording.
+
+    There's two cases where we have old-style recordings:
+
+        1.  The recording has been made with Pupil Capture < v1.16
+            (and never been upgraded to new-style)
+        2.  The recording has been made with Pupil Mobile and openend
+            with Pupil Player < v1.16
+    """
     try:
         info_csv = recording_info_utils.read_info_csv_file(rec_dir)
     except FileNotFoundError:
         return False
-    # We test if the "Data Format Version" or "Capture Software Version" field is
-    # present to differentiate untransformed Pupil Mobile recordings. These do not
-    # contain either of these keys. "Capture Software Version" is tested too for legacy
-    # reasons.
-    return "Data Format Version" in info_csv or "Capture Software Version" in info_csv
+
+    # NOTE:
+    # 1. "Unopened" Pupil Mobile recordings do not have a "Data Format Version" field.
+    # 2. Very old versions of Pupil Capture also did not write "Data Format Version".
+    is_newer_old_style = "Data Format Version" in info_csv
+    is_not_pupil_mobile = info_csv.get("Capture Software", "") != "Pupil Mobile"
+    return is_newer_old_style or is_not_pupil_mobile


### PR DESCRIPTION
Opening an unopened Pupil Mobile recording in Pupil Player would cause a crash with:

```
Traceback (most recent call last):
  File "---\pupil/pupil_src\launchables\player.py", line 835, in player_drop
    update_recording(rec_dir)
  File "---\pupil\pupil_src\shared_modules\pupil_recording\update\__init__.py", line 68, in update_recording
    _transformations_to_new_style[recording_type](rec_dir)
  File "---\pupil\pupil_src\shared_modules\pupil_recording\update\old_style.py", line 42, in transform_old_style_to_pprf_2_0
    _update_recording_to_old_style_v1_16(rec_dir)
  File "---\pupil\pupil_src\shared_modules\pupil_recording\update\old_style.py", line 144, in _update_recording_to_old_style_v1_16
    update_recording_v0913_to_v13(rec_dir)
  File "---\pupil\pupil_src\shared_modules\pupil_recording\update\old_style.py", line 355, in update_recording_v0913_to_v13
    pupil_data = fm.load_object(pupil_data_loc)
  File "---\pupil\pupil_src\shared_modules\file_methods.py", line 76, in load_object
    with file_path.open("rb") as fh:
  File "C:\Python\Python36\lib\pathlib.py", line 1183, in open
    opener=self._opener)
  File "C:\Python\Python36\lib\pathlib.py", line 1037, in _opener
    return self._accessor.open(self, flags, mode)
  File "C:\Python\Python36\lib\pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: '---\\recording\\pupil_data'
```