### PR TITLE
Fix monocular data export

### DIFF
--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -428,8 +428,20 @@ class Gaze_Positions_Exporter(_Base_Positions_Exporter):
                 gaze_normals1_3d = raw_value["gaze_normals_3d"].get(1, [None, None, None])
             # monocular
             elif raw_value.get("eye_center_3d", None) is not None:
-                eye_centers0_3d = raw_value["eye_center_3d"]
-                gaze_normals0_3d = raw_value["gaze_normal_3d"]
+                try:
+                    eye_id = raw_value["base_data"][0]["id"]
+                except (KeyError, IndexError):
+                    logger.warning(
+                        f"Unexpected raw base_data for monocular gaze!"
+                        f" Data: {raw_value.get('base_data', None)}"
+                    )
+                else:
+                    if str(eye_id) == "0":
+                        eye_centers0_3d = raw_value["eye_center_3d"]
+                        gaze_normals0_3d = raw_value["gaze_normal_3d"]
+                    elif str(eye_id) == "1":
+                        eye_centers1_3d = raw_value["eye_center_3d"]
+                        gaze_normals1_3d = raw_value["gaze_normal_3d"]
 
         return {
             "gaze_timestamp": gaze_timestamp,

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -10,18 +10,16 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import abc
-import collections
 import csv
 import logging
 import os
 import typing
 
-import csv_utils
 from pyglui import ui
 
+import csv_utils
 import player_methods as pm
 from plugin import Analysis_Plugin_Base
-
 
 # logging
 logger = logging.getLogger(__name__)
@@ -175,7 +173,7 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
                 positions_bisector=self.g_pool.gaze_positions,
                 timestamps=self.g_pool.timestamps,
                 export_window=export_window,
-                export_dir=export_dir
+                export_dir=export_dir,
             )
 
         if self.should_export_field_info:
@@ -186,7 +184,6 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
 
 
 class _Base_Positions_Exporter(abc.ABC):
-
     @classmethod
     @abc.abstractmethod
     def csv_export_filename(cls) -> str:
@@ -199,19 +196,19 @@ class _Base_Positions_Exporter(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def dict_export(cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int) -> dict:
+    def dict_export(
+        cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int
+    ) -> dict:
         pass
 
-    def csv_export_write(self, positions_bisector, timestamps, export_window, export_dir):
+    def csv_export_write(
+        self, positions_bisector, timestamps, export_window, export_dir
+    ):
         export_file = type(self).csv_export_filename()
         export_path = os.path.join(export_dir, export_file)
 
-        export_section = positions_bisector.init_dict_for_window(
-            export_window
-        )
-        export_world_idc = pm.find_closest(
-            timestamps, export_section["data_ts"]
-        )
+        export_section = positions_bisector.init_dict_for_window(export_window)
+        export_world_idc = pm.find_closest(timestamps, export_section["data_ts"])
 
         with open(export_path, "w", encoding="utf-8", newline="") as csvfile:
             csv_header = type(self).csv_export_labels()
@@ -226,7 +223,6 @@ class _Base_Positions_Exporter(abc.ABC):
 
 
 class Pupil_Positions_Exporter(_Base_Positions_Exporter):
-
     @classmethod
     def csv_export_filename(cls) -> str:
         return "pupil_positions.csv"
@@ -274,7 +270,9 @@ class Pupil_Positions_Exporter(_Base_Positions_Exporter):
         )
 
     @classmethod
-    def dict_export(cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int) -> dict:
+    def dict_export(
+        cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int
+    ) -> dict:
         # 2d data
         pupil_timestamp = str(raw_value["timestamp"])
         eye_id = raw_value["id"]
@@ -366,7 +364,6 @@ class Pupil_Positions_Exporter(_Base_Positions_Exporter):
 
 
 class Gaze_Positions_Exporter(_Base_Positions_Exporter):
-
     @classmethod
     def csv_export_filename(cls) -> str:
         return "gaze_positions.csv"
@@ -398,7 +395,9 @@ class Gaze_Positions_Exporter(_Base_Positions_Exporter):
         )
 
     @classmethod
-    def dict_export(cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int) -> dict:
+    def dict_export(
+        cls, raw_value: csv_utils.CSV_EXPORT_RAW_TYPE, world_index: int
+    ) -> dict:
 
         gaze_timestamp = str(raw_value["timestamp"])
         confidence = raw_value["confidence"]
@@ -424,8 +423,12 @@ class Gaze_Positions_Exporter(_Base_Positions_Exporter):
                 eye_centers0_3d = raw_value["eye_centers_3d"].get(0, [None, None, None])
                 eye_centers1_3d = raw_value["eye_centers_3d"].get(1, [None, None, None])
                 #
-                gaze_normals0_3d = raw_value["gaze_normals_3d"].get(0, [None, None, None])
-                gaze_normals1_3d = raw_value["gaze_normals_3d"].get(1, [None, None, None])
+                gaze_normals0_3d = raw_value["gaze_normals_3d"].get(
+                    0, [None, None, None]
+                )
+                gaze_normals1_3d = raw_value["gaze_normals_3d"].get(
+                    1, [None, None, None]
+                )
             # monocular
             elif raw_value.get("eye_center_3d", None) is not None:
                 try:


### PR DESCRIPTION
This PR fixes that for monocular gaze datums, the raw data export would always only populate the eye0 column for `eye_center_*` and `gaze_normal_*`, even if the data was taken from eye1.

Also I applied black and cleaned up the imports.