### PR TITLE
Update pyndsi on travis before testing

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,3 +1,6 @@
 python -m pip install -U pip
+
+pip install -U git+https://github.com/pupil-labs/pyndsi
+
 pip install pytest==5.2.2
 pytest


### PR DESCRIPTION
This needs to be added once we release NDSI v1.3 in order for the Travis tests to run.
To check if this works, first, re-run Travis on this commit.