### PR TITLE
Temporal cutoffs in binocular gaze mapper based on estimated FPS

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
+++ b/pupil_src/shared_modules/calibration_routines/gaze_mappers.py
@@ -79,7 +79,7 @@ class Binocular_Gaze_Mapper_Base(Gaze_Mapping_Plugin):
 
         self.min_pupil_confidence = 0.6
         self._caches = (deque(), deque())
-        self.default_temportal_cutoff = 0.3
+        self.default_temportal_cutoff = 1/120
         self.sample_cutoff = 10
 
     def calculate_temporal_cutoff(cache):


### PR DESCRIPTION
This PR changes the binocular gaze mapper to use a temporal cutoff based on the estimated FPS of the pupil data stream.
