### PR TITLE
Fix windows path issues

### DIFF
--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -190,16 +190,16 @@ class UVC_Source(Base_Source):
                 temp_path = Path("C:\\Windows\\Temp")
                 if not temp_path.exists():
                     raise RuntimeError(
-                        "Username contains Unicode characters and default Temp folder "
-                        "location could not be found. Please use a different username "
-                        "which only uses english characters!"
+                        "Your path to Pupil contains Unicode characters and the "
+                        "default Temp folder location could not be found. Please place "
+                        "Pupil on a path which only contains english characters!"
                     )
                 logger.debug(
                     "Detected Unicode characters in working directory! "
                     "Switching temporary driver install location to C:\\Windows\\Temp"
                 )
             else:
-                # if pwd has only ascii characters: use default temp location
+                # if cwd has only ascii characters: use default temp location
                 temp_path = None
 
             for id in ids_to_install:
@@ -235,9 +235,8 @@ class UVC_Source(Base_Source):
                     # then belong to a different user and cannot be deleted. We can
                     # ignore this, as temp dirs will be cleaned up on shutdown anyways.
                     logger.warning(
-                        "Received a PermissionError while trying to install drivers. "
-                        "If the driver do not work, please try running from an "
-                        "administrator shell again!"
+                        "Pupil was not run as administrator. If the drivers do not "
+                        "work, please try running as administrator again!"
                     )
                     logger.debug(e)
 


### PR DESCRIPTION
This PR fixes multiple issues on Windows with Unicode characters and spaces in the path to Pupil.

Most notably `libwdi` cannot handle non-ASCII characters in the path to unpack and install drivers to/from. This was bypassed by checking the working directory for ASCII compatibility and using `C:\Windows\Temp` (specifically, to avoid non-ASCII characters in potential default TEMP directory) as fallback location.

By using a new temporary folder for every driver, potential permission errors that occurred when cleaning up folders created by elevated commands have also been prevented. A frequently occurring error due to unescaped spaces in the old cleanup routine was thereby also fixed.