### PR TITLE
Use Announcer and Listener for gaze data change

### DIFF
--- a/pupil_src/shared_modules/data_changed.py
+++ b/pupil_src/shared_modules/data_changed.py
@@ -67,12 +67,12 @@ class Announcer:
         self._current_token = None
         plugin.add_observer("on_notify", self._on_notify)
 
-    def announce_new(self):
+    def announce_new(self, token_data=None):
         """
         Announce that new data is available for the topic. New means that is has
         never been broadcasted before (not even in a previous run of the software).
         """
-        token = _create_new_token()
+        token = _normalize_token(token_data)
         self._notify_all(token)
         _write_token_to_file(
             token, self._plugin_role, self._topic, self._plugin_name, self._rec_dir
@@ -171,6 +171,14 @@ class Listener(Observable):
                     self._rec_dir,
                 )
                 self.on_data_changed()
+
+
+def _normalize_token(token_data):
+    if token_data is None:
+        return _create_new_token()
+    if isinstance(token_data, str):
+        return token_data
+    return str(hash(token_data))
 
 
 def _create_new_token():

--- a/pupil_src/shared_modules/data_changed.py
+++ b/pupil_src/shared_modules/data_changed.py
@@ -67,18 +67,18 @@ class Announcer:
         self._current_token = None
         plugin.add_observer("on_notify", self._on_notify)
 
-    def announce_new(self, token_data=None):
+    def announce_new(self, delay=None, token_data=None):
         """
         Announce that new data is available for the topic. New means that is has
         never been broadcasted before (not even in a previous run of the software).
         """
         token = _normalize_token(token_data)
-        self._notify_all(token)
+        self._notify_all(token, delay=delay)
         _write_token_to_file(
             token, self._plugin_role, self._topic, self._plugin_name, self._rec_dir
         )
 
-    def announce_existing(self):
+    def announce_existing(self, delay=None):
         """
         Announce that data for a topic is available, which was already announced
         some time ago (the exact same data).
@@ -93,15 +93,16 @@ class Announcer:
             if read_token is not None:
                 self._current_token = read_token
             else:
-                self.announce_new()
+                self.announce_new(delay=delay)
                 return
-        self._notify_all(self._current_token)
+        self._notify_all(self._current_token, delay=delay)
 
-    def _notify_all(self, token):
+    def _notify_all(self, token, delay=None):
         self._plugin().notify_all(
             {
                 "subject": "data_changed.{}.announce_token".format(self._topic),
                 "token": token,
+                "delay": delay,
             }
         )
 

--- a/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
+++ b/pupil_src/shared_modules/eye_movement/eye_movement_detector_offline.py
@@ -137,17 +137,7 @@ class Offline_Eye_Movement_Detector(Observable, Eye_Movement_Detector_Base):
         return {"show_segmentation": self.menu_content.show_segmentation}
 
     def on_notify(self, notification):
-        if notification["subject"] == "gaze_positions_changed":
-            # TODO: Remove when gaze_positions will be announced with `data_changed.Announcer`
-            note = notification.copy()
-            note["subject"] = "data_changed.{}.announce_token".format(
-                self._gaze_changed_listener._topic
-            )
-            note["token"] = notification.get(
-                "token", "{:0>8x}".format(random.getrandbits(32))
-            )
-            self._gaze_changed_listener._on_notify(note)
-        elif notification["subject"] in (
+        if notification["subject"] in (
             Notification_Subject.SHOULD_RECALCULATE,
             Notification_Subject.MIN_DATA_CONFIDENCE_CHANGED,
         ):

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -44,7 +44,9 @@ from pyglui.pyfontstash import fontstash
 from scipy.spatial.distance import pdist
 
 import background_helper as bh
+import data_changed
 import file_methods as fm
+from observable import Observable
 import player_methods as pm
 from eye_movement.utils import can_use_3d_gaze_mapping
 from methods import denormalize
@@ -242,7 +244,7 @@ def detect_fixations(
     yield "Fixation detection complete", ()
 
 
-class Offline_Fixation_Detector(Fixation_Detector_Base):
+class Offline_Fixation_Detector(Observable, Fixation_Detector_Base):
     """Dispersion-duration-based fixation detector.
 
     This plugin detects fixations based on a dispersion threshold in terms of
@@ -279,6 +281,12 @@ class Offline_Fixation_Detector(Fixation_Detector_Base):
         self.prev_index = -1
         self.bg_task = None
         self.status = ""
+        self._gaze_changed_listener = data_changed.Listener(
+            "gaze_positions", g_pool.rec_dir, plugin=self
+        )
+        self._gaze_changed_listener.add_observer(
+            "on_data_changed", self._classify
+        )
         self.notify_all(
             {"subject": "fixation_detector.should_recalculate", "delay": 0.5}
         )
@@ -428,9 +436,6 @@ class Offline_Fixation_Detector(Fixation_Detector_Base):
         }
 
     def on_notify(self, notification):
-        if notification["subject"] == "gaze_positions_changed":
-            logger.info("Gaze postions changed. Recalculating.")
-            self._classify()
         if notification["subject"] == "min_data_confidence_changed":
             logger.info("Minimal data confidence changed. Recalculating.")
             self._classify()

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -20,7 +20,7 @@ from tasklib.manager import PluginTaskManager
 
 # IMPORTANT: GazeProducerBase needs to be THE LAST in the list of bases, otherwise
 # uniqueness by base class does not work
-class GazeFromOfflineCalibration(Observable, GazeProducerBase):
+class GazeFromOfflineCalibration(GazeProducerBase):
     pretty_class_name = "Gaze From Offline Calibration"
     icon_chr = chr(0xEC14)
     icon_font = "pupil_icons"

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -180,7 +180,7 @@ class GazeFromOfflineCalibration(GazeProducerBase):
 
     def _publish_gaze(self, gaze_bisector):
         self.g_pool.gaze_positions = gaze_bisector
-        self._gaze_changed_announcer.announce_new()
+        self._gaze_changed_announcer.announce_new(delay=1)
 
     def _seek_to_frame(self, frame_index):
         self.notify_all({"subject": "seek_control.should_seek", "index": frame_index})

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -180,7 +180,7 @@ class GazeFromOfflineCalibration(GazeProducerBase):
 
     def _publish_gaze(self, gaze_bisector):
         self.g_pool.gaze_positions = gaze_bisector
-        self.notify_all({"subject": "gaze_positions_changed", "delay": 1})
+        self._gaze_changed_announcer.announce_new()
 
     def _seek_to_frame(self, frame_index):
         self.notify_all({"subject": "seek_control.should_seek", "index": frame_index})

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
@@ -21,7 +21,7 @@ class GazeFromRecording(GazeProducerBase):
     def __init__(self, g_pool):
         super().__init__(g_pool)
         self.g_pool.gaze_positions = self._load_gaze_data()
-        self.notify_all({"subject": "gaze_positions_changed"})
+        self._gaze_changed_announcer.announce_existing()
 
     def _load_gaze_data(self):
         gaze = fm.load_pldata_file(self.g_pool.rec_dir, "gaze")

--- a/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
@@ -11,11 +11,12 @@ See COPYING and COPYING.LESSER for license details.
 
 from pyglui import ui
 
+from observable import Observable
 import player_methods as pm
 from plugin import Producer_Plugin_Base
 
 
-class GazeProducerBase(Producer_Plugin_Base):
+class GazeProducerBase(Observable, Producer_Plugin_Base):
     uniqueness = "by_base_class"
     order = 0.02
     icon_chr = chr(0xEC14)

--- a/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
@@ -11,6 +11,7 @@ See COPYING and COPYING.LESSER for license details.
 
 from pyglui import ui
 
+import data_changed
 from observable import Observable
 import player_methods as pm
 from plugin import Producer_Plugin_Base
@@ -21,6 +22,12 @@ class GazeProducerBase(Observable, Producer_Plugin_Base):
     order = 0.02
     icon_chr = chr(0xEC14)
     icon_font = "pupil_icons"
+
+    def __init__(self, g_pool):
+        super().__init__(g_pool)
+        self._gaze_changed_announcer = data_changed.Announcer(
+            "gaze_positions", g_pool.rec_dir, plugin=self
+        )
 
     def init_ui(self):
         self.add_menu()


### PR DESCRIPTION
##### TODO

- [x] Provide an optional `token` to `Announcer.announce_new`; this would allow to announce "new" data, that _might_ be the same as the previously announced data (e.g. running the gaze mapping on the same pupil data with the same configurations).
