### PR TITLE
Remove upsampling functionality from binocular gaze mapper

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -120,7 +120,6 @@ class Binocular_Gaze_Mapper_Base(Gaze_Mapping_Plugin):
                 p0 = self._caches[0][0]
                 p1 = self._caches[1].popleft()
                 older_pt = p1
-                older_cache = 1
                 cache_idx_not_popped = 0
 
             if abs(p0["timestamp"] - p1["timestamp"]) < self.temportal_cutoff:

--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -115,13 +115,18 @@ class Binocular_Gaze_Mapper_Base(Gaze_Mapping_Plugin):
                 p0 = self._caches[0].popleft()
                 p1 = self._caches[1][0]
                 older_pt = p0
+                cache_idx_not_popped = 1
             else:
                 p0 = self._caches[0][0]
                 p1 = self._caches[1].popleft()
                 older_pt = p1
+                older_cache = 1
+                cache_idx_not_popped = 0
 
             if abs(p0["timestamp"] - p1["timestamp"]) < self.temportal_cutoff:
                 gaze_datum = self._map_binocular(p0, p1)
+                # Do not reuse newer pupil position
+                self._caches[cache_idx_not_popped].popleft()
             else:
                 gaze_datum = self._map_monocular(older_pt)
 


### PR DESCRIPTION
This resulted in some pupil datums being mapped multiple times. One can verify the issue by subscribing to binocular gaze `gaze.3d.01.` and measuring the time differences between sequential gaze datums. 