### PR TITLE
Ubuntu 16.04: ffmpeg-3 ppa no longer available

### DIFF
--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -17,7 +17,7 @@ sudo apt install -y pkg-config git cmake build-essential nasm wget python3-setup
 Install ffmpeg3 from jonathonf's ppa:
 
 ```sh
-sudo add-apt-repository ppa:jonathonf/ffmpeg-3
+sudo add-apt-repository ppa:jonathonf/ffmpeg-4
 sudo apt-get update
 sudo apt install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev ffmpeg libav-tools x264 x265 libportaudio2 portaudio19-dev
 ```


### PR DESCRIPTION
`ppa:jonathonf/ffmpeg-3` is no longer available. Instead [`ppa:jonathonf/ffmpeg-4`](https://launchpad.net/~jonathonf/+archive/ubuntu/ffmpeg-4) can be used.