### PR TITLE
Include missing dll dependencies in Windows bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ mprofile_*.dat
 .ipynb_checkpoints/
 *.dmg
 *.zip
+deployment/pupil_v*
+*.pyd
+*.dll
+win_drv
+.vs

--- a/deployment/bundle.bat
+++ b/deployment/bundle.bat
@@ -43,7 +43,7 @@ call :Bundle player %current_tag%
 cd %release_dir%
 for /d %%d in (*) do (
 	echo Adding %%d
-	7z a -t7z ..\%release_dir%.7z %%d
+	7z a -tzip ..\%release_dir%.zip %%d
 )
 cd ..
 

--- a/deployment/bundle.bat
+++ b/deployment/bundle.bat
@@ -32,9 +32,13 @@ if not exist %release_dir% (
 	mkdir %release_dir%
 )
 
-call python ..\pupil_src\shared_modules\pupil_detectors\build.py
-call python ..\pupil_src\shared_modules\cython_methods\build.py
-call python ..\pupil_src\shared_modules\calibration_routines\optimization_calibration\build.py
+set PATH=%PATH%;C:\Python36\Lib\site-packages\scipy\.libs
+set PATH=%PATH%;C:\Python36\Lib\site-packages\torch\lib
+set PATH=%PATH%;C:\Python36\Lib\site-packages\zmq
+
+python ..\pupil_src\shared_modules\pupil_detectors\build.py
+python ..\pupil_src\shared_modules\cython_methods\build.py
+python ..\pupil_src\shared_modules\calibration_routines\optimization_calibration\build.py
 
 call :Bundle capture %current_tag%
 call :Bundle service %current_tag%

--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -209,6 +209,7 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
+        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -209,7 +209,6 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
-        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -251,7 +251,7 @@ elif platform.system() == "Windows":
     vc_redist_path = external_libs_path / "vc_redist"
     vc_redist_libs = [
         (lib.name, str(lib), "BINARY")
-        for lib in vs_redist_path.glob("*.dll")
+        for lib in vc_redist_path.glob("*.dll")
     ]
 
     coll = COLLECT(

--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -211,9 +211,11 @@ elif platform.system() == "Windows":
         "scipy.special._ufuncs_cxx",
     ]
 
+    external_libs_path = pathlib.Path("../../pupil_external")
+
     a = Analysis(
         ["../../pupil_src/main.py"],
-        pathex=["../../pupil_src/shared_modules/", "../../pupil_external"],
+        pathex=["../../pupil_src/shared_modules/", str(external_libs_path)],
         binaries=None,
         datas=None,
         hiddenimports=pyglui_hidden_imports
@@ -246,6 +248,12 @@ elif platform.system() == "Windows":
         for lib in apriltag_lib_path.rglob("*.dll")
     ]
 
+    vc_redist_path = external_libs_path / "vc_redist"
+    vc_redist_libs = [
+        (lib.name, str(lib), "BINARY")
+        for lib in vs_redist_path.glob("*.dll")
+    ]
+
     coll = COLLECT(
         exe,
         a.binaries,
@@ -257,6 +265,7 @@ elif platform.system() == "Windows":
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],
         [("pyglui/pupil_icons.ttf", ui.get_pupil_icons_font_path(), "DATA")],
         apriltag_libs,
+        vc_redist_libs,
         Tree(
             "../../pupil_src/shared_modules/calibration_routines/fingertip_calibration/weights/",
             prefix="weights",

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -208,6 +208,7 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
+        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -247,7 +247,7 @@ elif platform.system() == "Windows":
     vc_redist_path = external_libs_path / "vc_redist"
     vc_redist_libs = [
         (lib.name, str(lib), "BINARY")
-        for lib in vs_redist_path.glob("*.dll")
+        for lib in vc_redist_path.glob("*.dll")
     ]
 
     coll = COLLECT(

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -208,7 +208,6 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
-        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -210,9 +210,11 @@ elif platform.system() == "Windows":
         "scipy.special._ufuncs_cxx",
     ]
 
+    external_libs_path = pathlib.Path("../../pupil_external")
+ 
     a = Analysis(
         ["../../pupil_src/main.py"],
-        pathex=["../../pupil_src/shared_modules/", "../../pupil_external"],
+        pathex=["../../pupil_src/shared_modules/", str(external_libs_path)],
         hiddenimports=["pyglui.cygl.shader"]
         + scipy_imports
         + av_hidden_imports
@@ -242,6 +244,12 @@ elif platform.system() == "Windows":
         for lib in apriltag_lib_path.rglob("*.dll")
     ]
 
+    vc_redist_path = external_libs_path / "vc_redist"
+    vc_redist_libs = [
+        (lib.name, str(lib), "BINARY")
+        for lib in vs_redist_path.glob("*.dll")
+    ]
+
     coll = COLLECT(
         exe,
         a.binaries,
@@ -252,6 +260,7 @@ elif platform.system() == "Windows":
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],
         [("pyglui/pupil_icons.ttf", ui.get_pupil_icons_font_path(), "DATA")],
         apriltag_libs,
+        vc_redist_libs,
         Tree(
             "../../pupil_src/shared_modules/calibration_routines/fingertip_calibration/weights/",
             prefix="weights",

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -175,7 +175,6 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
-        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -177,9 +177,11 @@ elif platform.system() == "Windows":
         "scipy.special._ufuncs_cxx",
     ]
 
+    external_libs_path = pathlib.Path("../../pupil_external")
+
     a = Analysis(
         ["../../pupil_src/main.py"],
-        pathex=["../../pupil_src/shared_modules/", "../../pupil_external"],
+        pathex=["../../pupil_src/shared_modules/", str(external_libs_path)],
         binaries=None,
         datas=None,
         hiddenimports=pyglui_hidden_imports + scipy_imports + av_hidden_imports,
@@ -203,6 +205,13 @@ elif platform.system() == "Windows":
         console=False,
         resources=["pupil-service.ico,ICON"],
     )
+
+    vc_redist_path = external_libs_path / "vc_redist"
+    vc_redist_libs = [
+        (lib.name, str(lib), "BINARY")
+        for lib in vs_redist_path.glob("*.dll")
+    ]
+
     coll = COLLECT(
         exe,
         a.binaries,
@@ -214,6 +223,7 @@ elif platform.system() == "Windows":
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],
         [("pyglui/pupil_icons.ttf", ui.get_pupil_icons_font_path(), "DATA")],
         np_dll_list,
+        vc_redist_libs,
         strip=False,
         upx=True,
         name="Pupil Service",

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -175,6 +175,7 @@ elif platform.system() == "Windows":
         "scipy.integrate._dop",
         "scipy.special._ufuncs",
         "scipy.special._ufuncs_cxx",
+        "scipy.linalg.blas",
     ]
 
     external_libs_path = pathlib.Path("../../pupil_external")

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 
 
-import platform, sys, os, os.path, numpy, glob
+import platform, sys, os, os.path, numpy, glob, pathlib
 
 av_hidden_imports = [
     "av.format",
@@ -209,7 +209,7 @@ elif platform.system() == "Windows":
     vc_redist_path = external_libs_path / "vc_redist"
     vc_redist_libs = [
         (lib.name, str(lib), "BINARY")
-        for lib in vs_redist_path.glob("*.dll")
+        for lib in vc_redist_path.glob("*.dll")
     ]
 
     coll = COLLECT(

--- a/pupil_external/vc_redist/README.txt
+++ b/pupil_external/vc_redist/README.txt
@@ -1,0 +1,5 @@
+This folder includes dlls that have been extracted from vc_redist.x64.exe to fix https://github.com/pupil-labs/pupil/issues/1661
+
+Specifically, one needs:
+- concrt140.dll
+- vcomp140.dll


### PR DESCRIPTION
[edited by @pfaion ]
This makes sure that #1661 does not happen anymore on Windows systems without the latest Microsoft Visual Studio Redistributable libraries.