### PR TITLE
Bump ndsi version to v1.3

### DIFF
--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -23,7 +23,7 @@ from .base_backend import Base_Manager, Base_Source, SourceInfo
 try:
     from ndsi import __version__
 
-    assert Version(__version__) >= Version("1.0.dev0")
+    assert Version(__version__) >= Version("1.3")
     from ndsi import __protocol_version__
 except (ImportError, AssertionError):
     raise Exception("pyndsi version is to old. Please upgrade") from None


### PR DESCRIPTION
@papr did we need the previous `.dev0` suffix? I removed it for the bump as I couldn't see anything on NDSI.