### PR TITLE
Eyeball Outline for Player

### DIFF
--- a/pupil_src/shared_modules/video_export/plugins/eye_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/eye_video_exporter.py
@@ -36,7 +36,9 @@ class Eye_Video_Exporter(IsolatedFrameExporter):
 
     def customize_menu(self):
         self.menu.label = "Eye Video Exporter"
-        self.menu.append(ui.Switch("render_pupil", self, label="Render detected pupil"))
+        self.menu.append(
+            ui.Switch("render_pupil", self, label="Visualize Pupil Detection")
+        )
         super().customize_menu()
 
     def _export_eye_video(self, export_range, export_dir, eye_id):

--- a/pupil_src/shared_modules/video_overlay/ui/management.py
+++ b/pupil_src/shared_modules/video_overlay/ui/management.py
@@ -125,7 +125,9 @@ class UIManagementEyes(UIManagement):
             )
         )
         self._parent_menu.append(
-            ui.Switch("value", self.plugin().show_ellipses, label="Visualize Ellipses")
+            ui.Switch(
+                "value", self.plugin().show_ellipses, label="Visualize Pupil Detection"
+            )
         )
 
     def _add_overlay_menu(self, overlay):

--- a/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
+++ b/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
@@ -83,6 +83,24 @@ class PupilRenderer(ImageManipulator):
             thickness=-1,
         )
 
+        eye_ball = pupil_position.get("projected_sphere", None)
+        if eye_ball is not None:
+            try:
+                cv2.ellipse(
+                    image,
+                    center=tuple(int(v) for v in eye_ball["center"]),
+                    axes=tuple(int(v / 2) for v in eye_ball["axes"]),
+                    angle=int(eye_ball["angle"]),
+                    startAngle=0,
+                    endAngle=360,
+                    color=(26, 230, 0, 255 * pupil_position["model_confidence"]),
+                    thickness=2,
+                )
+            except ValueError:
+                # Happens when converting 'nan' to int
+                # TODO: Investigate why results are sometimes 'nan'
+                pass
+
     @staticmethod
     def get_ellipse_points(e, num_pts=10):
         c1 = e[0][0]


### PR DESCRIPTION
This PR adds the green eyeball outline visualization to the following **Player** plugins:
- eye overlay
- eye video export

The existing switch for toggling pupil ellipse visualization has been adjusted to include the eyeball outline as well.

When 3D data is not available, we only show the pupil ellipse just as before.