### PR TITLE
Remove manual libuvc copy for macOS bundles

### DIFF
--- a/deployment/deploy_capture/bundle.spec
+++ b/deployment/deploy_capture/bundle.spec
@@ -92,7 +92,6 @@ if platform.system() == "Darwin":
         a.binaries - libSystem,
         a.zipfiles,
         a.datas,
-        [("libuvc.0.dylib", "/usr/local/lib/libuvc.0.dylib", "BINARY")],
         [("libglfw.dylib", "/usr/local/lib/libglfw.dylib", "BINARY")],
         [("pyglui/OpenSans-Regular.ttf", ui.get_opensans_font_path(), "DATA")],
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],

--- a/deployment/deploy_player/bundle.spec
+++ b/deployment/deploy_player/bundle.spec
@@ -96,7 +96,6 @@ if platform.system() == "Darwin":
         a.binaries - libSystem,
         a.zipfiles,
         a.datas,
-        [("libuvc.0.dylib", "/usr/local/lib/libuvc.0.dylib", "BINARY")],
         [("libglfw.dylib", "/usr/local/lib/libglfw.dylib", "BINARY")],
         [("pyglui/OpenSans-Regular.ttf", ui.get_opensans_font_path(), "DATA")],
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],

--- a/deployment/deploy_service/bundle.spec
+++ b/deployment/deploy_service/bundle.spec
@@ -74,7 +74,6 @@ if platform.system() == "Darwin":
         a.binaries - libSystem,
         a.zipfiles,
         a.datas,
-        [("libuvc.0.dylib", "/usr/local/lib/libuvc.0.dylib", "BINARY")],
         [("libglfw.dylib", "/usr/local/lib/libglfw.dylib", "BINARY")],
         [("pyglui/OpenSans-Regular.ttf", ui.get_opensans_font_path(), "DATA")],
         [("pyglui/Roboto-Regular.ttf", ui.get_roboto_font_path(), "DATA")],


### PR DESCRIPTION
libuvc and its dependencies should automatically be detected when importing pyuvc during bundling.

Reverts bd3c72a81b9bde464c5ff45e54d636ecf3ffdcb5