### PR TITLE
Flip eye0 video preview by default

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -298,9 +298,10 @@ def eye(
             )
             session_settings.clear()
 
+        camera_is_physically_flipped = eye_id == 0
         g_pool.iconified = False
         g_pool.capture = None
-        g_pool.flip = session_settings.get("flip", False)
+        g_pool.flip = session_settings.get("flip", camera_is_physically_flipped)
         g_pool.display_mode = session_settings.get("display_mode", "camera_image")
         g_pool.display_mode_info_text = {
             "camera_image": "Raw eye camera image. This uses the least amount of CPU power",


### PR DESCRIPTION
The right eye camera (`Pupil Cam1/2/3 ID0`) is assembled upside-down in the Pupil Core headset and VR/AR-addons. The eye process has always allowed the user to flip the eye video preview in the eye windows' general menus.

With this PR we are enabling this option by default for the right eye camera.