### PR TITLE
Fix fullscreen calibration

### DIFF
--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -427,10 +427,11 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
         p_window_size = glfwGetFramebufferSize(self._window)
         if p_window_size == (0, 0):
-            # Might be minimized or on Windows in fullscreen mode but tabbed out
-            # (rendered only in background). We get errors when we call the code below
-            # with window size (0, 0). Anyways we probably want to stop calibration in
-            # this case as it will screw up the calibration anyways.
+            # On Windows we get a window_size of (0, 0) when either minimizing the
+            # Window or when tabbing out (rendered only in the background). We get
+            # errors when we call the code below with window size (0, 0). Anyways we
+            # probably want to stop calibration in this case as it will screw up the
+            # calibration anyways.
             self.stop()
             return
 

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -9,7 +9,6 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import os
 import cv2
 import numpy as np
 from gl_utils import adjust_gl_view, clear_gl_screen, basic_gl_setup

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -422,7 +422,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
 
     def gl_display_in_window(self):
         if glfwWindowShouldClose(self._window):
-            self.close_window()
+            self.stop()
             return
 
         p_window_size = glfwGetFramebufferSize(self._window)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -253,7 +253,12 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     self.window_position_default[1],
                 )
 
-            glfwSetInputMode(self._window, GLFW_CURSOR, GLFW_CURSOR_DISABLED)
+            # This makes it harder to accidentally tab out of fullscreen by clicking on
+            # some other window (e.g. when having two monitors). On the other hand you
+            # want a cursor to adjust the window size when not in fullscreen mode.
+            cursor = GLFW_CURSOR_DISABLED if self.fullscreen else GLFW_CURSOR_HIDDEN
+
+            glfwSetInputMode(self._window, GLFW_CURSOR, cursor)
 
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -414,11 +414,18 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     )
 
     def gl_display_in_window(self):
-        active_window = glfwGetCurrentContext()
         if glfwWindowShouldClose(self._window):
             self.close_window()
             return
 
+        p_window_size = glfwGetFramebufferSize(self._window)
+        if p_window_size == (0, 0):
+            # Might be minimized or on Windows in fullscreen mode but tabbed out
+            # (rendered only in background). Anyways we get errors when we call the code
+            # below with window size (0, 0).
+            return
+
+        active_window = glfwGetCurrentContext()
         glfwMakeContextCurrent(self._window)
 
         clear_gl_screen()
@@ -427,7 +434,6 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         r = self.marker_scale * hdpi_factor
         gl.glMatrixMode(gl.GL_PROJECTION)
         gl.glLoadIdentity()
-        p_window_size = glfwGetFramebufferSize(self._window)
         gl.glOrtho(0, p_window_size[0], p_window_size[1], 0, -1, 1)
         # Switch back to Model View Matrix
         gl.glMatrixMode(gl.GL_MODELVIEW)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -253,7 +253,7 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                     self.window_position_default[1],
                 )
 
-            glfwSetInputMode(self._window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN)
+            glfwSetInputMode(self._window, GLFW_CURSOR, GLFW_CURSOR_DISABLED)
 
             # Register callbacks
             glfwSetFramebufferSizeCallback(self._window, on_resize)

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -238,9 +238,14 @@ class Screen_Marker_Calibration(Calibration_Plugin):
                 monitor = None
                 width, height = 640, 360
 
+            # NOTE: Always creating windowed window here, even if in fullscreen mode. On
+            # windows you might experience a black screen for up to 1 sec when creating
+            # a blank window directly in fullscreen mode. By creating it windowed and
+            # then switching to fullscreen it will stay white the entire time.
             self._window = glfwCreateWindow(
-                width, height, title, monitor=monitor, share=glfwGetCurrentContext()
+                width, height, title, share=glfwGetCurrentContext()
             )
+
             if not self.fullscreen:
                 glfwSetWindowPos(
                     self._window,
@@ -262,6 +267,10 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             basic_gl_setup()
             # refresh speed settings
             glfwSwapInterval(0)
+
+            if self.fullscreen:
+                # Switch to full screen here. See NOTE above at glfwCreateWindow().
+                glfwSetWindowMonitor(self._window, monitor, 0, 0, width, height)
 
             glfwMakeContextCurrent(active_window)
 

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -268,11 +268,13 @@ class Screen_Marker_Calibration(Calibration_Plugin):
             # refresh speed settings
             glfwSwapInterval(0)
 
+            glfwMakeContextCurrent(active_window)
+
             if self.fullscreen:
                 # Switch to full screen here. See NOTE above at glfwCreateWindow().
-                glfwSetWindowMonitor(self._window, monitor, 0, 0, width, height)
-
-            glfwMakeContextCurrent(active_window)
+                glfwSetWindowMonitor(
+                    self._window, monitor, 0, 0, width, height, refreshRate
+                )
 
     def on_window_key(self, window, key, scancode, action, mods):
         if action == GLFW_PRESS:

--- a/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
+++ b/pupil_src/shared_modules/calibration_routines/screen_marker_calibration.py
@@ -428,8 +428,10 @@ class Screen_Marker_Calibration(Calibration_Plugin):
         p_window_size = glfwGetFramebufferSize(self._window)
         if p_window_size == (0, 0):
             # Might be minimized or on Windows in fullscreen mode but tabbed out
-            # (rendered only in background). Anyways we get errors when we call the code
-            # below with window size (0, 0).
+            # (rendered only in background). We get errors when we call the code below
+            # with window size (0, 0). Anyways we probably want to stop calibration in
+            # this case as it will screw up the calibration anyways.
+            self.stop()
             return
 
         active_window = glfwGetCurrentContext()

--- a/pupil_src/shared_modules/glfw.py
+++ b/pupil_src/shared_modules/glfw.py
@@ -446,6 +446,7 @@ glfwRestoreWindow = _glfw.glfwRestoreWindow
 glfwShowWindow = _glfw.glfwShowWindow
 glfwHideWindow = _glfw.glfwHideWindow
 glfwGetWindowMonitor = _glfw.glfwGetWindowMonitor
+glfwSetWindowMonitor = _glfw.glfwSetWindowMonitor
 glfwGetWindowAttrib = _glfw.glfwGetWindowAttrib
 glfwSetWindowUserPointer = _glfw.glfwSetWindowUserPointer
 glfwGetWindowUserPointer = _glfw.glfwGetWindowUserPointer


### PR DESCRIPTION
This PR fixes a couple of bugs with the screen marker calibration window:

- On Windows the window won't be black on open anymore
- Capture won't crash anymore (or throw errors) when tabbing out of the calibration
- The calibration will stop when the window is closed/minimized/tabbed out
- The cursor will be captured in fullscreen mode. This reduces the risk of accidentally tabbing out when having more than 1 monitor.

@papr please test all kinds of shenanigans with the calibration window on macOS