### PR TITLE
Add feedback for empty GazeMapper

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -98,12 +98,20 @@ class GazeMapperController(Observable):
                 gaze_mapper.gaze_ts.append(timestamp)
 
         def on_completed_mapping(_):
-            gaze_mapper.status = "Successfully completed mapping"
+            if gaze_mapper.empty():
+                gaze_mapper.status = "No data mapped!"
+                logger.warning(
+                    f"Gaze mapper {gaze_mapper.name} produced no data."
+                    f" Please check the quality of your Pupil data"
+                    f" and ensure you are using the appropriate pipeline!"
+                )
+            else:
+                gaze_mapper.status = "Successfully completed mapping"
             self.publish_all_enabled_mappers()
             self.validate_gaze_mapper(gaze_mapper)
             self._gaze_mapper_storage.save_to_disk()
             self.on_gaze_mapping_calculated(gaze_mapper)
-            logger.info("Complete gaze mapping for '{}'".format(gaze_mapper.name))
+            logger.info(f"Completed gaze mapping for '{gaze_mapper.name}'")
 
         task.add_observer("on_yield", on_yield_gaze)
         task.add_observer("on_completed", on_completed_mapping)

--- a/pupil_src/shared_modules/gaze_producer/model/gaze_mapper.py
+++ b/pupil_src/shared_modules/gaze_producer/model/gaze_mapper.py
@@ -47,10 +47,8 @@ class GazeMapper(StorageItem):
         self.gaze = gaze
         self.gaze_ts = gaze_ts
 
-    @property
-    def calculate_complete(self):
-        # we cannot just use `self.gaze and self.gaze_ts` because this ands the arrays
-        return len(self.gaze) > 0 and len(self.gaze_ts) > 0
+    def empty(self):
+        return len(self.gaze) == 0 and len(self.gaze_ts) == 0
 
     @staticmethod
     def from_tuple(tuple_):

--- a/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_menu.py
@@ -80,7 +80,7 @@ class GazeMapperMenu(plugin_ui.StorageEditMenu):
 
     def _create_calculate_button(self, gaze_mapper):
         return ui.Button(
-            label="Recalculate" if gaze_mapper.calculate_complete else "Calculate",
+            label="Calculate" if gaze_mapper.empty() else "Recalculate",
             function=self._on_click_calculate,
         )
 

--- a/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_timeline.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_timeline.py
@@ -74,7 +74,7 @@ class GazeMapperTimeline:
         color = (
             [0.3, 0.5, 0.5, alpha]
             # [136 / 255, 92 / 255, 197 / 255, alpha*1.0]
-            if gaze_mapper.calculate_complete
+            if not gaze_mapper.empty()
             else [0.66 * 0.7, 0.86 * 0.7, 0.46 * 0.7, alpha * 0.8]
         )
         return RangeElementFrameIdx(from_idx, to_idx, color_rgba=color, height=10)


### PR DESCRIPTION
If a GazeMapper did not produce any data, e.g. because the pupil data had the wrong method, it would still show `"Successfully completed mapping"` in the UI, but the timeline was grayed out.

I changed it so that you get a warning in this case that your GazeMapper did not produce any data.