### PR TITLE
Decouple dual detectors

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
@@ -38,6 +38,7 @@ class Detector2DPlugin(PupilDetectorPlugin):
 
     label = "C++ 2d detector"
     identifier = "2d"
+    order = 0.100
 
     def __init__(
         self, g_pool=None, namespaced_properties=None, detector_2d: Detector2D = None

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
@@ -47,7 +47,7 @@ class Detector2DPlugin(PupilDetectorPlugin):
         self.detector_2d = detector_2d or Detector2D(namespaced_properties or {})
         self.proxy = PropertyProxy(self.detector_2d)
 
-    def detect(self, frame):
+    def detect(self, frame, **kwargs):
         # convert roi-plugin to detector roi
         roi = Roi(*self.g_pool.roi.bounds)
 

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -9,7 +9,9 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 import logging
+from distutils.version import LooseVersion as VersionFormat
 
+import pupil_detectors
 from pupil_detectors import Detector3D, DetectorBase, Roi
 from pyglui import ui
 from pyglui.cygl.utils import draw_gl_texture
@@ -29,6 +31,15 @@ from .visualizer_2d import draw_eyeball_outline, draw_pupil_outline
 from .visualizer_3d import Eye_Visualizer
 
 logger = logging.getLogger(__name__)
+
+if VersionFormat(pupil_detectors.__version__) < VersionFormat("1.0.5"):
+    msg = (
+        f"This version of Pupil requires pupil_detectors >= 1.0.5."
+        f" You are running with pupil_detectors == {pupil_detectors.__version__}."
+        f" Please upgrade to a newer version!"
+    )
+    logger.error(msg)
+    raise RuntimeError(msg)
 
 
 class Detector3DPlugin(PupilDetectorPlugin):

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -60,7 +60,7 @@ class Detector3DPlugin(PupilDetectorPlugin):
             color_img=debug_img,
             roi=roi,
             debug=self.is_debug_window_open,
-            internal_raw_2d_data=kwargs.get("internal_raw_2d_data", None)
+            internal_raw_2d_data=kwargs.get("internal_raw_2d_data", None),
         )
 
         eye_id = self.g_pool.eye_id

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -49,7 +49,7 @@ class Detector3DPlugin(PupilDetectorPlugin):
         # debug window
         self.debugVisualizer3D = Eye_Visualizer(g_pool, self.detector_3d.focal_length())
 
-    def detect(self, frame):
+    def detect(self, frame, **kwargs):
         # convert roi-plugin to detector roi
         roi = Roi(*self.g_pool.roi.bounds)
 
@@ -60,6 +60,7 @@ class Detector3DPlugin(PupilDetectorPlugin):
             color_img=debug_img,
             roi=roi,
             debug=self.is_debug_window_open,
+            internal_raw_2d_data=kwargs.get("internal_raw_2d_data", None)
         )
 
         eye_id = self.g_pool.eye_id

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -38,6 +38,7 @@ class Detector3DPlugin(PupilDetectorPlugin):
 
     label = "C++ 3d detector"
     identifier = "3d"
+    order = 0.101
 
     def __init__(
         self, g_pool=None, namespaced_properties=None, detector_3d: Detector3D = None

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_base_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_base_plugin.py
@@ -92,7 +92,20 @@ class PupilDetectorPlugin(Plugin):
                 self.on_resolution_change(self._last_frame_size, frame_size)
             self._last_frame_size = frame_size
 
-        detection_result = self.detect(frame=frame)
+        # TODO: The following sections with internal_2d_raw_data are for allowing dual
+        # detectors until pye3d is finished. Then we should cleanup this section!
+
+        # this is only revelant when running the 3D detector, for 2D we just ignore the
+        # additional parameter
+        detection_result = self.detect(
+            frame=frame, internal_raw_2d_data=event.get("internal_2d_raw_data", None)
+        )
+
+        # if we are running the 2D detector, we might get internal data that we don't
+        # want published, so we remove it from the dict 
+        if "internal_2d_raw_data" in detection_result:
+            event["internal_2d_raw_data"] = detection_result.pop("internal_2d_raw_data")
+
         if EVENT_KEY in event:
             event[EVENT_KEY].append(detection_result)
         else:

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_base_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_base_plugin.py
@@ -102,7 +102,7 @@ class PupilDetectorPlugin(Plugin):
         )
 
         # if we are running the 2D detector, we might get internal data that we don't
-        # want published, so we remove it from the dict 
+        # want published, so we remove it from the dict
         if "internal_2d_raw_data" in detection_result:
             event["internal_2d_raw_data"] = detection_result.pop("internal_2d_raw_data")
 


### PR DESCRIPTION
This PR modifies the detector plugins in order to allow running 2D and 3D detectors in parallel, without having the 2D detector twice.

This branch only work together with https://github.com/pupil-labs/pupil-detectors/pull/9