### PR TITLE
Don't detect pupils when ROI out of frame bounds

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -564,6 +564,9 @@ def eye(
             frame = event.get("frame")
             if frame:
                 f_width, f_height = g_pool.capture.frame_size
+                # TODO: Roi should be its own plugin. This way we could put it at the
+                # appropriate order for recent_events() to process frame resolution
+                # changes immediately after the backend.
                 if (g_pool.u_r.array_shape[0], g_pool.u_r.array_shape[1]) != (
                     f_height,
                     f_width,

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -1,3 +1,6 @@
+import logging
+
+from pupil_detectors import Detector3D, DetectorBase, Roi
 from pyglui import ui
 from pyglui.cygl.utils import draw_gl_texture
 
@@ -10,11 +13,12 @@ from gl_utils import (
 )
 from methods import normalize
 from plugin import Plugin
-from pupil_detectors import Detector3D, DetectorBase, Roi
 
-from .detector_base_plugin import PupilDetectorPlugin, PropertyProxy
-from .visualizer_2d import draw_pupil_outline, draw_eyeball_outline
+from .detector_base_plugin import PropertyProxy, PupilDetectorPlugin
+from .visualizer_2d import draw_eyeball_outline, draw_pupil_outline
 from .visualizer_3d import Eye_Visualizer
+
+logger = logging.getLogger(__name__)
 
 
 class Detector3DPlugin(PupilDetectorPlugin):
@@ -36,6 +40,17 @@ class Detector3DPlugin(PupilDetectorPlugin):
 
     def detect(self, frame):
         roi = Roi(*self.g_pool.u_r.get()[:4])
+        if (
+            not 0 <= roi.x_min <= roi.x_max < frame.width
+            or not 0 <= roi.y_min <= roi.y_max < frame.height
+        ):
+            # TODO: Invalid ROIs can occur when switching camera resolutions, because we
+            # adjust the roi only after all plugin recent_events() have been called.
+            # Optimally we make a plugin out of the ROI and call its recent_events()
+            # immediately after the backend, before the detection.
+            logger.debug(f"Invalid Roi {roi} for img {frame.width}x{frame.height}!")
+            return None
+
         result = self.detector_3d.detect(
             gray_img=frame.gray,
             timestamp=frame.timestamp,


### PR DESCRIPTION
Currently we update the Roi too late when switching resolutions, resulting in a bad Roi being passed to the pupil detectors. This can cause crashes on the C++ side, so I caught these cases here.
Long-term we should make a plugin out of the roi and handle everything in the correct order.