### PR TITLE
Only render detector debug views in algorithm mode

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
@@ -34,8 +34,9 @@ class Detector2DPlugin(PupilDetectorPlugin):
 
     def detect(self, frame):
         roi = Roi(*self.g_pool.u_r.get()[:4])
+        debug_img = frame.bgr if self.g_pool.display_mode == "algorithm" else None
         result = self.detector_2d.detect(
-            gray_img=frame.gray, color_img=frame.bgr, roi=roi
+            gray_img=frame.gray, color_img=debug_img, roi=roi,
         )
         eye_id = self.g_pool.eye_id
         location = result["location"]

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -36,10 +36,11 @@ class Detector3DPlugin(PupilDetectorPlugin):
 
     def detect(self, frame):
         roi = Roi(*self.g_pool.u_r.get()[:4])
+        debug_img = frame.bgr if self.g_pool.display_mode == "algorithm" else None
         result = self.detector_3d.detect(
             gray_img=frame.gray,
             timestamp=frame.timestamp,
-            color_img=frame.bgr,
+            color_img=debug_img,
             roi=roi,
             debug=self.is_debug_window_open,
         )


### PR DESCRIPTION
This PR fixes the offline pupil detection displaying the algorithm view by default.

Additionally it disables rendering the algorithm view when `display_mode` is not `"algorithm"`.
Previously we would always render the algorithm view, even when not in algorithm mode.
This could potentially have a big impact on performance.