### PR TITLE
Draw 2D pupil ellipse in blue and cleanup code

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_2d_plugin.py
@@ -76,7 +76,7 @@ class Detector2DPlugin(PupilDetectorPlugin):
 
     def gl_display(self):
         if self._recent_detection_result:
-            draw_pupil_outline(self._recent_detection_result)
+            draw_pupil_outline(self._recent_detection_result, color_rgb=(0, 0.5, 1))
 
     def init_ui(self):
         super().init_ui()

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_2d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_2d.py
@@ -8,61 +8,55 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import cv2
+import logging
+from typing import Dict, Tuple
 
-from pyglui.cygl.utils import RGBA, draw_polyline, draw_points
+import cv2
+from pyglui.cygl.utils import RGBA, draw_points, draw_polyline
+
+logger = logging.getLogger(__name__)
+
+
+def draw_ellipse(
+    ellipse: Dict, rgba: Tuple, thickness: float, draw_center: bool = False
+):
+    try:
+        pts = cv2.ellipse2Poly(
+            center=(int(ellipse["center"][0]), int(ellipse["center"][1])),
+            axes=(int(ellipse["axes"][0] / 2), int(ellipse["axes"][1] / 2)),
+            angle=int(ellipse["angle"]),
+            arcStart=0,
+            arcEnd=360,
+            delta=8,
+        )
+    except ValueError:
+        # Happens when converting 'nan' to int
+        # TODO: Investigate why results are sometimes 'nan'
+        logger.debug(f"WARN: trying to draw ellipse with 'NaN' data: {ellipse}")
+        return
+
+    draw_polyline(pts, thickness, RGBA(*rgba))
+    if draw_center:
+        draw_points(
+            [ellipse["center"]], size=20, color=RGBA(*rgba), sharpness=1.0,
+        )
 
 
 def draw_eyeball_outline(pupil_detection_result_3d):
-    eye_ball = pupil_detection_result_3d["projected_sphere"]
-    try:
-        pts = cv2.ellipse2Poly(
-            (int(eye_ball["center"][0]), int(eye_ball["center"][1])),
-            (int(eye_ball["axes"][0] / 2), int(eye_ball["axes"][1] / 2)),
-            int(eye_ball["angle"]),
-            0,
-            360,
-            8,
-        )
-    except ValueError:
-        # Happens when converting 'nan' to int
-        # TODO: Investigate why results are sometimes 'nan'
-        return
-    draw_polyline(
-        pts, 2, RGBA(0.0, 0.9, 0.1, pupil_detection_result_3d["model_confidence"])
+    draw_ellipse(
+        ellipse=pupil_detection_result_3d["projected_sphere"],
+        rgba=(0, 0.9, 0.1, pupil_detection_result_3d["model_confidence"]),
+        thickness=2,
     )
 
 
-def draw_pupil_outline(pupil_detection_result_2d):
-    """Requires `"ellipse" in pupil_detection_result_2d`"""
+def draw_pupil_outline(pupil_detection_result_2d, color_rgb=(1.0, 0.0, 0.0)):
     if pupil_detection_result_2d["confidence"] <= 0.0:
         return
 
-    try:
-        pts = cv2.ellipse2Poly(
-            (
-                int(pupil_detection_result_2d["ellipse"]["center"][0]),
-                int(pupil_detection_result_2d["ellipse"]["center"][1]),
-            ),
-            (
-                int(pupil_detection_result_2d["ellipse"]["axes"][0] / 2),
-                int(pupil_detection_result_2d["ellipse"]["axes"][1] / 2),
-            ),
-            int(pupil_detection_result_2d["ellipse"]["angle"]),
-            0,
-            360,
-            15,
-        )
-    except ValueError:
-        # Happens when converting 'nan' to int
-        # TODO: Investigate why results are sometimes 'nan'
-        return
-
-    confidence = pupil_detection_result_2d["confidence"] * 0.7
-    draw_polyline(pts, 1, RGBA(1.0, 0, 0, confidence))
-    draw_points(
-        [pupil_detection_result_2d["ellipse"]["center"]],
-        size=20,
-        color=RGBA(1.0, 0.0, 0.0, confidence),
-        sharpness=1.0,
+    draw_ellipse(
+        ellipse=pupil_detection_result_2d["ellipse"],
+        rgba=(*color_rgb, pupil_detection_result_2d["confidence"]),
+        thickness=1,
+        draw_center=True,
     )


### PR DESCRIPTION
This will color the 2D ellipse visualization in blue, which helps now that we have both 2D and 3D detectors running in parallel. This change affects both Capture and Player.

I also increased the polygon count of the ellipse outline to match that of the 3D eyeball visualization for a smoother pupil. After some testing, I did not touch the thickness, so pupil ellipses are still drawn with 1px, while the eyeball outline has 2px as before.

Example:
![Screenshot from 2020-05-14 13-49-08](https://user-images.githubusercontent.com/7101194/81931054-c730bc80-95e9-11ea-8dd1-47177ac99bb8.png)
