### PR TITLE
fixed #1830

### DIFF
--- a/pupil_src/shared_modules/file_methods.py
+++ b/pupil_src/shared_modules/file_methods.py
@@ -237,6 +237,7 @@ class Serialized_Dict(object):
                 self._ser_data,
                 raw=False,
                 use_list=False,
+                strict_map_key=False,
                 object_hook=self.unpacking_object_hook,
                 ext_hook=self.unpacking_ext_hook,
             )


### PR DESCRIPTION
this will address the problem described in #1830  by adding strict_map_key=False to the function call.

As msgpack prior to 1.0.0 used this as default value this will keep backward compatibility but now also ensures that msgpack >= 1.0.0  works as they put the default parameter to True.