### PR TITLE
Stop nonmonotonic recording

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -141,7 +141,7 @@ def eye(
         from file_methods import Persistent_Dict
         from version_utils import VersionFormat
         from methods import normalize, denormalize, timer
-        from av_writer import JPEG_Writer, MPEG_Writer, NonMonotonicError
+        from av_writer import JPEG_Writer, MPEG_Writer, NonMonotonicTimestampError
         from ndsi import H264Writer
         from video_capture import source_classes, manager_classes
         from roi import Roi
@@ -586,7 +586,7 @@ def eye(
                 if g_pool.writer:
                     try:
                         g_pool.writer.write_video_frame(frame)
-                    except NonMonotonicError as e:
+                    except NonMonotonicTimestampError as e:
                         logger.error(
                             "Recorder received non-monotonic timestamp!"
                             " Stopping the recording!"

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -141,7 +141,7 @@ def eye(
         from file_methods import Persistent_Dict
         from version_utils import VersionFormat
         from methods import normalize, denormalize, timer
-        from av_writer import JPEG_Writer, MPEG_Writer
+        from av_writer import JPEG_Writer, MPEG_Writer, NonMonotonicError
         from ndsi import H264Writer
         from video_capture import source_classes, manager_classes
         from roi import Roi
@@ -584,7 +584,18 @@ def eye(
                     pass
 
                 if g_pool.writer:
-                    g_pool.writer.write_video_frame(frame)
+                    try:
+                        g_pool.writer.write_video_frame(frame)
+                    except NonMonotonicError as e:
+                        logger.error(
+                            "Recorder received non-monotonic timestamp!"
+                            " Stopping the recording!"
+                        )
+                        logger.debug(str(e))
+                        ipc_socket.notify({"subject": "recording.should_stop"})
+                        ipc_socket.notify(
+                            {"subject": "recording.should_stop", "remote_notify": "all"}
+                        )
 
                 result = event.get("pupil_detection_result", None)
                 if result is not None:

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -89,7 +89,7 @@ def write_timestamps(file_loc, timestamps, output_format="npy"):
         )
 
 
-class NonMonotonicError(ValueError):
+class NonMonotonicTimestampError(ValueError):
     """Indicates that a Writer received non-monotonic data to write."""
 
     pass
@@ -170,7 +170,7 @@ class AV_Writer(abc.ABC):
             last_ts = self.timestamps[-1]
             if ts < last_ts:
                 self.release()
-                raise NonMonotonicError(
+                raise NonMonotonicTimestampError(
                     "Non-monotonic timestamps!"
                     f"Last timestamp: {last_ts}. Given timestamp: {ts}"
                 )

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -89,6 +89,12 @@ def write_timestamps(file_loc, timestamps, output_format="npy"):
         )
 
 
+class NonMonotonicError(ValueError):
+    """Indicates that a Writer received non-monotonic data to write."""
+
+    pass
+
+
 class AV_Writer(abc.ABC):
     def __init__(self, output_file_path: str, start_time_synced: int):
         """
@@ -164,7 +170,7 @@ class AV_Writer(abc.ABC):
             last_ts = self.timestamps[-1]
             if ts < last_ts:
                 self.release()
-                raise ValueError(
+                raise NonMonotonicError(
                     "Non-monotonic timestamps!"
                     f"Last timestamp: {last_ts}. Given timestamp: {ts}"
                 )

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -23,7 +23,7 @@ from ndsi import H264Writer
 from pyglui import ui
 
 import csv_utils
-from av_writer import MPEG_Writer, JPEG_Writer, NonMonotonicError
+from av_writer import MPEG_Writer, JPEG_Writer, NonMonotonicTimestampError
 from file_methods import PLData_Writer, load_object
 from methods import get_system_info, timer
 from video_capture.ndsi_backend import NDSI_Source
@@ -439,7 +439,7 @@ class Recorder(System_Plugin_Base):
                 try:
                     self.writer.write_video_frame(frame)
                     self.frame_count += 1
-                except NonMonotonicError as e:
+                except NonMonotonicTimestampError as e:
                     logger.error(
                         "Recorder received non-monotonic timestamp!"
                         " Stopping the recording!"

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -23,7 +23,7 @@ from ndsi import H264Writer
 from pyglui import ui
 
 import csv_utils
-from av_writer import MPEG_Writer, JPEG_Writer
+from av_writer import MPEG_Writer, JPEG_Writer, NonMonotonicError
 from file_methods import PLData_Writer, load_object
 from methods import get_system_info, timer
 from video_capture.ndsi_backend import NDSI_Source
@@ -436,9 +436,19 @@ class Recorder(System_Plugin_Base):
                     writer.extend(data)
             if "frame" in events:
                 frame = events["frame"]
-                self.writer.write_video_frame(frame)
-                self.frame_count += 1
-
+                try:
+                    self.writer.write_video_frame(frame)
+                    self.frame_count += 1
+                except NonMonotonicError as e:
+                    logger.error(
+                        "Recorder received non-monotonic timestamp!"
+                        " Stopping the recording!"
+                    )
+                    logger.debug(str(e))
+                    self.notify_all({"subject": "recording.should_stop"})
+                    self.notify_all(
+                        {"subject": "recording.should_stop", "remote_notify": "all"}
+                    )
             # # cv2.putText(frame.img, "Frame %s"%self.frame_count,(200,200), cv2.FONT_HERSHEY_SIMPLEX,1,(255,100,100))
 
             self.button.status_text = self.get_rec_time_str()


### PR DESCRIPTION
When timestamps are handled from external sources, the sources need to take care of syncing time. This can lead to jumps in timestamps when syncing while recording.

Since the video writer classes work under the assumption of monotonic data, we cannot handle negative time jumps caused by syncing. Previously Capture would just crash when receiving a negative time jump.

This PR handles negative time jumps more gracefully:
- A running recording will be stopped, so the partial recording is useable
- An error message will be shown, more detailed information will be logged as debug info
- Capture does not crash anymore