### PR TITLE
Add pip upgrade instructions to README

### DIFF
--- a/docs/dependencies-macos.md
+++ b/docs/dependencies-macos.md
@@ -66,6 +66,9 @@ make && make install
 We recommend using a virtual environment with a valid installation of Python 3.6 or higher.
 
 ```sh
+# Upgrade pip to latest version. This is necessary for some dependencies.
+python -m pip install --upgrade pip
+
 pip install cysignals
 pip install cython
 pip install msgpack==0.5.6

--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -133,6 +133,9 @@ sudo ldconfig
 We recommend using a virtual environment with a valid installation of Python 3.6 or higher.
 
 ```sh
+# Upgrade pip to latest version. This is necessary for some dependencies.
+python -m pip install --upgrade pip
+
 pip install cysignals
 pip install cython
 pip install msgpack==0.5.6

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -52,6 +52,9 @@ sudo udevadm trigger
 We recommend using a virtual environment with a valid installation of Python 3.6 or higher.
 
 ```sh
+# Upgrade pip to latest version. This is necessary for some dependencies.
+python -m pip install --upgrade pip
+
 pip install cysignals
 pip install cython
 pip install msgpack==0.5.6

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -87,6 +87,9 @@ If you downloaded to linked installer:
 ## Install Python Libraries
 
 ```sh
+# Upgrade pip to latest version. This is necessary for some dependencies.
+python -m pip install --upgrade pip
+
 pip install cython
 pip install msgpack==0.5.6
 pip install numexpr


### PR DESCRIPTION
When pip is too old, the installation of e.g. pupil-apriltags will fail.
See issue there: https://github.com/pupil-labs/apriltags/issues/13
This looks like an issue of Pupil when just running the pip install commands from the docs, which probably inspired PR #1775 

Adding exlicit upgrade instructions should get rid of this issue.

As this is user-facing docs-only, we should merge into master.