### PR TITLE
Add ROI mouse-interaction back in

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -666,6 +666,9 @@ def eye(
                         # Position in img pixels
                         pos = denormalize(pos, g_pool.capture.frame_size)
 
+                        # TODO: remove when ROI is plugin
+                        uroi_on_mouse_button(button, action, mods)
+
                         for plugin in g_pool.plugins:
                             if plugin.on_click(pos, button, action):
                                 break


### PR DESCRIPTION
The ROI-mouse-interaction has been accidentally removed when adding the Plugin workflow to eye.py This PR adds this back in.

Note that we have planned to move the ROI code to an actual plugin as well, which will allow us to get rid of all the duplicate logic between ROI and plugins.

Closes #1777 