### PR TITLE
Use custom error if video does not have frames

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -25,10 +25,6 @@ VIDEO_EXTS = ("mp4", "mjpeg", "h264", "mkv", "avi", "fake")
 VIDEO_TIME_EXTS = VIDEO_EXTS + ("time",)
 
 
-class VideoDoesNotContainFramesError(ValueError):
-    pass
-
-
 class Exposure_Time(object):
     def __init__(self, max_ET, frame_rate, mode="manual"):
         self.mode = mode
@@ -193,8 +189,8 @@ class Video:
             # 3. decode() yields None
             first_frame = next(cont.decode(video=0), None)
             if first_frame is None:
-                raise VideoDoesNotContainFramesError()
-        except (av.AVError, VideoDoesNotContainFramesError):
+                return False  # container does not contain frames
+        except av.AVError:
             return False
         else:
             cont.seek(0)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -25,6 +25,10 @@ VIDEO_EXTS = ("mp4", "mjpeg", "h264", "mkv", "avi", "fake")
 VIDEO_TIME_EXTS = VIDEO_EXTS + ("time",)
 
 
+class VideoDoesNotContainFramesError(ValueError):
+    pass
+
+
 class Exposure_Time(object):
     def __init__(self, max_ET, frame_rate, mode="manual"):
         self.mode = mode
@@ -189,8 +193,8 @@ class Video:
             # 3. decode() yields None
             first_frame = next(cont.decode(video=0), None)
             if first_frame is None:
-                raise av.AVError("Video does not contain any frames")
-        except av.AVError:
+                raise VideoDoesNotContainFramesError()
+        except (av.AVError, VideoDoesNotContainFramesError):
             return False
         else:
             cont.seek(0)


### PR DESCRIPTION
The old implementation raises a TypeError as `av.AVError` expects an additional error code. Instead of passing any error code, the new implementation raises (and catches) a custom error in the case that a video is valid but does not contain any frames.