### PR TITLE
Add explicit link for downloading app bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ target="_blank">
 </a>
 
 
-[Download the latest apps](https://github.com/pupil-labs/pupil/releases/latest "Download Pupil Capture, Pupil Player, and Pupil Service application bundles")! 
+You don't need to know how to write code to _use_ Pupil. [Download the latest apps](https://github.com/pupil-labs/pupil/releases/latest "Download Pupil Capture, Pupil Player, and Pupil Service application bundles")! 
 
-You don't need to know how to write code to _use_ Pupil. Read the [Pupil Core user guide](https://docs.pupil-labs.com/core/ "Pupil Core user guide"). 
+Read the [Pupil Core user guide](https://docs.pupil-labs.com/core/ "Pupil Core user guide"). 
 
 ## Developers
 There are a number of ways you can interact with Pupil Core software as a developer:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Our vision is to create tools for a diverse group of people interested in learni
 Chat with us on [Discord](https://pupil-labs.com/chat "Pupil Server on Discord").
 
 ## Users
+<a 
+href="https://github.com/pupil-labs/pupil/releases/latest"
+rel="noopener"
+target="_blank">
+	<p align="center">
+		<img 
+		src="https://raw.githubusercontent.com/wiki/pupil-labs/pupil/media/images/pupil_labs_pupil_core_app_download_banner.jpg" 
+		alt="Download the latest Pupil Core Apps: Pupil Capture, Pupil Player, Pupil Service"/>
+	</p>
+</a>
+
+
 [Download the latest apps](https://github.com/pupil-labs/pupil/releases/latest "Download Pupil Capture, Pupil Player, and Pupil Service application bundles")! 
 
 You don't need to know how to write code to _use_ Pupil. Read the [Pupil Core user guide](https://docs.pupil-labs.com/core/ "Pupil Core user guide"). 


### PR DESCRIPTION
There have been a few users who are not familiar with GitHub having difficulty finding out where to download the latest application bundles. 

I propose to add an image here with a "button" within the image that links to releases/latest. For sake of redundancy I also propose to leave the text link "download the latest apps" - but I am open to suggestions of removing this. 