### PR TITLE
Add glGetError() check to every Plugin.gl_display()

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -63,6 +63,7 @@ def eye(
     eye_id,
     overwrite_cap_settings=None,
     hide_ui=False,
+    debug=False,
 ):
     """reads eye video and detects the pupil.
 
@@ -181,6 +182,7 @@ def eye(
         g_pool = SimpleNamespace()
 
         # make some constants avaiable
+        g_pool.debug = debug
         g_pool.user_dir = user_dir
         g_pool.version = version
         g_pool.app = "capture"
@@ -705,6 +707,7 @@ def eye_profiled(
     eye_id,
     overwrite_cap_settings=None,
     hide_ui=False,
+    debug=False,
 ):
     import cProfile
     import subprocess
@@ -712,7 +715,7 @@ def eye_profiled(
     from .eye import eye
 
     cProfile.runctx(
-        "eye(timebase, is_alive_flag,ipc_pub_url,ipc_sub_url,ipc_push_url, user_dir, version, eye_id, overwrite_cap_settings, hide_ui)",
+        "eye(timebase, is_alive_flag,ipc_pub_url,ipc_sub_url,ipc_push_url, user_dir, version, eye_id, overwrite_cap_settings, hide_ui, debug)",
         {
             "timebase": timebase,
             "is_alive_flag": is_alive_flag,
@@ -724,6 +727,7 @@ def eye_profiled(
             "eye_id": eye_id,
             "overwrite_cap_settings": overwrite_cap_settings,
             "hide_ui": hide_ui,
+            "debug": debug,
         },
         locals(),
         "eye{}.pstats".format(eye_id),

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -28,7 +28,9 @@ MIN_DATA_CONFIDENCE_DEFAULT = 0.6
 MIN_CALIBRATION_CONFIDENCE_DEFAULT = 0.8
 
 
-def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version):
+def player(
+    rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version, debug
+):
     # general imports
     from time import sleep
     import logging
@@ -250,6 +252,7 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         # log info about Pupil Platform and Platform in player.log
         logger.info("Application Version: {}".format(app_version))
         logger.info("System Info: {}".format(get_system_info()))
+        logger.debug(f"Debug flag: {debug}")
 
         icon_bar_width = 50
         window_size = None
@@ -692,7 +695,9 @@ def player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_versio
         sleep(1.0)
 
 
-def player_drop(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version):
+def player_drop(
+    rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version, debug
+):
     # general imports
     import logging
 
@@ -868,7 +873,7 @@ def player_drop(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_v
 
 
 def player_profiled(
-    rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version
+    rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version, debug
 ):
     import cProfile
     import subprocess
@@ -876,7 +881,7 @@ def player_profiled(
     from .player import player
 
     cProfile.runctx(
-        "player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version)",
+        "player(rec_dir, ipc_pub_url, ipc_sub_url, ipc_push_url, user_dir, app_version, debug)",
         {
             "rec_dir": rec_dir,
             "ipc_pub_url": ipc_pub_url,
@@ -884,6 +889,7 @@ def player_profiled(
             "ipc_push_url": ipc_push_url,
             "user_dir": user_dir,
             "app_version": app_version,
+            "debug": debug,
         },
         locals(),
         "player.pstats",

--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -25,6 +25,7 @@ def service(
     version,
     preferred_remote_port,
     hide_ui,
+    debug,
 ):
     """Maps pupil to gaze data, can run various plug-ins.
 
@@ -120,9 +121,11 @@ def service(
 
         logger.info("Application Version: {}".format(version))
         logger.info("System Info: {}".format(get_system_info()))
+        logger.debug(f"Debug flag: {debug}")
 
         # g_pool holds variables for this process they are accesible to all plugins
         g_pool = SimpleNamespace()
+        g_pool.debug = debug
         g_pool.app = "service"
         g_pool.user_dir = user_dir
         g_pool.version = version
@@ -333,12 +336,13 @@ def service_profiled(
     version,
     preferred_remote_port,
     hide_ui,
+    debug,
 ):
     import cProfile, subprocess, os
     from .service import service
 
     cProfile.runctx(
-        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port,hide_ui)",
+        "service(timebase,eye_procs_alive,ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port,hide_ui,debug)",
         {
             "timebase": timebase,
             "eye_procs_alive": eye_procs_alive,
@@ -349,6 +353,7 @@ def service_profiled(
             "version": version,
             "preferred_remote_port": preferred_remote_port,
             "hide_ui": hide_ui,
+            "debug": debug,
         },
         locals(),
         "service.pstats",

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -24,6 +24,7 @@ def world(
     version,
     preferred_remote_port,
     hide_ui,
+    debug,
 ):
     """Reads world video and runs plugins.
 
@@ -131,6 +132,7 @@ def world(
 
         logger.info("Application Version: {}".format(version))
         logger.info("System Info: {}".format(get_system_info()))
+        logger.debug(f"Debug flag: {debug}")
 
         import audio
 
@@ -207,6 +209,7 @@ def world(
 
         # g_pool holds variables for this process they are accessible to all plugins
         g_pool = SimpleNamespace()
+        g_pool.debug = debug
         g_pool.app = "capture"
         g_pool.process = "world"
         g_pool.user_dir = user_dir
@@ -765,6 +768,7 @@ def world_profiled(
     version,
     preferred_remote_port,
     hide_ui,
+    debug,
 ):
     import cProfile
     import subprocess
@@ -772,7 +776,7 @@ def world_profiled(
     from .world import world
 
     cProfile.runctx(
-        "world(timebase, eye_procs_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port, hide_ui)",
+        "world(timebase, eye_procs_alive, ipc_pub_url,ipc_sub_url,ipc_push_url,user_dir,version,preferred_remote_port, hide_ui, debug)",
         {
             "timebase": timebase,
             "eye_procs_alive": eye_procs_alive,
@@ -783,6 +787,7 @@ def world_profiled(
             "version": version,
             "preferred_remote_port": preferred_remote_port,
             "hide_ui": hide_ui,
+            "debug": debug,
         },
         locals(),
         "world.pstats",

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -296,6 +296,7 @@ def launcher():
                             eye_id,
                             n.get("overwrite_cap_settings"),
                             parsed_args.hide_ui,
+                            parsed_args.debug,
                         ),
                     ).start()
                 elif "notify.player_process.should_start" in topic:
@@ -309,6 +310,7 @@ def launcher():
                             ipc_push_url,
                             user_dir,
                             app_version,
+                            parsed_args.debug,
                         ),
                     ).start()
                 elif "notify.world_process.should_start" in topic:
@@ -325,6 +327,7 @@ def launcher():
                             app_version,
                             parsed_args.port,
                             parsed_args.hide_ui,
+                            parsed_args.debug,
                         ),
                     ).start()
                 elif "notify.clear_settings_process.should_start" in topic:
@@ -345,6 +348,7 @@ def launcher():
                             app_version,
                             parsed_args.port,
                             parsed_args.hide_ui,
+                            parsed_args.debug,
                         ),
                     ).start()
                 elif "notify.player_drop_process.should_start" in topic:
@@ -358,6 +362,7 @@ def launcher():
                             ipc_push_url,
                             user_dir,
                             app_version,
+                            parsed_args.debug,
                         ),
                     ).start()
                 elif "notify.circle_detector_process.should_start" in topic:

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -57,13 +57,8 @@ class Plugin(object):
     def __init__(self, g_pool):
         self.g_pool = g_pool
 
-        # Monkeypatch potentially overwritten gl_display functions to include
-        # error checking. This is because we often receive OpenGL errors as
-        # results of buggy pyglui code that gets called in gl_display. Since
-        # pyglui does not check glGetError(), we run into these errors at other
-        # places at the code when e.g. using pyopengl. By checking after every
-        # plugin we can at least partially localize the error!
-        self.__monkeypatch_gl_display_error_checking()
+        if getattr(g_pool, "debug", False):
+            self.__monkeypatch_gl_display_error_checking()
 
     def init_ui(self):
         """
@@ -305,6 +300,12 @@ class Plugin(object):
         self.menu_icon = None
 
     def __monkeypatch_gl_display_error_checking(self):
+        # Monkeypatch gl_display functions to include error checking. This is because we
+        # often receive OpenGL errors as results of buggy pyglui code that gets called
+        # in gl_display. Since pyglui does not check glGetError(), we run into these
+        # errors at other places at the code when e.g. using pyopengl. By checking after
+        # every plugin we can at least partially localize the error!
+
         # Take gl_display function prototype from class, i.e. not bound to an
         # instance. This will return potentially overwritten implementations
         # from child classes.

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -13,7 +13,11 @@ import importlib
 import logging
 import os
 import sys
+import types
 from time import time
+
+from OpenGL.GL import glGetError
+from OpenGL.GLU import gluErrorString
 
 logger = logging.getLogger(__name__)
 """
@@ -52,6 +56,14 @@ class Plugin(object):
 
     def __init__(self, g_pool):
         self.g_pool = g_pool
+
+        # Monkeypatch potentially overwritten gl_display functions to include
+        # error checking. This is because we often receive OpenGL errors as
+        # results of buggy pyglui code that gets called in gl_display. Since
+        # pyglui does not check glGetError(), we run into these errors at other
+        # places at the code when e.g. using pyopengl. By checking after every
+        # plugin we can at least partially localize the error!
+        self.__monkeypatch_gl_display_error_checking()
 
     def init_ui(self):
         """
@@ -291,6 +303,25 @@ class Plugin(object):
         self.g_pool.iconbar.remove(self.menu_icon)
         self.menu = None
         self.menu_icon = None
+
+    def __monkeypatch_gl_display_error_checking(self):
+        # Take gl_display function prototype from class, i.e. not bound to an
+        # instance. This will return potentially overwritten implementations
+        # from child classes.
+        unpatched_gl_display = self.__class__.gl_display
+
+        # Create wrapper method including a glGetError check
+        def wrapper(_self):
+            unpatched_gl_display(_self)
+            err = glGetError()
+            if err != 0:
+                logger.error(
+                    f"Encountered OpenGL Error in Plugin '{_self.class_name}'!"
+                    f" Error code: {err}, msg: {gluErrorString(err)}"
+                )
+
+        # Bind wrapper to current instance
+        self.gl_display = types.MethodType(wrapper, self)
 
 
 # Plugin manager classes and fns


### PR DESCRIPTION
We often receive OpenGL errors as results of buggy pyglui code that gets called in `gl_display()` of plugins. Since pyglui does not check `glGetError()`, we run into these errors at other places at the code when e.g. using pyopengl. By checking after every plugin's `gl_display()` call we can at least partially localize the error!

Since it's easy to skip calling the base `Plugin.gl_display()` from subclasses, I monkeypatched a wrapper into all subclasses.