### PR TITLE
add an option to limit FPS for online pupil detection for performance

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
@@ -16,6 +16,8 @@ from pupil_detectors import Detector2D, DetectorBase, Roi
 from .detector_base_plugin import PupilDetectorPlugin, PropertyProxy
 from .visualizer_2d import draw_pupil_outline
 
+import logging
+logger = logging.getLogger(__name__)
 
 class Detector2DPlugin(PupilDetectorPlugin):
     uniqueness = "by_base_class"
@@ -31,8 +33,15 @@ class Detector2DPlugin(PupilDetectorPlugin):
         super().__init__(g_pool=g_pool)
         self.detector_2d = detector_2d or Detector2D(namespaced_properties or {})
         self.proxy = PropertyProxy(self.detector_2d)
+        self._subsample_fps = 0
+        self._last_detect_timestamp = 0
 
     def detect(self, frame):
+        if self._subsample_fps > 0 and frame.timestamp > self._last_detect_timestamp:
+            if (frame.timestamp-self._last_detect_timestamp)*self._subsample_fps < 1:
+                # skip the detection on that frame, return previous result
+                return self._recent_detection_result
+        self._last_detect_timestamp = frame.timestamp
         roi = Roi(*self.g_pool.u_r.get()[:4])
         result = self.detector_2d.detect(
             gray_img=frame.gray, color_img=frame.bgr, roi=roi
@@ -55,6 +64,14 @@ class Detector2DPlugin(PupilDetectorPlugin):
     @property
     def pretty_class_name(self):
         return "Pupil Detector 2D"
+
+    @property
+    def subsample_fps(self):
+        return self._subsample_fps
+
+    @subsample_fps.setter
+    def subsample_fps(self, subsample_fps):
+        self._subsample_fps = subsample_fps
 
     def gl_display(self):
         if self._recent_detection_result:
@@ -97,6 +114,16 @@ class Detector2DPlugin(PupilDetectorPlugin):
                 label="Pupil max",
                 min=50,
                 max=400,
+                step=1,
+            )
+        )
+        self.menu.append(
+            ui.Slider(
+                "subsample_fps",
+                self,
+                label="subsample FPS",
+                min=0,
+                max=250,
                 step=1,
             )
         )


### PR DESCRIPTION
We have a video camera that capture frame at up to 1KHz FPS, and the most important for us is to dump the video at the highest FPS to the disk to allow offline (re)analysis.
In order to improve the performance and avoid losing frames, I quickly implemented an option to subsample the frames sent to the online pupil detection.
As such, we still have an online feedback on the ability of the algorithm to properly detect the pupil with the current camera setup, but at a lower CPU cost.
This is only for the 2D detector, but it could easily be done for the 3D one and factor it in the base plugin class. 
Pushing it as it might be of interest for other users.
Tell me what you think.