### PR TITLE
Allow replacing `by_class` unique plugins

### DIFF
--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -350,13 +350,13 @@ class Plugin_List(object):
     def __str__(self):
         return "Plugin List: {}".format(self._plugins)
 
-    def add(self, new_plugin, args={}):
+    def add(self, new_plugin_cls, args={}):
         """
         add a plugin instance to the list.
         """
-        self._avoid_duplication(new_plugin)
+        self._find_and_remove_duplicates(new_plugin_cls)
 
-        plugin_instance = new_plugin(self.g_pool, **args)
+        plugin_instance = new_plugin_cls(self.g_pool, **args)
         if not plugin_instance.alive:
             logger.warning("plugin failed to initialize")
             return
@@ -367,9 +367,9 @@ class Plugin_List(object):
         if self.g_pool.app in ("capture", "player"):
             plugin_instance.init_ui()
 
-    def _avoid_duplication(self, new_plugin_cls):
+    def _find_and_remove_duplicates(self, new_plugin_cls):
         for duplicate in self._duplicates(new_plugin_cls):
-            self._remove_duplicate(duplicate)
+            self._remove_duplicated_instance(duplicate)
 
     def _duplicates(self, new_plugin_cls):
         if new_plugin_cls.uniqueness == "by_base_class":
@@ -387,7 +387,7 @@ class Plugin_List(object):
         )
         yield from duplicates
 
-    def _remove_duplicate(self, duplicated_plugin_inst):
+    def _remove_duplicated_instance(self, duplicated_plugin_inst):
         name = duplicated_plugin_inst.pretty_class_name
         uniq = duplicated_plugin_inst.uniqueness
         message = f"Replacing {name} due to '{uniq}' uniqueness"

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -9,11 +9,11 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
+import importlib
+import logging
 import os
 import sys
-import importlib
 from time import time
-import logging
 
 logger = logging.getLogger(__name__)
 """
@@ -354,25 +354,7 @@ class Plugin_List(object):
         """
         add a plugin instance to the list.
         """
-        if new_plugin.uniqueness == "by_base_class":
-            for p in self._plugins:
-                if p.base_class == new_plugin.__bases__[-1]:
-                    replc_str = "Plugin {} of base class {} will be replaced by {}."
-                    logger.debug(
-                        replc_str.format(p, p.base_class_name, new_plugin.__name__)
-                    )
-                    p.alive = False
-                    self.clean()
-
-        elif new_plugin.uniqueness == "by_class":
-            for p in self._plugins:
-                if p.this_class == new_plugin:
-                    logger.warning(
-                        "Plugin '{}' is already loaded . Did not add it.".format(
-                            new_plugin.__name__
-                        )
-                    )
-                    return
+        self._avoid_duplication(new_plugin)
 
         plugin_instance = new_plugin(self.g_pool, **args)
         if not plugin_instance.alive:
@@ -384,6 +366,42 @@ class Plugin_List(object):
 
         if self.g_pool.app in ("capture", "player"):
             plugin_instance.init_ui()
+
+    def _avoid_duplication(self, new_plugin_cls):
+        for duplicate in self._duplicates(new_plugin_cls):
+            self._remove_duplicate(duplicate)
+
+    def _duplicates(self, new_plugin_cls):
+        if new_plugin_cls.uniqueness == "by_base_class":
+            yield from self._duplicates_by_rule(
+                self._has_same_base_class, new_plugin_cls
+            )
+        elif new_plugin_cls.uniqueness == "by_class":
+            yield from self._duplicates_by_rule(self._is_same_class, new_plugin_cls)
+
+    def _duplicates_by_rule(self, is_duplicate_rule, new_plugin_cls):
+        duplicates = (
+            old_plugin_inst
+            for old_plugin_inst in self._plugins
+            if is_duplicate_rule(old_plugin_inst, new_plugin_cls)
+        )
+        yield from duplicates
+
+    def _remove_duplicate(self, duplicated_plugin_inst):
+        name = duplicated_plugin_inst.pretty_class_name
+        uniq = duplicated_plugin_inst.uniqueness
+        message = f"Replacing {name} due to '{uniq}' uniqueness"
+        logger.debug(message)
+        duplicated_plugin_inst.alive = False
+        self.clean()
+
+    @staticmethod
+    def _has_same_base_class(old_plugin_inst, new_plugin_cls):
+        return old_plugin_inst.base_class == new_plugin_cls.__bases__[-1]
+
+    @staticmethod
+    def _is_same_class(old_plugin_inst, new_plugin_cls):
+        return old_plugin_inst.this_class == new_plugin_cls
 
     def clean(self):
         """


### PR DESCRIPTION
Changes previous behavior where running `by_class` unique plugins could not be replaced.

This behaviour is especially problematic if `by_class` plugins are started by default. In this case, there would not be a possibility to change their configuration.

With the new behaviour, a new configuration can be loaded by restarting the plugin with the new config. The old plugin will be removed.