### PR TITLE
Custom gl error

### DIFF
--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -36,6 +36,29 @@ __all__ = [
     "Coord_System",
 ]
 
+
+########################################################################################
+# START OPENGL DEBUGGING
+
+# We are injecting a custom error handling function into PyOpenGL to better investigate
+# GLErrors that we are potentially producing in pyglui or cygl and that we don't catch
+# appropriately. You can produce OpenGL errors with the following snippets for testing:
+
+# import ctypes
+# gl = ctypes.windll.LoadLibrary("opengl32") # NOTE: this is for windows, modify if needed
+
+# # This produces `error 1281 (GL_INVALID_VALUE)`
+# gl.glViewport(0, 0, -100, 1)
+
+# # This produces `error 1280 (GL_INVALID_ENUM)` for some reason (!?)
+# gl.glBegin()
+# gl.glViewport(0, 0, -100, 1)
+# gl.glEnd()
+
+# # Check errors: (will consume flag)
+# logger.debug(gl.glGetError())
+
+
 _original_gl_error_check = OpenGL.error._ErrorChecker.glCheckError
 
 
@@ -62,6 +85,9 @@ def custom_gl_error_handling(
 
 
 OpenGL.error._ErrorChecker.glCheckError = custom_gl_error_handling
+
+# END OPENGL DEBUGGING
+########################################################################################
 
 
 def is_window_visible(window):


### PR DESCRIPTION
Currently, the Python OpenGL bindings perform an explicit error check after each call. For better debugging, it keeps track of the current OpenGL call. If an opengl error occurred before the check, that was not explicitly checked, the bindings error checker will trigger but print the wrong context.

This PR attempts to work around this by emptying the opengl error queue and only logging the exceptions instead of raising them.

Caveat: In case of OpenGL errors, this might result in unexpected visual effects instead of crashing the application.