### PR TITLE
Bump minimal pyglui version to 1.27

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -131,7 +131,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         )
 
         assert VersionFormat(pyglui_version) >= VersionFormat(
-            "1.24"
+            "1.27"
         ), "pyglui out of date, please upgrade to newest version"
 
         process_was_interrupted = False

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -119,7 +119,7 @@ def world(
         from pyglui import ui, cygl, __version__ as pyglui_version
 
         assert VersionFormat(pyglui_version) >= VersionFormat(
-            "1.24"
+            "1.27"
         ), "pyglui out of date, please upgrade to newest version"
         from pyglui.cygl.utils import Named_Texture
         import gl_utils


### PR DESCRIPTION
Once https://github.com/pupil-labs/pyglui/pull/112 has been merged.