### PR TITLE
Use pupil data bisector as g_pool.pupil_positions

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -324,7 +324,6 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
 
         # populated by producers
         g_pool.pupil_positions = pm.Bisector()
-        g_pool.pupil_positions_by_id = (pm.Bisector(), pm.Bisector())
         g_pool.gaze_positions = pm.Bisector()
         g_pool.fixations = pm.Affiliator()
         g_pool.eye_movements = pm.Affiliator()

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -323,7 +323,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         )
 
         # populated by producers
-        g_pool.pupil_positions = pm.Bisector()
+        g_pool.pupil_positions = pm.PupilDataBisector()
         g_pool.gaze_positions = pm.Bisector()
         g_pool.fixations = pm.Affiliator()
         g_pool.eye_movements = pm.Affiliator()

--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -62,7 +62,11 @@ class GazeMapperController(Observable):
                 "mapper '{}'".format(calibration.name, gaze_mapper.name),
             )
             return None
-        task = self._create_mapping_task(gaze_mapper, calibration)
+        try:
+            task = self._create_mapping_task(gaze_mapper, calibration)
+        except worker.map_gaze.NotEnoughPupilData:
+            self._abort_calculation(gaze_mapper, "There is no pupil data to be mapped!")
+            return None
         self._task_manager.add_task(task)
         logger.info("Start gaze mapping for '{}'".format(gaze_mapper.name))
 

--- a/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
@@ -53,6 +53,7 @@ def _map_gaze(
     manual_correction_y,
     shared_memory,
 ):
+    fake_gpool.import_runtime_plugins()
     gazers_by_name = registered_gazer_classes_by_class_name()
     gazer_cls = gazers_by_name[gazer_class_name]
     gazer = gazer_cls(fake_gpool, params=gazer_params)

--- a/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
@@ -19,10 +19,16 @@ from .fake_gpool import FakeGPool
 g_pool = None  # set by the plugin
 
 
+class NotEnoughPupilData(ValueError):
+    pass
+
+
 def create_task(gaze_mapper, calibration):
     assert g_pool, "You forgot to set g_pool by the plugin"
     mapping_window = pm.exact_window(g_pool.timestamps, gaze_mapper.mapping_index_range)
     pupil_pos_in_mapping_range = g_pool.pupil_positions.by_ts_window(mapping_window)
+    if not pupil_pos_in_mapping_range:
+        raise NotEnoughPupilData
 
     fake_gpool = FakeGPool.from_g_pool(g_pool)
 

--- a/pupil_src/shared_modules/gaze_producer/worker/validate_gaze.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/validate_gaze.py
@@ -60,6 +60,7 @@ def validate(
     pupils_in_validation_range,
     refs_in_validation_range,
 ):
+    g_pool.import_runtime_plugins()
     gazers_by_name = registered_gazer_classes_by_class_name()
     gazer_class = gazers_by_name[gazer_class_name]
 

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -8,10 +8,18 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
+import collections
+import functools
 import logging
+import re
+import typing as T
+from itertools import chain
 
 import cv2
 import numpy as np
+
+import file_methods as fm
+import player_methods as pm
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +143,187 @@ class Affiliator(Bisector):
             "start_ts": self.data_ts[start_idx:stop_idx],
             "stop_ts": self.stop_ts[start_idx:stop_idx],
         }
+
+
+class PupilTopic:
+    WildcardKey = T.Union[type(...), slice]
+    EyeIdFilterKey = T.Union[WildcardKey, int, str, T.Iterable[int], T.Iterable[str]]
+    DetectorTagFilterKey = T.Union[WildcardKey, str, T.Iterable[str]]
+
+    _FORMAT_STRING_V1 = "pupil.{eye_id}"
+    _FORMAT_STRING_V2 = "pupil.{eye_id}.{detector_tag}"
+
+    _MATCH_FORMAT_STRING_V1 = r"^pupil\.(?P<eye_id>{eye_id})$"
+    _MATCH_FORMAT_STRING_V2 = (
+        r"^pupil\.(?P<eye_id>{eye_id})\.(?P<detector_tag>{detector_tag})$"
+    )
+
+    _legacy_method_to_detector_tag = {
+        "2d c++": "2d",
+        "3d c++": "3d",
+    }
+
+    @staticmethod
+    def create(topic: str, pupil_datum: dict) -> str:
+        regex_v1 = PupilTopic._match_regex_v1()
+        match_v1 = re.match(regex_v1, topic)
+        if match_v1:
+            detector_tag = pupil_datum["method"]
+            if detector_tag in PupilTopic._legacy_method_to_detector_tag:
+                detector_tag = PupilTopic._legacy_method_to_detector_tag[detector_tag]
+            return PupilTopic._FORMAT_STRING_V2.format(
+                eye_id=match_v1.group("eye_id"), detector_tag=detector_tag,
+            )
+        regex_v2 = PupilTopic._match_regex_v2()
+        match_v2 = re.match(regex_v2, topic)
+        if match_v2:
+            return PupilTopic._FORMAT_STRING_V2.format(
+                eye_id=match_v2.group("eye_id"),
+                detector_tag=match_v2.group("detector_tag"),
+            )
+        raise ValueError(f'Invalid pupil topic: "{topic}"')
+
+    @staticmethod
+    def match(topic: str, eye_id=None, detector_tag=None):
+        eye_id = PupilTopic._canonical_subpattern(eye_id)
+        detector_tag = PupilTopic._canonical_subpattern(detector_tag)
+        regex_v2 = PupilTopic._match_regex_v2(eye_id=eye_id, detector_tag=detector_tag)
+        return re.match(regex_v2, topic)
+
+    @staticmethod
+    def _canonical_subpattern(key) -> str:
+        if isinstance(key, slice) and key != slice(None, None, None):
+            raise ValueError("Only unconstrained slices (`:`, `::`) allowed")
+        elif key is None or key is ... or isinstance(key, slice):
+            return None
+        elif isinstance(key, str) or isinstance(key, int):
+            return str(key)
+        else:
+            return f'({"|".join(map(str, key))})'
+
+    @staticmethod
+    @functools.lru_cache(128)
+    def _match_regex_v2(
+        eye_id: T.Optional[str] = None, detector_tag: T.Optional[str] = None
+    ):
+        if eye_id is None:
+            eye_id = "[01]"
+
+        if detector_tag is None:
+            detector_tag = r"[^\.]+"
+
+        pattern = PupilTopic._MATCH_FORMAT_STRING_V2.format(
+            eye_id=eye_id, detector_tag=detector_tag,
+        )
+
+        return re.compile(pattern)
+
+    @staticmethod
+    @functools.lru_cache(32)
+    def _match_regex_v1(eye_id: T.Optional[str] = None):
+        if eye_id is None:
+            eye_id = "[01]"
+
+        pattern = PupilTopic._MATCH_FORMAT_STRING_V1.format(eye_id=eye_id,)
+
+        return re.compile(pattern)
+
+
+class PupilDataBisector:
+    def __init__(self, data: fm.PLData = fm.PLData([], [], [])):
+        self._bisectors = collections.defaultdict(pm.Mutable_Bisector)
+        self._init_from_data(data)
+
+    def _init_from_data(self, data: fm.PLData):
+        for pupil_topic, data in self._group_data_by_pupil_topic(data).items():
+            assert pupil_topic not in self._bisectors
+            assert len(data.topics) == len(data.data) == len(data.timestamps)
+            bisector = pm.Mutable_Bisector(data.data, data.timestamps)
+            self._bisectors[pupil_topic] = bisector
+
+    def init_dict_for_window(self, ts_window):
+        init_dict = collections.defaultdict(list)
+        for topic, bisector in self._bisectors.items():
+            _init_dict = bisector.init_dict_for_window(ts_window)
+            for key, values in _init_dict.items():
+                init_dict[key].extend(values)
+            topics = [topic] * len(_init_dict["data"])
+            init_dict["topics"].extend(topics)
+
+        return init_dict
+
+    @staticmethod
+    def from_init_dict(init_dict):
+        data = fm.PLData(init_dict["data"], init_dict["data_ts"], init_dict["topics"])
+        return PupilDataBisector(data)
+
+    def __getitem__(
+        self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]
+    ) -> pm.Bisector:
+        bisectors = [
+            B for topic, B in self._bisectors.items() if PupilTopic.match(topic, *key)
+        ]
+        return self.combine_bisectors(bisectors)
+
+    def by_ts_window(self, ts_window):
+        bisectors = self._bisectors.values()
+        init_dicts = [b.init_dict_for_window(ts_window) for b in bisectors]
+        bisectors = [pm.Bisector(**init_dict) for init_dict in init_dicts]
+        combined = self.combine_bisectors(bisectors)
+        return combined
+
+    def by_ts(self, ts):
+        # Returns datum for first bisector that contains it
+        # TODO: Might require rework depending on where/how it is used
+        for bisector in self._bisectors.values():
+            try:
+                return bisector.by_ts(ts)
+            except ValueError:
+                continue
+        raise ValueError
+
+    def append(self, topic, datum, timestamp):
+        pupil_topic = PupilTopic.create(topic, datum)
+        self._bisectors[pupil_topic].insert(timestamp, datum)
+
+    def clear(self):
+        self._bisectors.clear()
+
+    def copy(self):
+        copy = type(self)()
+        for topic, bisector in self._bisectors.items():
+            copy._bisectors[topic] = bisector.copy()
+        return copy
+
+    @staticmethod
+    def combine_bisectors(bisectors: T.Iterable[pm.Bisector]) -> pm.Bisector:
+        data = list(chain.from_iterable(b.data for b in bisectors))
+        data_ts = list(chain.from_iterable(b.data_ts for b in bisectors))
+        return pm.Bisector(data, data_ts)
+
+    @classmethod
+    def load_from_file(cls, dir_path, filename) -> "PupilDataBisector":
+        data = fm.load_pldata_file(dir_path, filename)
+        return cls(data=data)
+
+    def save_to_file(self, dir_path, filename):
+        with fm.PLData_Writer(dir_path, filename) as writer:
+            for topic, bisector in self._bisectors.items():
+                for timestamp, datum in zip(bisector.timestamps, bisector.data):
+                    writer.append_serialized(timestamp, topic, datum.serialized)
+
+    ### PRIVATE
+
+    @staticmethod
+    def _group_data_by_pupil_topic(data: fm.PLData) -> T.Dict[str, fm.PLData]:
+        assert len(data.topics) == len(data.data) == len(data.timestamps)
+        data_by_topic = collections.defaultdict(lambda: fm.PLData([], [], []))
+        for raw_topic, datum, ts in zip(data.topics, data.data, data.timestamps):
+            pupil_topic = PupilTopic.create(raw_topic, datum)
+            data_by_topic[pupil_topic].data.append(datum)
+            data_by_topic[pupil_topic].timestamps.append(ts)
+            data_by_topic[pupil_topic].topics.append(raw_topic)
+        return data_by_topic
 
 
 def find_closest(target, source):

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -52,6 +52,13 @@ class Bisector(object):
             self.data_ts = self.data_ts[self.sorted_idc]
             self.data = self.data[self.sorted_idc].tolist()
 
+    def copy(self):
+        copy = type(self)()
+        copy.data = self.data.copy()
+        copy.data_ts = self.data_ts.copy()
+        copy.sorted_idc = self.sorted_idc.copy()
+        return copy
+
     def by_ts(self, ts):
         """
         :param ts: timestamp to extract.

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -9,13 +9,9 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import collections
 import logging
 import os
 from itertools import chain
-import re
-import functools
-import typing as T
 
 import numpy as np
 import OpenGL.GL as gl
@@ -156,7 +152,10 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
 
             # max_val must not be 0, else gl will crash
             all_pupil_data_chained = chain.from_iterable(ts_data_pairs_right_left)
-            max_val = max((pd[1] for pd in all_pupil_data_chained)) or 1
+            try:
+                max_val = max((pd[1] for pd in all_pupil_data_chained))
+            except ValueError:  # max() arg is an empty sequence
+                max_val = 1
 
             self.cache[key] = {
                 "right": ts_data_pairs_right_left[0],
@@ -221,7 +220,7 @@ class Pupil_From_Recording(Pupil_Producer_Base):
     def __init__(self, g_pool):
         super().__init__(g_pool)
 
-        pupil_data = PupilDataBisector.load_from_file(g_pool.rec_dir, "pupil")
+        pupil_data = pm.PupilDataBisector.load_from_file(g_pool.rec_dir, "pupil")
         g_pool.pupil_positions = pupil_data
         self._pupil_changed_announcer.announce_existing()
         logger.debug("pupil positions changed")
@@ -232,187 +231,6 @@ class Pupil_From_Recording(Pupil_Producer_Base):
         self.menu.append(
             ui.Info_Text("Currently, pupil positions are loaded from the recording.")
         )
-
-
-class PupilTopic:
-    WildcardKey = T.Union[type(...), slice]
-    EyeIdFilterKey = T.Union[WildcardKey, int, str, T.Iterable[int], T.Iterable[str]]
-    DetectorTagFilterKey = T.Union[WildcardKey, str, T.Iterable[str]]
-
-    _FORMAT_STRING_V1 = "pupil.{eye_id}"
-    _FORMAT_STRING_V2 = "pupil.{eye_id}.{detector_tag}"
-
-    _MATCH_FORMAT_STRING_V1 = r"^pupil\.(?P<eye_id>{eye_id})$"
-    _MATCH_FORMAT_STRING_V2 = (
-        r"^pupil\.(?P<eye_id>{eye_id})\.(?P<detector_tag>{detector_tag})$"
-    )
-
-    _legacy_method_to_detector_tag = {
-        "2d c++": "2d",
-        "3d c++": "3d",
-    }
-
-    @staticmethod
-    def create(topic: str, pupil_datum: dict) -> str:
-        regex_v1 = PupilTopic._match_regex_v1()
-        match_v1 = re.match(regex_v1, topic)
-        if match_v1:
-            detector_tag = pupil_datum["method"]
-            if detector_tag in PupilTopic._legacy_method_to_detector_tag:
-                detector_tag = PupilTopic._legacy_method_to_detector_tag[detector_tag]
-            return PupilTopic._FORMAT_STRING_V2.format(
-                eye_id=match_v1.group("eye_id"), detector_tag=detector_tag,
-            )
-        regex_v2 = PupilTopic._match_regex_v2()
-        match_v2 = re.match(regex_v2, topic)
-        if match_v2:
-            return PupilTopic._FORMAT_STRING_V2.format(
-                eye_id=match_v2.group("eye_id"),
-                detector_tag=match_v2.group("detector_tag"),
-            )
-        raise ValueError(f'Invalid pupil topic: "{topic}"')
-
-    @staticmethod
-    def match(topic: str, eye_id=None, detector_tag=None):
-        eye_id = PupilTopic._canonical_subpattern(eye_id)
-        detector_tag = PupilTopic._canonical_subpattern(detector_tag)
-        regex_v2 = PupilTopic._match_regex_v2(eye_id=eye_id, detector_tag=detector_tag)
-        return re.match(regex_v2, topic)
-
-    @staticmethod
-    def _canonical_subpattern(key) -> str:
-        if isinstance(key, slice) and key != slice(None, None, None):
-            raise ValueError("Only unconstrained slices (`:`, `::`) allowed")
-        elif key is None or key is ... or isinstance(key, slice):
-            return None
-        elif isinstance(key, str) or isinstance(key, int):
-            return str(key)
-        else:
-            return f'({"|".join(map(str, key))})'
-
-    @staticmethod
-    @functools.lru_cache(128)
-    def _match_regex_v2(
-        eye_id: T.Optional[str] = None, detector_tag: T.Optional[str] = None
-    ):
-        if eye_id is None:
-            eye_id = "[01]"
-
-        if detector_tag is None:
-            detector_tag = r"[^\.]+"
-
-        pattern = PupilTopic._MATCH_FORMAT_STRING_V2.format(
-            eye_id=eye_id, detector_tag=detector_tag,
-        )
-
-        return re.compile(pattern)
-
-    @staticmethod
-    @functools.lru_cache(32)
-    def _match_regex_v1(eye_id: T.Optional[str] = None):
-        if eye_id is None:
-            eye_id = "[01]"
-
-        pattern = PupilTopic._MATCH_FORMAT_STRING_V1.format(eye_id=eye_id,)
-
-        return re.compile(pattern)
-
-
-class PupilDataBisector:
-    def __init__(self, data: fm.PLData = fm.PLData([], [], [])):
-        self._bisectors = collections.defaultdict(pm.Mutable_Bisector)
-        self._init_from_data(data)
-
-    def _init_from_data(self, data: fm.PLData):
-        for pupil_topic, data in self._group_data_by_pupil_topic(data).items():
-            assert pupil_topic not in self._bisectors
-            assert len(data.topics) == len(data.data) == len(data.timestamps)
-            bisector = pm.Mutable_Bisector(data.data, data.timestamps)
-            self._bisectors[pupil_topic] = bisector
-
-    def init_dict_for_window(self, ts_window):
-        init_dict = collections.defaultdict(list)
-        for topic, bisector in self._bisectors.items():
-            _init_dict = bisector.init_dict_for_window(ts_window)
-            for key, values in _init_dict.items():
-                init_dict[key].extend(values)
-            topics = [topic] * len(_init_dict["data"])
-            init_dict["topics"].extend(topics)
-
-        return init_dict
-
-    @staticmethod
-    def from_init_dict(init_dict):
-        data = fm.PLData(init_dict["data"], init_dict["data_ts"], init_dict["topics"])
-        return PupilDataBisector(data)
-
-    def __getitem__(
-        self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]
-    ) -> pm.Bisector:
-        bisectors = [
-            B for topic, B in self._bisectors.items() if PupilTopic.match(topic, *key)
-        ]
-        return self.combine_bisectors(bisectors)
-
-    def by_ts_window(self, ts_window):
-        bisectors = self._bisectors.values()
-        init_dicts = [b.init_dict_for_window(ts_window) for b in bisectors]
-        bisectors = [pm.Bisector(**init_dict) for init_dict in init_dicts]
-        combined = self.combine_bisectors(bisectors)
-        return combined
-
-    def by_ts(self, ts):
-        # Returns datum for first bisector that contains it
-        # TODO: Might require rework depending on where/how it is used
-        for bisector in self._bisectors.values():
-            try:
-                return bisector.by_ts(ts)
-            except ValueError:
-                continue
-        raise ValueError
-
-    def append(self, topic, datum, timestamp):
-        pupil_topic = PupilTopic.create(topic, datum)
-        self._bisectors[pupil_topic].insert(timestamp, datum)
-
-    def clear(self):
-        self._bisectors.clear()
-
-    def copy(self):
-        copy = type(self)()
-        for topic, bisector in self._bisectors.items():
-            copy._bisectors[topic] = bisector.copy()
-        return copy
-
-    @staticmethod
-    def combine_bisectors(bisectors: T.Iterable[pm.Bisector]) -> pm.Bisector:
-        data = list(chain.from_iterable(b.data for b in bisectors))
-        data_ts = list(chain.from_iterable(b.data_ts for b in bisectors))
-        return pm.Bisector(data, data_ts)
-
-    @classmethod
-    def load_from_file(cls, dir_path, filename) -> "PupilDataBisector":
-        data = fm.load_pldata_file(dir_path, filename)
-        return cls(data=data)
-
-    def save_to_file(self, dir_path, filename):
-        with fm.PLData_Writer(dir_path, filename) as writer:
-            for topic, bisector in self._bisectors.items():
-                for timestamp, datum in zip(bisector.timestamps, bisector.data):
-                    writer.append_serialized(timestamp, topic, datum.serialized)
-
-    ### PRIVATE
-
-    @staticmethod
-    def _group_data_by_pupil_topic(data: fm.PLData) -> T.Dict[str, fm.PLData]:
-        assert len(data.topics) == len(data.data) == len(data.timestamps)
-        data_by_topic = collections.defaultdict(lambda: fm.PLData([], [], []))
-        for raw_topic, datum, ts in zip(data.topics, data.data, data.timestamps):
-            pupil_topic = PupilTopic.create(raw_topic, datum)
-            data_by_topic[pupil_topic].data.append(datum)
-            data_by_topic[pupil_topic].timestamps.append(ts)
-            data_by_topic[pupil_topic].topics.append(raw_topic)
-        return data_by_topic
 
 
 class Offline_Pupil_Detection(Pupil_Producer_Base):
@@ -448,7 +266,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.detection_method = session_meta_data["detection_method"]
         self.detection_status = session_meta_data["detection_status"]
 
-        self._pupil_data_store = PupilDataBisector.load_from_file(
+        self._pupil_data_store = pm.PupilDataBisector.load_from_file(
             self.data_dir, self.session_data_name
         )
 

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -272,7 +272,7 @@ class PupilTopic:
 
     _MATCH_FORMAT_STRING_V1 = r"^pupil\.(?P<eye_id>{eye_id})$"
     _MATCH_FORMAT_STRING_V2 = (
-        r"^pupil\.(?P<eye_id>{eye_id}).(?P<detector_tag>{detector_tag})$"
+        r"^pupil\.(?P<eye_id>{eye_id})\.(?P<detector_tag>{detector_tag})$"
     )
 
     _legacy_method_to_detector_tag = {
@@ -327,7 +327,7 @@ class PupilTopic:
             eye_id = "[01]"
 
         if detector_tag is None:
-            detector_tag = "[^\.]+"
+            detector_tag = r"[^\.]+"
 
         pattern = PupilTopic._MATCH_FORMAT_STRING_V2.format(
             eye_id=eye_id, detector_tag=detector_tag,

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -371,6 +371,12 @@ class PupilDataBisector:
     def clear(self):
         self._bisectors.clear()
 
+    def copy(self):
+        copy = type(self)()
+        for topic, bisector in self._bisectors.items():
+            copy._bisectors[topic] = bisector.copy()
+        return copy
+
     @staticmethod
     def combine_bisectors(bisectors: T.Iterable[pm.Bisector]) -> pm.Bisector:
         data = list(chain.from_iterable(b.data for b in bisectors))

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -86,8 +86,8 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
         )
 
         self.cache = {}
-        self.cache_pupil_timeline_data("diameter")
-        self.cache_pupil_timeline_data("confidence")
+        self.cache_pupil_timeline_data("diameter", detector_tag="3d")
+        self.cache_pupil_timeline_data("confidence", detector_tag="2d")
 
         self.glfont = fs.Context()
         self.glfont.add_font("opensans", ui.get_opensans_font_path())
@@ -103,8 +103,8 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
         self.g_pool.user_timelines.append(self.conf_timeline)
 
     def _refresh_timelines(self):
-        self.cache_pupil_timeline_data("diameter")
-        self.cache_pupil_timeline_data("confidence")
+        self.cache_pupil_timeline_data("diameter", detector_tag="3d")
+        self.cache_pupil_timeline_data("confidence", detector_tag="2d")
         self.dia_timeline.refresh()
         self.conf_timeline.refresh()
 
@@ -121,7 +121,7 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
             window = pm.enclosing_window(self.g_pool.timestamps, frm_idx)
             events["pupil"] = self.g_pool.pupil_positions.by_ts_window(window)
 
-    def cache_pupil_timeline_data(self, key):
+    def cache_pupil_timeline_data(self, key: str, detector_tag: str):
         world_start_stop_ts = [self.g_pool.timestamps[0], self.g_pool.timestamps[-1]]
         if not self.g_pool.pupil_positions:
             self.cache[key] = {
@@ -133,7 +133,7 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
         else:
             ts_data_pairs_right_left = [], []
             for eye_id in (0, 1):
-                pupil_positions = self.g_pool.pupil_positions_by_id[eye_id]
+                pupil_positions = self.g_pool.pupil_positions[eye_id, detector_tag]
                 if pupil_positions:
                     t0, t1 = (
                         pupil_positions.timestamps[0],

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -267,11 +267,13 @@ class PupilTopic:
     EyeIdFilterKey = T.Union[WildcardKey, int, str, T.Iterable[int], T.Iterable[str]]
     DetectorTagFilterKey = T.Union[WildcardKey, str, T.Iterable[str]]
 
-    _FORMAT_STRING_V1 = 'pupil.{eye_id}'
-    _FORMAT_STRING_V2 = 'pupil.{eye_id}.{detector_tag}'
+    _FORMAT_STRING_V1 = "pupil.{eye_id}"
+    _FORMAT_STRING_V2 = "pupil.{eye_id}.{detector_tag}"
 
-    _MATCH_FORMAT_STRING_V1 = r'^pupil\.(?P<eye_id>{eye_id})$'
-    _MATCH_FORMAT_STRING_V2 = r'^pupil\.(?P<eye_id>{eye_id}).(?P<detector_tag>{detector_tag})$'
+    _MATCH_FORMAT_STRING_V1 = r"^pupil\.(?P<eye_id>{eye_id})$"
+    _MATCH_FORMAT_STRING_V2 = (
+        r"^pupil\.(?P<eye_id>{eye_id}).(?P<detector_tag>{detector_tag})$"
+    )
 
     _legacy_method_to_detector_tag = {
         "2d c++": "2d",
@@ -287,8 +289,7 @@ class PupilTopic:
             if detector_tag in PupilTopic._legacy_method_to_detector_tag:
                 detector_tag = PupilTopic._legacy_method_to_detector_tag[detector_tag]
             return PupilTopic._FORMAT_STRING_V2.format(
-                eye_id=match_v1.group("eye_id"),
-                detector_tag=detector_tag,
+                eye_id=match_v1.group("eye_id"), detector_tag=detector_tag,
             )
         regex_v2 = PupilTopic._match_regex_v2()
         match_v2 = re.match(regex_v2, topic)
@@ -319,16 +320,17 @@ class PupilTopic:
 
     @staticmethod
     @functools.lru_cache(128)
-    def _match_regex_v2(eye_id: T.Optional[str] = None, detector_tag: T.Optional[str] = None):
+    def _match_regex_v2(
+        eye_id: T.Optional[str] = None, detector_tag: T.Optional[str] = None
+    ):
         if eye_id is None:
-            eye_id = '[01]'
+            eye_id = "[01]"
 
         if detector_tag is None:
-            detector_tag = '[^\.]+'
+            detector_tag = "[^\.]+"
 
         pattern = PupilTopic._MATCH_FORMAT_STRING_V2.format(
-            eye_id=eye_id,
-            detector_tag=detector_tag,
+            eye_id=eye_id, detector_tag=detector_tag,
         )
 
         return re.compile(pattern)
@@ -337,17 +339,14 @@ class PupilTopic:
     @functools.lru_cache(32)
     def _match_regex_v1(eye_id: T.Optional[str] = None):
         if eye_id is None:
-            eye_id = '[01]'
+            eye_id = "[01]"
 
-        pattern = PupilTopic._MATCH_FORMAT_STRING_V1.format(
-            eye_id=eye_id,
-        )
+        pattern = PupilTopic._MATCH_FORMAT_STRING_V1.format(eye_id=eye_id,)
 
         return re.compile(pattern)
 
 
 class PupilDataBisector:
-
     def __init__(self, data: fm.PLData = fm.PLData([], [], [])):
         self._bisectors = collections.defaultdict(pm.Mutable_Bisector)
         self._init_from_data(data)
@@ -359,8 +358,12 @@ class PupilDataBisector:
             bisector = pm.Mutable_Bisector(data.data, data.timestamps)
             self._bisectors[pupil_topic] = bisector
 
-    def __getitem__(self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]) -> pm.Bisector:
-        bisectors = [B for topic, B in self._bisectors.items() if PupilTopic.match(topic, *key)]
+    def __getitem__(
+        self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]
+    ) -> pm.Bisector:
+        bisectors = [
+            B for topic, B in self._bisectors.items() if PupilTopic.match(topic, *key)
+        ]
         return self.combine_bisectors(bisectors)
 
     def append(self, topic, datum, timestamp):
@@ -401,8 +404,6 @@ class PupilDataBisector:
         return data_by_topic
 
 
-
-
 class Offline_Pupil_Detection(Pupil_Producer_Base):
     """docstring for Offline_Pupil_Detection"""
 
@@ -430,11 +431,15 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
             session_meta_data = {}
             session_meta_data["detection_status"] = ["unknown", "unknown"]
 
-        session_meta_data["detection_method"] = "3d" # Force 3D detection method, since the detectors produce both
+        session_meta_data[
+            "detection_method"
+        ] = "3d"  # Force 3D detection method, since the detectors produce both
         self.detection_method = session_meta_data["detection_method"]
         self.detection_status = session_meta_data["detection_status"]
 
-        self._pupil_data_store = PupilDataBisector.load_from_file(self.data_dir, self.session_data_name)
+        self._pupil_data_store = PupilDataBisector.load_from_file(
+            self.data_dir, self.session_data_name
+        )
 
         self.eye_video_loc = [None, None]
 
@@ -492,7 +497,9 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
     def detection_progress(self) -> float:
         total = sum(self.eye_frame_num)
         if total:
-            return min(len(self._pupil_data_store[:, self.detection_method]) / total, 1.0)
+            return min(
+                len(self._pupil_data_store[:, self.detection_method]) / total, 1.0
+            )
         else:
             return 0.0
 

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -364,6 +364,30 @@ class PupilDataBisector:
         ]
         return self.combine_bisectors(bisectors)
 
+    def by_ts_window(self, ts_window):
+        bisectors = self._bisectors.values()
+        init_dicts = [b.init_dict_for_window(ts_window) for b in bisectors]
+        bisectors = [pm.Bisector(**init_dict) for init_dict in init_dicts]
+        combined = self.combine_bisectors(bisectors)
+        return combined
+
+    def by_ts(self, ts):
+        # Returns datum for first bisector that contains it
+        # TODO: Might require rework depending on where/how it is used
+        for bisector in self._bisectors.values():
+            try:
+                return bisector.by_ts(ts)
+            except ValueError:
+                continue
+        raise ValueError
+
+    def init_dict_for_window(self, ts_window):
+        init_dict = collections.defaultdict(list)
+        for bisector in self._bisectors.values():
+            for key, values in bisector.init_dict_for_window(ts_window).items():
+                init_dict[key].extend(values)
+        return init_dict
+
     def append(self, topic, datum, timestamp):
         pupil_topic = PupilTopic.create(topic, datum)
         self._bisectors[pupil_topic].insert(timestamp, datum)

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -356,6 +356,22 @@ class PupilDataBisector:
             bisector = pm.Mutable_Bisector(data.data, data.timestamps)
             self._bisectors[pupil_topic] = bisector
 
+    def init_dict_for_window(self, ts_window):
+        init_dict = collections.defaultdict(list)
+        for topic, bisector in self._bisectors.items():
+            _init_dict = bisector.init_dict_for_window(ts_window)
+            for key, values in _init_dict.items():
+                init_dict[key].extend(values)
+            topics = [topic] * len(_init_dict["data"])
+            init_dict["topics"].extend(topics)
+
+        return init_dict
+
+    @staticmethod
+    def from_init_dict(init_dict):
+        data = fm.PLData(init_dict["data"], init_dict["data_ts"], init_dict["topics"])
+        return PupilDataBisector(data)
+
     def __getitem__(
         self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]
     ) -> pm.Bisector:
@@ -380,13 +396,6 @@ class PupilDataBisector:
             except ValueError:
                 continue
         raise ValueError
-
-    def init_dict_for_window(self, ts_window):
-        init_dict = collections.defaultdict(list)
-        for bisector in self._bisectors.values():
-            for key, values in bisector.init_dict_for_window(ts_window).items():
-                init_dict[key].extend(values)
-        return init_dict
 
     def append(self, topic, datum, timestamp):
         pupil_topic = PupilTopic.create(topic, datum)

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -216,36 +216,10 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
             thickness=4.0 * scale,
         )
 
-    def create_pupil_positions_by_id(self, ts_to_datum, ts_to_topic):
-        topic_data_ts = (
-            (ts_to_topic[ts], datum, ts) for ts, datum in ts_to_datum.items()
-        )
-        return self.create_pupil_positions_by_id_iterative(topic_data_ts)
-
-    def create_pupil_positions_by_id_iterative(self, topic_data_ts):
-        id0_id1_data = collections.deque(), collections.deque()
-        id0_id1_time = collections.deque(), collections.deque()
-
-        for topic, datum, timestamp in topic_data_ts:
-            eye_id = int(topic[-1])  # use topic to identify eye
-            assert eye_id == datum["id"]
-            id0_id1_data[eye_id].append(datum)
-            id0_id1_time[eye_id].append(timestamp)
-
-        bisector_id0 = pm.Bisector(id0_id1_data[0], id0_id1_time[0])
-        bisector_id1 = pm.Bisector(id0_id1_data[1], id0_id1_time[1])
-        return (bisector_id0, bisector_id1)
-
 
 class Pupil_From_Recording(Pupil_Producer_Base):
     def __init__(self, g_pool):
         super().__init__(g_pool)
-
-        g_pool.pupil_positions_by_id = self.create_pupil_positions_by_id_iterative(
-            zip(
-                pupil_data_file.topics, pupil_data_file.data, pupil_data_file.timestamps
-            )
-        )
 
         pupil_data = PupilDataBisector.load_from_file(g_pool.rec_dir, "pupil")
         g_pool.pupil_positions = pupil_data
@@ -570,10 +544,6 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.menu_icon.indicator_stop = self.detection_progress
 
     def correlate_publish(self):
-        bisector_eye0 = self._pupil_data_store[0, self.detection_method]
-        bisector_eye1 = self._pupil_data_store[1, self.detection_method]
-
-        self.g_pool.pupil_positions_by_id = (bisector_eye0, bisector_eye1)
         self.g_pool.pupil_positions = self._pupil_data_store.copy()
         self._pupil_changed_announcer.announce_new()
         logger.debug("pupil positions changed")
@@ -606,6 +576,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
     def redetect(self):
         self._pupil_data_store.clear()
         self.g_pool.pupil_positions = self._pupil_data_store.copy()
+        self._pupil_changed_announcer.announce_new()
         self.detection_finished_flag = False
         self.detection_paused = False
         for eye_id in range(2):

--- a/pupil_src/shared_modules/system_timelines.py
+++ b/pupil_src/shared_modules/system_timelines.py
@@ -54,8 +54,8 @@ class System_Timelines(Observable, System_Plugin_Base):
 
     def cache_fps_data(self):
         fps_world = self.calculate_fps(self.g_pool.timestamps)
-        fps_eye0 = self.calculate_fps(self.g_pool.pupil_positions_by_id[0].timestamps)
-        fps_eye1 = self.calculate_fps(self.g_pool.pupil_positions_by_id[1].timestamps)
+        fps_eye0 = self.calculate_fps(self.g_pool.pupil_positions[0, :].timestamps)
+        fps_eye1 = self.calculate_fps(self.g_pool.pupil_positions[1, :].timestamps)
 
         t0, t1 = self.g_pool.timestamps[0], self.g_pool.timestamps[-1]
         self.cache = {
@@ -68,6 +68,7 @@ class System_Timelines(Observable, System_Plugin_Base):
 
     def calculate_fps(self, timestamps):
         if len(timestamps) > 1:
+            timestamps = np.unique(timestamps)
             fps = 1.0 / np.diff(timestamps)
             return tuple(zip(timestamps, fps))
         return ()

--- a/pupil_src/shared_modules/video_export/plugins/eye_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/eye_video_exporter.py
@@ -44,7 +44,7 @@ class Eye_Video_Exporter(IsolatedFrameExporter):
     def _export_eye_video(self, export_range, export_dir, eye_id):
         if self.render_pupil:
             process_frame = _add_pupil_ellipse(
-                self.g_pool.pupil_positions_by_id[eye_id]
+                self.g_pool.pupil_positions[eye_id, "3d"]  # TODO pass 2d/3d
             )
         else:
             process_frame = _no_change
@@ -93,6 +93,7 @@ class _add_pupil_ellipse:
     def __call__(self, _, frame):
         eye_image = frame.img
         try:
+            # TODO: handle 2d and 3d data
             pupil_datum = self._pupil_positions_of_eye.by_ts(frame.timestamp)
             self.renderer.render_pupil(eye_image, pupil_datum)
         except ValueError:

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -123,7 +123,6 @@ def _export_world_video(
     from vis_light_points import Vis_Light_Points
     from vis_polyline import Vis_Polyline
     from vis_watermark import Vis_Watermark
-    from pupil_producers import PupilDataBisector
 
     PID = str(os.getpid())
     logger = logging.getLogger(__name__ + " with pid: " + PID)
@@ -233,7 +232,7 @@ def _export_world_video(
                 for serialized in initializers["data"]
             ]
 
-        g_pool.pupil_positions = PupilDataBisector.from_init_dict(
+        g_pool.pupil_positions = pm.PupilDataBisector.from_init_dict(
             pre_computed_eye_data["pupil"]
         )
         g_pool.gaze_positions = pm.Bisector(**pre_computed_eye_data["gaze"])

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -74,8 +74,6 @@ class World_Video_Exporter(VideoExporter):
         pre_computed = {
             "gaze": self.g_pool.gaze_positions,
             "pupil": self.g_pool.pupil_positions,
-            "pupil_by_id_0": self.g_pool.pupil_positions_by_id[0],
-            "pupil_by_id_1": self.g_pool.pupil_positions_by_id[1],
             "fixations": self.g_pool.fixations,
         }
 

--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -125,6 +125,7 @@ def _export_world_video(
     from vis_light_points import Vis_Light_Points
     from vis_polyline import Vis_Polyline
     from vis_watermark import Vis_Watermark
+    from pupil_producers import PupilDataBisector
 
     PID = str(os.getpid())
     logger = logging.getLogger(__name__ + " with pid: " + PID)
@@ -234,10 +235,8 @@ def _export_world_video(
                 for serialized in initializers["data"]
             ]
 
-        g_pool.pupil_positions = pm.Bisector(**pre_computed_eye_data["pupil"])
-        g_pool.pupil_positions_by_id = (
-            pm.Bisector(**pre_computed_eye_data["pupil_by_id_0"]),
-            pm.Bisector(**pre_computed_eye_data["pupil_by_id_1"]),
+        g_pool.pupil_positions = PupilDataBisector.from_init_dict(
+            pre_computed_eye_data["pupil"]
         )
         g_pool.gaze_positions = pm.Bisector(**pre_computed_eye_data["gaze"])
         g_pool.fixations = pm.Affiliator(**pre_computed_eye_data["fixations"])

--- a/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
@@ -116,7 +116,8 @@ class Eye_Overlay(Observable, Plugin):
     def make_current_pupil_datum_getter(self, eye_id):
         def _pupil_getter():
             try:
-                pupil_data = self.g_pool.pupil_positions_by_id[eye_id]
+                # TODO: handle 2d and 3d data
+                pupil_data = self.g_pool.pupil_positions[eye_id, "3d"]
                 closest_pupil_idx = pm.find_closest(
                     pupil_data.data_ts, self.current_frame_ts
                 )


### PR DESCRIPTION
Fixes #1851 

Removes `g_pool.pupil_positions_by_id[id_]`. Use `g_pool.pupil_positions[id_, :]` instead.