### PR TITLE
Improving Player performance

### DIFF
--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -414,7 +414,7 @@ class Offline_Blink_Detection(Observable, Blink_Detection):
             blink["end_timestamp"] = self.timestamps[idx]
             blink["timestamp"] = (blink["end_timestamp"] + blink["start_timestamp"]) / 2
             blink["duration"] = blink["end_timestamp"] - blink["start_timestamp"]
-            blink["base_data"] = pupil_data[start_idx:idx]
+            blink["base_data"] = pupil_data[start_idx:idx].tolist()
             blink["filter_response"] = self.filter_response[start_idx:idx].tolist()
             # blink confidence is the mean of the absolute filter response
             # during the blink event, clamped at 1.

--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -231,10 +231,10 @@ class Offline_Blink_Detection(Observable, Blink_Detection):
         )
 
     def _pupil_data(self):
-        data = self.g_pool.pupil_positions[:, "2d"]
+        data = self.g_pool.pupil_positions[..., "2d"]
         if not data:
             # Fall back to 3d data
-            data = self.g_pool.pupil_positions[:, "3d"]
+            data = self.g_pool.pupil_positions[..., "3d"]
         return data
 
     def init_ui(self):

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -146,7 +146,7 @@ class Affiliator(Bisector):
 
 
 class PupilTopic:
-    WildcardKey = T.Union[type(...), slice]
+    WildcardKey = type(...)
     EyeIdFilterKey = T.Union[WildcardKey, int, str, T.Iterable[int], T.Iterable[str]]
     DetectorTagFilterKey = T.Union[WildcardKey, str, T.Iterable[str]]
 
@@ -257,6 +257,7 @@ class PupilDataBisector:
         data = fm.PLData(init_dict["data"], init_dict["data_ts"], init_dict["topics"])
         return PupilDataBisector(data)
 
+    @functools.lru_cache(32)
     def __getitem__(
         self, key: T.Tuple[PupilTopic.EyeIdFilterKey, PupilTopic.DetectorTagFilterKey]
     ) -> pm.Bisector:

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -47,7 +47,7 @@ class Bisector(object):
                     " timestamp in `data_ts`"
                 )
             )
-        elif not data:
+        elif not len(data):
             self.data = []
             self.data_ts = np.asarray([])
             self.sorted_idc = []
@@ -58,7 +58,7 @@ class Bisector(object):
             # Find correct order once and reorder both lists in-place
             self.sorted_idc = np.argsort(self.data_ts)
             self.data_ts = self.data_ts[self.sorted_idc]
-            self.data = self.data[self.sorted_idc].tolist()
+            self.data = self.data[self.sorted_idc]
 
     def copy(self):
         copy = type(self)()
@@ -102,7 +102,7 @@ class Bisector(object):
         return iter(self.data)
 
     def __bool__(self):
-        return bool(self.data)
+        return bool(len(self.data))
 
     @property
     def timestamps(self):

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -359,7 +359,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         total = sum(self.eye_frame_num)
         if total:
             return min(
-                len(self._pupil_data_store[:, self.detection_method]) / total, 1.0
+                len(self._pupil_data_store[..., self.detection_method]) / total, 1.0
             )
         else:
             return 0.0
@@ -380,6 +380,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                 assert pm.PupilTopic.match(topic, eye_id=pupil_datum["id"])
                 timestamp = pupil_datum["timestamp"]
                 self._pupil_data_store.append(topic, pupil_datum, timestamp)
+                self._pupil_data_store.__getitem__.cache_clear()
             else:
                 payload = self.data_sub.deserialize_payload(*remaining_frames)
                 if payload["subject"] == "file_source.video_finished":
@@ -425,6 +426,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
     def redetect(self):
         self._pupil_data_store.clear()
+        self._pupil_data_store.__getitem__.cache_clear()
         self.g_pool.pupil_positions = self._pupil_data_store.copy()
         self._pupil_changed_announcer.announce_new()
         self.detection_finished_flag = False

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -161,7 +161,7 @@ class Raw_Data_Exporter(Analysis_Plugin_Base):
         if self.should_export_pupil_positions:
             pupil_positions_exporter = Pupil_Positions_Exporter()
             pupil_positions_exporter.csv_export_write(
-                positions_bisector=self.g_pool.pupil_positions[:, :],
+                positions_bisector=self.g_pool.pupil_positions[..., ...],
                 timestamps=self.g_pool.timestamps,
                 export_window=export_window,
                 export_dir=export_dir,

--- a/pupil_src/shared_modules/system_timelines.py
+++ b/pupil_src/shared_modules/system_timelines.py
@@ -54,8 +54,8 @@ class System_Timelines(Observable, System_Plugin_Base):
 
     def cache_fps_data(self):
         fps_world = self.calculate_fps(self.g_pool.timestamps)
-        fps_eye0 = self.calculate_fps(self.g_pool.pupil_positions[0, :].timestamps)
-        fps_eye1 = self.calculate_fps(self.g_pool.pupil_positions[1, :].timestamps)
+        fps_eye0 = self.calculate_fps(self.g_pool.pupil_positions[0, ...].timestamps)
+        fps_eye1 = self.calculate_fps(self.g_pool.pupil_positions[1, ...].timestamps)
 
         t0, t1 = self.g_pool.timestamps[0], self.g_pool.timestamps[-1]
         self.cache = {


### PR DESCRIPTION
- Caches `PupilBisector.__getitem__`, effectively avoiding combination the same bisectors over and over again
- Stop converting `Bisector.data` to `list`, avoiding reconversion to `ndarray` down the line
    - Might cause issues when serializing slices of `g_pool.pupil_positions`, etc. In this case, call `data_slice.tolist()` before serializing
    - Requires compatibility tests with all Player plugin

Considerable time is spent when serializing data for a background process. We should think about a method of transferring the data bit-by-bit, instead of in a bulk.

Most of the performance comes from decoding images into RGB buffers and manipulating them. Nothing we can do about right now.