### PR TITLE
Do not process on_click events when there's no frame

### DIFF
--- a/pupil_src/shared_modules/roi.py
+++ b/pupil_src/shared_modules/roi.py
@@ -283,6 +283,9 @@ class Roi(Plugin):
         self.model.frame_size = (frame.width, frame.height)
 
     def on_click(self, pos: Vec2, button: int, action: int) -> bool:
+        if not self.has_frame or self.model.is_invalid():
+            return False
+
         if action == glfw.GLFW_PRESS:
             clicked_handle = self.get_handle_at(pos)
             if clicked_handle != self.active_handle:


### PR DESCRIPTION
Fixes #1825 

I think `not self.has_frame` should already be sufficient, but I noticed that I safe-guarded the other plugin-lifecycle functions (`gl_display`, `on_pos`) already in the same way, so for consistency (and double safety) I also check `model.is_invalid()`.