### PR TITLE
Correctly handle empty video files

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -183,8 +183,13 @@ class Video:
     def check_valid(self):
         try:
             cont = av.open(self.path)
-            n = cont.decode(video=0)
-            _ = next(n)
+            # Three failure scenarios:
+            # 1. Broken video -> AVError
+            # 2. decode() does not yield anything
+            # 3. decode() yields None
+            first_frame = next(cont.decode(video=0), None)
+            if first_frame is None:
+                raise av.AVError("Video does not contain any frames")
         except av.AVError:
             return False
         else:


### PR DESCRIPTION
Fixes `av_frame is referenced before assignment` crash in file backend if video is actually empty but was not recognized as such.