### PR TITLE
Remove 2D settings from 3D detector UI

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -97,46 +97,11 @@ class Detector3DPlugin(PupilDetectorPlugin):
     def init_ui(self):
         super().init_ui()
         self.menu.label = self.pretty_class_name
-        info = ui.Info_Text(
-            "Switch to the algorithm display mode to see a visualization of pupil detection parameters overlaid on the eye video. "
-            + "Adjust the pupil intensity range so that the pupil is fully overlaid with blue. "
-            + "Adjust the pupil min and pupil max ranges (red circles) so that the detected pupil size (green circle) is within the bounds."
-        )
-        self.menu.append(info)
         self.menu.append(
-            ui.Slider(
-                "2d.intensity_range",
-                self.proxy,
-                label="Pupil intensity range",
-                min=0,
-                max=60,
-                step=1,
+            ui.Info_Text(
+                "Open the debug window to see a visualization of the 3D pupil detection."
             )
         )
-        self.menu.append(
-            ui.Slider(
-                "2d.pupil_size_min",
-                self.proxy,
-                label="Pupil min",
-                min=1,
-                max=250,
-                step=1,
-            )
-        )
-        self.menu.append(
-            ui.Slider(
-                "2d.pupil_size_max",
-                self.proxy,
-                label="Pupil max",
-                min=50,
-                max=400,
-                step=1,
-            )
-        )
-        info_3d = ui.Info_Text(
-            "Open the debug window to see a visualization of the 3D pupil detection."
-        )
-        self.menu.append(info_3d)
         self.menu.append(ui.Button("Reset 3D model", self.reset_model))
         self.menu.append(ui.Button("Open debug window", self.debug_window_toggle))
         model_sensitivity_slider = ui.Slider(


### PR DESCRIPTION
When both detectors are running in parallel, the 2D settings of the 3D plugin are not used anymore.
I also removed the large info text about the algorithm view from the 3D plugin, since it is only used for debugging the 2D settings.

2D UI (unchanged):
![image](https://user-images.githubusercontent.com/7101194/81939622-d833fa80-95f6-11ea-96b5-c7de26a7b01b.png)

New 3D UI: 
![image](https://user-images.githubusercontent.com/7101194/81939662-e550e980-95f6-11ea-975e-51382574b148.png)
