### PR TITLE
Fix windows driver issues v2

### DIFF
--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -181,12 +181,13 @@ class UVC_Source(Base_Source):
         if ids_present > 0:
             logger.warning("Updating drivers, please wait...")
 
-            pupil_capture_install_loc = Path.cwd()
             # NOTE: libwdi in PupilDrvIns.exe cannot deal with unicode characters in the
             # temporary path where the drivers will be installed. Check for non-ascii in
-            # current working directory and use C:\Windows\Temp as fallback.
+            # the default tempdir location and use C:\Windows\Temp as fallback.
+            temp_path = None  # use default temp_path
             try:
-                str(pupil_capture_install_loc.resolve()).encode("ascii")
+                with tempfile.TemporaryDirectory(dir=temp_path) as work_dir:
+                    work_dir.encode("ascii")
             except UnicodeEncodeError:
                 temp_path = Path("C:\\Windows\\Temp")
                 if not temp_path.exists():
@@ -199,11 +200,9 @@ class UVC_Source(Base_Source):
                     "Detected Unicode characters in working directory! "
                     "Switching temporary driver install location to C:\\Windows\\Temp"
                 )
-            else:
-                # if cwd has only ascii characters: use default temp location
-                temp_path = None
 
             for id in ids_to_install:
+                pupil_capture_install_loc = Path.cwd()
                 # Create a new temp dir for every driver so even when experiencing
                 # PermissionErrors, we can just continue installing all necessary
                 # drivers.


### PR DESCRIPTION
There was a user who could not install the drivers on Windows.
The cause seemed to be that `Path.cwd()` returned `C:\Windows\system32` for no apparent reason, although the bundle was located in a different folder.

This PR will rely on using the bundle path taken from `sys` instead.

Additionally, I fixed another potential issue where the Unicode check would not properly work if the bundle was installed to a location outside of the user's home folder, but the home folder would still contain Unicode characters.