### PR TITLE
Remove calibration fixation boost

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/manual_marker_calibration.py
@@ -200,8 +200,6 @@ class Manual_Marker_Calibration(Calibration_Plugin):
                         ref["screen_pos"] = marker_pos
                         ref["timestamp"] = frame.timestamp
                         self.ref_list.append(ref)
-                        if events.get("fixations", []):
-                            self.counter -= 5
                         if self.counter <= 0:
                             # last sample before counter done and moving on
                             audio.tink()

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -226,9 +226,14 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     )
                     self.monitor_idx = 0
                     monitor = glfwGetMonitors()[self.monitor_idx]
-                width, height, redBits, blueBits, greenBits, refreshRate = glfwGetVideoMode(
-                    monitor
-                )
+                (
+                    width,
+                    height,
+                    redBits,
+                    blueBits,
+                    greenBits,
+                    refreshRate,
+                ) = glfwGetVideoMode(monitor)
             else:
                 monitor = None
                 width, height = 640, 360
@@ -342,11 +347,9 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             # Always save pupil positions
             self.pupil_list.extend(events["pupil"])
 
-            if on_position and len(self.markers) and events.get("fixations", []):
-                fixation_boost = 5
+            if on_position and len(self.markers):
                 self.screen_marker_state = min(
-                    self.sample_duration + self.lead_in,
-                    self.screen_marker_state + fixation_boost,
+                    self.sample_duration + self.lead_in, self.screen_marker_state,
                 )
 
             # Animate the screen marker

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -711,7 +711,7 @@ class Fixation_Detector(Fixation_Detector_Base):
             age_threshold = ts_newest - self.min_duration / 1000.0
             # pop elements until only one element below the age threshold remains:
             while self.history[1]["timestamp"] < age_threshold:
-                self.history.popleft()  # remove outdated gaze points
+                del self.history[0]  # remove outdated gaze points
 
         except IndexError:
             pass


### PR DESCRIPTION
Earlier to #1743, the manual marker and screen marker calibrations could be sped up when the Online Fixation Detector was active. This was possible since it used the 3d eye model to calculate fixations. Due to consistency reasons, see 515783161abdf0165ab1898ae2ac83b992916251 for details, we have decided to disable this functionality. Instead the fixation detector always requires calibrated gaze which is not available during the calibration. 