### PR TITLE
Diameter 3d timeline

### DIFF
--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -90,7 +90,7 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
         self.glfont.set_font("opensans")
 
         self.dia_timeline = ui.Timeline(
-            "Pupil Diameter [px]", self.draw_pupil_diameter, self.draw_dia_legend
+            "Pupil Diameter [mm]", self.draw_pupil_diameter, self.draw_dia_legend
         )
         self.conf_timeline = ui.Timeline(
             "Pupil Confidence", self.draw_pupil_conf, self.draw_conf_legend

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -165,6 +165,8 @@ class Pupil_Producer_Base(Observable, Producer_Plugin_Base):
                 # max_val must not be 0, else gl will crash
                 all_pupil_data_chained = chain.from_iterable(ts_data_pairs_right_left)
                 try:
+                    # Outlier removal based on:
+                    # https://en.wikipedia.org/wiki/Outlier#Tukey's_fences
                     min_val, max_val = np.quantile(
                         [pd[1] for pd in all_pupil_data_chained], [0.25, 0.75]
                     )

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -375,7 +375,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                 # pupil data only has one remaining frame
                 payload_serialized = next(remaining_frames)
                 pupil_datum = fm.Serialized_Dict(msgpack_bytes=payload_serialized)
-                assert int(topic[-1]) == pupil_datum["id"]
+                assert pm.PupilTopic.match(topic, eye_id=pupil_datum["id"])
                 timestamp = pupil_datum["timestamp"]
                 self._pupil_data_store.append(topic, pupil_datum, timestamp)
             else:


### PR DESCRIPTION
Switches diameter timeline from 2d pixels to 3d millimeters. Filters outliers using [Tukey's fences](https://en.wikipedia.org/wiki/Outlier#Tukey's_fences) and shows displayed range in timeline legend.

Previously:
![Screenshot 2020-04-22 at 13 47 08](https://user-images.githubusercontent.com/168390/79978559-660d4180-84a0-11ea-8fc0-8bce10499fe7.png)
Afterward:
![Screenshot 2020-04-22 at 13 42 15](https://user-images.githubusercontent.com/168390/79978577-6c9bb900-84a0-11ea-881f-caf7752e7dbd.png)

This makes the timeline consistent with the realtime diameter 3d graph in Capture.