### PR TITLE
Fix Announcer not storing new tokens in instance

### DIFF
--- a/pupil_src/shared_modules/data_changed.py
+++ b/pupil_src/shared_modules/data_changed.py
@@ -72,10 +72,14 @@ class Announcer:
         Announce that new data is available for the topic. New means that is has
         never been broadcasted before (not even in a previous run of the software).
         """
-        token = _normalize_token(token_data)
-        self._notify_all(token, delay=delay)
+        self._current_token = _normalize_token(token_data)
+        self._notify_all(self._current_token, delay=delay)
         _write_token_to_file(
-            token, self._plugin_role, self._topic, self._plugin_name, self._rec_dir
+            self._current_token,
+            self._plugin_role,
+            self._topic,
+            self._plugin_name,
+            self._rec_dir,
         )
 
     def announce_existing(self, delay=None):


### PR DESCRIPTION
Fixes the following bug:

1. Have a recording with stored data for both recording and offline data for both pupil and gaze.
1. Select **Pupil from Recording** and compute the **Offline gaze mapper**.
1. Switch to **Gaze from Recording**.
1. Switch to **Offline Pupil**.
1. Switch back to **Offline gaze mapper**.

Result: The offline gaze mapper displays the gaze that was mapped previously to **Pupil from Recording**, although we currently have **Offline Pupil** selected.

---
**BUT (!!)**
@papr @romanroibu 
This PR fixes the obvious bug. But I'm not sure that what's happening is actually the intended behavior. The `Offline_Pupil_Detection` will always call `announce_new()` when loading existing data from storage, should it be `announce_existing()` in that case? Otherwise we create a new token for an already existing cache?