### PR TITLE
Fix preferred camera selection

### DIFF
--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -111,16 +111,16 @@ class UVC_Source(Base_Source):
                         uid_for_name = devices_by_name[d_name]["uid"]
                         try:
                             self.uvc_capture = uvc.Capture(uid_for_name)
+                            break
                         except uvc.OpenError:
                             logger.info(
-                                "{} matches {} but is already in use or blocked.".format(
-                                    uid_for_name, name
-                                )
+                                f"{uid_for_name} matches {name} but is already in use "
+                                "or blocked."
                             )
                         except uvc.InitError:
                             logger.error("Camera failed to initialize.")
-                        else:
-                            break
+                if self.uvc_capture:
+                    break
 
         # checkframestripes will be initialized accordingly in configure_capture()
         self.enable_stripe_checks = check_stripes


### PR DESCRIPTION
Previous version did only break out of inner loop but not the outer loop. This caused the selection to continue instead of using the first found match.