### PR TITLE
Adjust realsense loglevel

### DIFF
--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -60,8 +60,7 @@ else:
 
 try:
     from .realsense2_backend import Realsense2_Source, Realsense2_Manager
-except ImportError as ie:
-    print(ie)
+except ImportError:
     logger.debug(
         "Install pyrealsense2 to use the Intel RealSense backend for D400 series cameras"
     )

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -22,22 +22,28 @@ These backends are available:
 - File: Loads video from file
 """
 
+import logging
 import os
-import numpy as np
 from glob import glob
+
+import numpy as np
+
 from camera_models import load_intrinsics
 
-import logging
+from .base_backend import (
+    Base_Manager,
+    Base_Source,
+    EndofVideoError,
+    InitialisationError,
+    StreamError,
+)
+from .fake_backend import Fake_Manager, Fake_Source
+from .file_backend import File_Manager, File_Source, FileSeekError
+from .hmd_streaming import HMD_Streaming_Source
+from .uvc_backend import UVC_Manager, UVC_Source
 
 logger = logging.getLogger(__name__)
 
-from .base_backend import InitialisationError, StreamError, EndofVideoError
-from .base_backend import Base_Source, Base_Manager
-from .fake_backend import Fake_Source, Fake_Manager
-from .file_backend import FileSeekError
-from .file_backend import File_Source, File_Manager
-from .uvc_backend import UVC_Source, UVC_Manager
-from .hmd_streaming import HMD_Streaming_Source
 
 source_classes = [File_Source, UVC_Source, Fake_Source, HMD_Streaming_Source]
 manager_classes = [File_Manager, UVC_Manager, Fake_Manager]

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -53,7 +53,7 @@ else:
 try:
     from .realsense_backend import Realsense_Source, Realsense_Manager
 except ImportError:
-    logger.info("Install pyrealsense to use the Intel RealSense backend")
+    logger.debug("Install pyrealsense to use the Intel RealSense backend")
 else:
     source_classes.append(Realsense_Source)
     manager_classes.append(Realsense_Manager)
@@ -62,7 +62,7 @@ try:
     from .realsense2_backend import Realsense2_Source, Realsense2_Manager
 except ImportError as ie:
     print(ie)
-    logger.info(
+    logger.debug(
         "Install pyrealsense2 to use the Intel RealSense backend for D400 series cameras"
     )
 else:


### PR DESCRIPTION
Not having realsense installed is actually the normal use case, so most of the users would get the log info message and did not know what it was about. It was decided to switch the realsense info to level `debug`.