### PR TITLE
Plugin_List unique initialization

### DIFF
--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -310,18 +310,35 @@ class Plugin_List(object):
         # for readablitly.
         self.g_pool.plugins = self
 
-        # now add plugins to plugin list.
-        for initializer in plugin_initializers:
-            name, args = initializer
-            logger.debug("Loading plugin: {} with settings {}".format(name, args))
+        # NOTE: we should not .add() plugins if they get removed immediately again
+        # because of uniqueness constraints. Here we are filtering the passed list first
+        # before calling .add(). This is important so we e.g. don't initialize the UVC
+        # source in player, which will try installing drivers and crash in the bundle.
+
+        # expand first for later filtering
+        expanded_initializers = []
+        for name, args in plugin_initializers:
             try:
-                plugin_by_name[name]
+                expanded_initializers.append((plugin_by_name[name], name, args))
             except KeyError:
-                logger.debug(
-                    "Plugin '{}' failed to load. Not available for import.".format(name)
-                )
+                logger.debug(f"Plugin {name} failed to load, not available for import.")
+        # only add plugins that won't be replaced by newer plugins
+        for i, (plugin, name, args) in enumerate(expanded_initializers):
+            for new_plugin, new_name, _ in expanded_initializers[i + 1 :]:
+                if (
+                    new_plugin.uniqueness == "by_base_class"
+                    and plugin.__bases__[-1] == new_plugin.__bases__[-1]
+                ) or (new_plugin.uniqueness == "by_class" and plugin == new_plugin):
+                    logger.debug(
+                        f"Skipping initialization of plugin {name} because it will be"
+                        f" replaced by newer plugin {new_name} with uniqueness"
+                        f" `{new_plugin.uniqueness}`."
+                    )
+                    break
             else:
-                self.add(plugin_by_name[name], args)
+                # no new_plugin found which would replace old_plugin
+                logger.debug(f"Loading plugin: {name} with settings {args}")
+                self.add(plugin, args)
 
     def __iter__(self):
         for p in self._plugins:

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -305,8 +305,9 @@ class Plugin_List(object):
         self.g_pool = g_pool
         plugin_by_name = g_pool.plugin_by_name
 
-        # add self as g_pool.plguins object to allow plugins to call the plugins list during init.
-        # this will be done again when the init returns but is kept there for readablitly.
+        # add self as g_pool.plguins object to allow plugins to call the plugins list
+        # during init. this will be done again when the init returns but is kept there
+        # for readablitly.
         self.g_pool.plugins = self
 
         # now add plugins to plugin list.


### PR DESCRIPTION
There was a problem where in Player the eye-proces (offline detection) initialized the UVC source plugin, which tried to install drivers on windows. This should not happen, because we don't need UVC in player and actually overwrote the video source.

The problem was that the plugin initializers would be called before filtering the list by uniqueness.
I added filtering of the initial `__init__` list before constructing the initial set of plugins.

All the logic in .add() stayed untouched.