### PR TITLE
Let travis run pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,20 @@
-sudo: required
-services:
-- docker
-language: python
-branches:
-  only:
-    - master
-os:
-- linux
+# Travis integration for running unittests on pupil-labs/pupil
+
+# NOTE: Tests are currently only ran on Ubuntu 18.04
+# There's a docker image pupillabs/pupil-docker-ubuntu:latest which contains all
+# required dependencies for the test-suite to run.
+
+os: minimal
+services: docker
 
 before_install:
-- docker --version
-- docker run -d --name pupil-ubuntu --mount type=bind,source=$TRAVIS_BUILD_DIR,target=/root/pupil
-  pupillabs/pupil-docker-ubuntu:latest tail -f /dev/null
-- docker ps
+  - docker pull pupillabs/pupil-docker-ubuntu:latest
+  - chmod +x ./.travis/*.sh
 
 script:
-- docker exec -t pupil-ubuntu bash -c "chmod +x pupil && 
-  cd pupil/deployment &&
-  ./bundle.sh"
-
-before_deploy:
-  - echo "Preparing to deploy to Github"
-
-deploy:
-  provider: releases
-  api_key:
-    secure: Qlzhn0zM3J+JPTW1aTUwb2uY2LCljna5pgZjJfF5fxoEMb0RHwFXazncqTlqgXwF+WJfefdgdsvXIuLJ6cuylikzMhebv5x5oq11j+B//16lV/juiQCA0B6ej7CyTWVUevWS1Av/ImfaUOcF18wdNHiKJX+T5tnwirYswnDwK4DFmTwduYQtCuyDCMvPZQtzVhHS807+fPJCnoWAPp+nir44WvOMW31KSSYVz/LOqndb3+rAZl7LVVW4riF1uSMB7La16NQ9qx/ZvMNOAk3IXelKrkzOWp5kWWF3PEj6xGf5r1SAf/caCcfBbMYOTNXvcUNBhBED+klRK0nNtEATrHDN5+K3MGMOSklKUz5MNi6EPrj8rNfUjs0H7nyCXzh8qjV6/fJ807lIywVsIsASAjD2mfYBztX/flDMNmUDC5mntZYUmMlbDgJdF3Zxs9LHJBb5j53LYQ4QCRhnShKp4/ZtAsFFgtQw9i/cj+lE/m+hF2iZOtqYUPMlV2/zHIPm8PZWPA5tE16B3pr/rq5JXtrfjReEE2cr8+TyjycUA1yvVgyjeqHD5jgf8l2Fbn4FNAsU8bylbKGLxHGJV3LPJtqg44SQSTaqDkpbs5XWM52M5tCgiBtpa0gj8rY8Qe+f/4P6+LVzUezGMn+4RgBavhL6IFKigc7X9E99hc7/U2o=
-  file_glob: true
-  file: $TRAVIS_BUILD_DIR/deployment/*.zip
-  skip_cleanup: true
-  name: $TRAVIS_TAG $TRAVIS_OS_NAME - CI
-  body: $TRAVIS_TAG $TRAVIS_OS_NAME release built by CI
-  draft: true
-  on:
-    # tags: true
-    branch: master
-    repo: pupil-labs/pupil
+  - >
+    docker run --rm
+    -v `pwd`:/repo
+    -w /repo
+    pupillabs/pupil-docker-ubuntu:latest
+    /bin/bash /repo/.travis/run_tests.sh

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,0 +1,3 @@
+python -m pip install -U pip
+pip install pytest
+pytest


### PR DESCRIPTION
I removed the old (unused) travis config and replaced it with a new one.
Currently there's only a pytest run in an Ubuntu 18.04 docker image.