### PR TITLE
Hide realsense cameras in camera selection list

### DIFF
--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -908,6 +908,9 @@ class UVC_Manager(Base_Manager):
             "eye1": ["ID1"],
             "world": ["ID2", "Logitech"],
         }
+        # Do not show RealSense cameras in selection, since they are not supported
+        # anymore in Pupil Capture since v1.22 and won't work.
+        self.ignore_patterns = ["RealSense"]
 
     def get_devices(self):
         self.devices.update()
@@ -925,6 +928,7 @@ class UVC_Manager(Base_Manager):
                 key=f"cam.{device['uid']}",
             )
             for device in self.devices
+            if not any(pattern in device["name"] for pattern in self.ignore_patterns)
         ]
 
     def activate(self, key):


### PR DESCRIPTION
Since v1.22 Pupil Capture does not offer built-in support for Intel RealSense cameras anymore. The cameras would still show up in the camera selection list, although activating them would have no effect. This would confuse users, as they could use the cameras previously.

This PR filters out all cameras with **RealSense** in the name from the camera activation list.

TODO:
- [x] Check if this really works, I don't have a RealSense available to test