### PR TITLE
Bump recording info version for Pupil v2.0

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/info/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/info/__init__.py
@@ -13,6 +13,8 @@ from .. import Version
 from .recording_info import RecordingInfoFile
 from .recording_info_2_0 import _RecordingInfoFile_2_0
 from .recording_info_2_1 import _RecordingInfoFile_2_1
+from .recording_info_2_2 import _RecordingInfoFile_2_2
 
 RecordingInfoFile.register_child_class(Version("2.0"), _RecordingInfoFile_2_0)
 RecordingInfoFile.register_child_class(Version("2.1"), _RecordingInfoFile_2_1)
+RecordingInfoFile.register_child_class(Version("2.2"), _RecordingInfoFile_2_2)

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_2.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_2.py
@@ -1,0 +1,36 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2020 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+from . import RecordingInfoFile, Version
+from .recording_info_2_0 import _RecordingInfoFile_2_0
+from . import recording_info_utils as utils
+
+
+class _RecordingInfoFile_2_2(_RecordingInfoFile_2_0):
+
+    # Used to make Pupil v2.0 recordings backwards incompatible with v1.*
+
+    @property
+    def meta_version(self) -> Version:
+        return Version("2.2")
+
+    @property
+    def min_player_version(self) -> Version:
+        return Version("2.0")
+
+    @property
+    def _private_key_schema(self) -> RecordingInfoFile._KeyValueSchema:
+        return {
+            **super()._private_key_schema,
+            # overwrite meta_version key from parent
+            "meta_version": (utils.validator_version_string, lambda _: "2.2"),
+            "min_player_version": (utils.validator_version_string, lambda _: "2.0"),
+        }

--- a/pupil_src/shared_modules/pupil_recording/update/new_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/new_style.py
@@ -26,7 +26,16 @@ logger = logging.getLogger(__name__)
 
 def recording_update_to_latest_new_style(rec_dir: str):
     info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
+    check_min_player_version(info_file)
 
+    # incremental upgrade ...
+    if info_file.meta_version < Version("2.1"):
+        info_file = update_newstyle_20_21(rec_dir)
+    if info_file.meta_version < Version("2.2"):
+        info_file = update_newstyle_21_22(rec_dir)
+
+
+def check_min_player_version(info_file: RecordingInfoFile):
     # TODO: get_version() returns a LooseVersion, but we are using packaging.Version
     # now, need to adjust this across the codebase
     if info_file.min_player_version > Version(get_version().vstring):
@@ -35,36 +44,6 @@ def recording_update_to_latest_new_style(rec_dir: str):
             f"{info_file.min_player_version}"
         )
         raise InvalidRecordingException(reason=player_out_of_date)
-
-    if info_file.meta_version < Version("2.1"):
-        # There was a bug in v1.16 and v1.17 that caused corrupted gaze data when
-        # transforming a PI recording to new_style. Need to delete and re-transform.
-        if (
-            info_file.recording_software_name
-            == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
-        ):
-            logger.debug("Upgrading PI recording opened with pre v.1.18")
-            for path in Path(rec_dir).iterdir():
-                if not path.is_file:
-                    continue
-                if path.name in ["gaze.pldata", "gaze_timestamps.npy"]:
-                    logger.debug(
-                        f"Deleting potentially corrupted file '{path.name}'"
-                        f" from pre v1.18."
-                    )
-                    path.unlink()
-            invisible._convert_gaze(PupilRecording(rec_dir))
-            # Bump info file version to 2.1
-            new_info_file = RecordingInfoFile.create_empty_file(
-                rec_dir, fixed_version=Version("2.1")
-            )
-            new_info_file.update_writeable_properties_from(info_file)
-            info_file = new_info_file
-            info_file.save_file()
-
-    # if info_file.min_player_version < Version("1.17"):
-    #     ... incremental update ...
-    #     Increases min_player_version
 
 
 def check_for_worldless_recording_new_style(rec_dir):
@@ -79,3 +58,45 @@ def check_for_worldless_recording_new_style(rec_dir):
         fake_world_object = {"version": fake_world_version}
         fake_world_path = rec_dir / "world.fake"
         fm.save_object(fake_world_object, fake_world_path)
+
+
+def update_newstyle_20_21(rec_dir: str):
+    # There was a bug in v1.16 and v1.17 that caused corrupted gaze data when
+    # transforming a PI recording to new_style. Need to delete and re-transform.
+    info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
+
+    if (
+        info_file.recording_software_name
+        == RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+    ):
+        logger.debug("Upgrading PI recording opened with pre v.1.18")
+        for path in Path(rec_dir).iterdir():
+            if not path.is_file:
+                continue
+            if path.name in ["gaze.pldata", "gaze_timestamps.npy"]:
+                logger.debug(
+                    f"Deleting potentially corrupted file '{path.name}'"
+                    f" from pre v1.18."
+                )
+                path.unlink()
+        invisible._convert_gaze(PupilRecording(rec_dir))
+        # Bump info file version to 2.1
+        new_info_file = RecordingInfoFile.create_empty_file(
+            rec_dir, fixed_version=Version("2.1")
+        )
+        new_info_file.update_writeable_properties_from(info_file)
+        info_file = new_info_file
+        info_file.save_file()
+
+    return info_file
+
+
+def update_newstyle_21_22(rec_dir: str):
+    # Used to make Pupil v2.0 recordings backwards incompatible with v1.x
+    old_info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
+    new_info_file = RecordingInfoFile.create_empty_file(
+        rec_dir, fixed_version=Version("2.2")
+    )
+    new_info_file.update_writeable_properties_from(old_info_file)
+    new_info_file.save_file()
+    return new_info_file


### PR DESCRIPTION
Add recording info meta version 2.2.
Upgrade Pupil v2.0 recordings to be incompatible with Pupil v1.x.