### PR TITLE
Small improvements for Pupil Core v2 (1)

### DIFF
--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 class SingleMarkerMode(enum.Enum):
     FULL_SCREEN = "Full screen"
     WINDOW = "Window"
-    MANUAL = "Manual"
+    MANUAL = "Physical Marker"
 
     @staticmethod
     def all_modes() -> T.List["SingleMarkerMode"]:

--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -90,7 +90,7 @@ class SingleMarkerChoreographyPlugin(
         **kwargs,
     ):
         if marker_mode is None:
-            marker_mode = SingleMarkerMode.FULL_SCREEN
+            marker_mode = SingleMarkerMode.MANUAL
         else:
             marker_mode = SingleMarkerMode.from_label(marker_mode)
 

--- a/pupil_src/shared_modules/network_api/network_api_plugin.py
+++ b/pupil_src/shared_modules/network_api/network_api_plugin.py
@@ -29,9 +29,9 @@ class NetworkApiPlugin(Plugin):
     icon_font = "pupil_icons"
     order = 0.01  # excecute first
 
-    @property
-    def pretty_class_name(self):
-        return self.menu_label
+    @classmethod
+    def parse_pretty_class_name(cls) -> str:
+        return cls.menu_label
 
     def __init__(self, g_pool, **kwargs):
         super().__init__(g_pool)


### PR DESCRIPTION
### Changes
- Set the default mode for Single Marker Calibration to `MANUAL`
- Renamed the `MANUAL` mode label in Single Marker Calibration to `"Physical Marker"`
- Fixed to label name for `NetworkApiPlugin` to consistently show `"Network API"`
