### PR TITLE
Fix broken function call for square markers

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -168,9 +168,13 @@ class GUI:
         if not surface.detected:
             return
 
-        corners, top_indicator, title_anchor, surface_edit_anchor, marker_edit_anchor = self._get_surface_anchor_points(
-            surface
-        )
+        (
+            corners,
+            top_indicator,
+            title_anchor,
+            surface_edit_anchor,
+            marker_edit_anchor,
+        ) = self._get_surface_anchor_points(surface)
         alpha = min(1, surface.build_up_status)
 
         surface_color = rgb_to_rgba(self.color_primary_rgb, alpha=alpha)
@@ -402,9 +406,10 @@ class GUI:
                 if not surface.detected:
                     continue
 
-                surface_edit_pressed, marker_edit_pressed = self._check_surface_button_pressed(
-                    surface, pos
-                )
+                (
+                    surface_edit_pressed,
+                    marker_edit_pressed,
+                ) = self._check_surface_button_pressed(surface, pos)
 
                 if surface_edit_pressed:
                     if surface in self._edit_surf_corners:

--- a/pupil_src/shared_modules/surface_tracker/gui.py
+++ b/pupil_src/shared_modules/surface_tracker/gui.py
@@ -310,7 +310,7 @@ class GUI:
             marker_type = marker.marker_type
             if (
                 marker_type == Surface_Marker_Type.SQUARE
-                and marker.perimeter < self.tracker.marker_min_perimeter
+                and marker.perimeter < self.tracker.marker_detector.marker_min_perimeter
             ):
                 continue
 


### PR DESCRIPTION
Currently Capture and Player crash when clicking "add/remove markers" while the legacy square marker detector is selected.

The cause is a wrong function call, likely from earlier refactors.