### PR TITLE
Downgrade pytest to 5.2.2

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,3 +1,3 @@
 python -m pip install -U pip
-pip install pytest
+pip install pytest==5.2.2
 pytest


### PR DESCRIPTION
Currently there seems to be an issue where pytest 5.2.3 runs the calibration module (although this one is not tested).
Since we don't have the dependencies setup yet on travis, this will crash.