### PR TITLE
Need to install pupil detector as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Pupil
-
 <a 
 href="https://pupil-labs.com"
 rel="noopener"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Pupil
+
 <a 
 href="https://pupil-labs.com"
 rel="noopener"

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -63,6 +63,7 @@ pip install pyopengl
 pip install pyzmq
 pip install scipy
 pip install git+https://github.com/zeromq/pyre
+pip install pupil-detectors
 
 pip install pupil_apriltags
 pip install git+https://github.com/pupil-labs/PyAV


### PR DESCRIPTION
With pupil detector being externalized, it is now a dependency for installation. I'm on ubuntu 18 and I'm not sure how this will effect other OS installs so only updating the Ubuntu 18 install instructions