### PR TITLE
Enable combination of --hide-ui and --profile flags

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -878,6 +878,7 @@ def eye_profiled(
     version,
     eye_id,
     overwrite_cap_settings=None,
+    hide_ui=False,
 ):
     import cProfile
     import subprocess
@@ -896,6 +897,7 @@ def eye_profiled(
             "version": version,
             "eye_id": eye_id,
             "overwrite_cap_settings": overwrite_cap_settings,
+            "hide_ui": hide_ui,
         },
         locals(),
         "eye{}.pstats".format(eye_id),

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -886,7 +886,7 @@ def eye_profiled(
     from .eye import eye
 
     cProfile.runctx(
-        "eye(timebase, is_alive_flag,ipc_pub_url,ipc_sub_url,ipc_push_url, user_dir, version, eye_id, overwrite_cap_settings)",
+        "eye(timebase, is_alive_flag,ipc_pub_url,ipc_sub_url,ipc_push_url, user_dir, version, eye_id, overwrite_cap_settings, hide_ui)",
         {
             "timebase": timebase,
             "is_alive_flag": is_alive_flag,

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -334,12 +334,13 @@ def service_profiled(
     user_dir,
     version,
     preferred_remote_port,
+    hide_ui,
 ):
     import cProfile, subprocess, os
     from .service import service
 
     cProfile.runctx(
-        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version)",
+        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,hide_ui)",
         {
             "timebase": timebase,
             "eye_procs_alive": eye_procs_alive,
@@ -349,6 +350,7 @@ def service_profiled(
             "user_dir": user_dir,
             "version": version,
             "preferred_remote_port": preferred_remote_port,
+            "hide_ui": hide_ui,
         },
         locals(),
         "service.pstats",

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -340,7 +340,7 @@ def service_profiled(
     from .service import service
 
     cProfile.runctx(
-        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,hide_ui)",
+        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port,hide_ui)",
         {
             "timebase": timebase,
             "eye_procs_alive": eye_procs_alive,

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -764,7 +764,7 @@ def world_profiled(
     from .world import world
 
     cProfile.runctx(
-        "world(timebase, eye_procs_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port)",
+        "world(timebase, eye_procs_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port, hide_ui)",
         {
             "timebase": timebase,
             "eye_procs_alive": eye_procs_alive,

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -756,6 +756,7 @@ def world_profiled(
     user_dir,
     version,
     preferred_remote_port,
+    hide_ui,
 ):
     import cProfile
     import subprocess
@@ -773,6 +774,7 @@ def world_profiled(
             "user_dir": user_dir,
             "version": version,
             "preferred_remote_port": preferred_remote_port,
+            "hide_ui": hide_ui,
         },
         locals(),
         "world.pstats",


### PR DESCRIPTION
The --hide-ui flags were missing in the *_profiled launchables.

This was started by #1759 but service_profiled was missing.
I quickly made a new PR for being able to include this in today's release.