### PR TITLE
Fix gaze corruption when deactivating gaze mappers

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/model/gaze_mapper.py
+++ b/pupil_src/shared_modules/gaze_producer/model/gaze_mapper.py
@@ -29,8 +29,8 @@ class GazeMapper(StorageItem):
         status="Not calculated yet",
         accuracy_result="",
         precision_result="",
-        gaze=[],
-        gaze_ts=[],
+        gaze=None,
+        gaze_ts=None,
     ):
         self.unique_id = unique_id
         self.name = name
@@ -44,8 +44,8 @@ class GazeMapper(StorageItem):
         self.status = status
         self.accuracy_result = accuracy_result
         self.precision_result = precision_result
-        self.gaze = gaze
-        self.gaze_ts = gaze_ts
+        self.gaze = gaze if gaze is not None else []
+        self.gaze_ts = gaze_ts if gaze_ts is not None else []
 
     @property
     def calculate_complete(self):


### PR DESCRIPTION
I had 2 offline Gaze Mappers and deactivated one. As a result there was a lot of weirdly duplicated and wrong data in the gaze export.

I did not figure out the whole chain of what was going wrong but stumbled across this piece of code. Never use mutable types as default parameter values! After fixing this the problem disappeared for me.

Since I didn't fully validate that this was indeed the cause of the problem, maybe see if you can reproduce the issue before (and not afterward).
