### PR TITLE
Surface cache improvements

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface_tracker.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker.py
@@ -191,10 +191,11 @@ class Surface_Tracker(Plugin, metaclass=ABCMeta):
         )
 
         def set_marker_detector_mode(value):
-            self.marker_detector.marker_detector_mode = value
-            self.notify_all(
-                {"subject": "surface_tracker.marker_detection_params_changed"}
-            )
+            if self.marker_detector.marker_detector_mode != value:
+                self.marker_detector.marker_detector_mode = value
+                self.notify_all(
+                    {"subject": "surface_tracker.marker_detection_params_changed"}
+                )
 
         menu = ui.Growing_Menu("Marker Detection Parameters")
         menu.collapsed = True

--- a/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
@@ -173,6 +173,8 @@ class Surface_Tracker_Offline(Surface_Tracker, Analysis_Plugin_Base):
         self.marker_cache_unfiltered = Cache(previous_state)
         self.marker_cache = self._filter_marker_cache(self.marker_cache_unfiltered)
 
+        if self.cache_filler is not None:
+            self.cache_filler.cancel()
         self.cache_filler = background_tasks.background_video_processor(
             self.g_pool.capture.source_path,
             offline_utils.marker_detection_callable(


### PR DESCRIPTION
I found two inconveniences when passing by the surface tracker:
1. Selecting the same detection mode would recalculate the cache (although nothing changed)
2. Switching the detection mode would log raised exceptions on Windows because of incomplete cleanup.