### PR TITLE
Fix circle marker visualization after gaps

### DIFF
--- a/pupil_src/launchables/marker_detectors.py
+++ b/pupil_src/launchables/marker_detectors.py
@@ -38,7 +38,11 @@ def circle_detector(ipc_push_url, pair_url, source_path, batch_size=20):
     from circle_detector import CircleTracker
 
     try:
-        src = File_Source(SimpleNamespace(), source_path, timing=None)
+        # TODO: we need fill_gaps=True for correct frame indices to paint the circle
+        # markers on the world stream. But actually we don't want to process gap frames
+        # with the marker detector. We should make an option to only receive non-gap
+        # frames, but with gap-like indices?
+        src = File_Source(SimpleNamespace(), source_path, timing=None, fill_gaps=True)
 
         frame = src.get_frame()
         logger.info("Starting calibration marker detection...")


### PR DESCRIPTION
Fill gaps on circle marker detection to have correct frame indices.

This fixes the visualization of the circle markers being off when there are gaps before the markers, e.g. from the calibration procedure before validation markers.