### PR TITLE
Improve Offline Pupil Detection data storage during detection

### DIFF
--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -323,6 +323,35 @@ class PupilDataBisector:
         return data_by_topic
 
 
+class PupilDataCollector:
+    def __init__(self):
+        self._collection = collections.defaultdict(dict)
+
+    def append(self, topic, datum, timestamp):
+        pupil_topic = PupilTopic.create(topic, datum)
+        self._collection[pupil_topic][timestamp] = datum
+
+    def clear(self):
+        self._collection.clear()
+
+    def as_pupil_data_bisector(self) -> PupilDataBisector:
+        bisectors = {}
+        for topic, timestamps_data in self._collection.items():
+            timestamps = list(timestamps_data.keys())
+            data = list(timestamps_data.values())
+            bisector = Bisector(data, timestamps)
+            bisectors[topic] = bisector
+        pupil_data_bisector = PupilDataBisector(bisectors=bisectors)
+        return pupil_data_bisector
+
+    def count_collected(self, eye_id=None, detector_tag=None):
+        num_collected = 0
+        for topic, values in self._collection.items():
+            if PupilTopic.match(topic, eye_id, detector_tag):
+                num_collected += len(values)
+        return num_collected
+
+
 def find_closest(target, source):
     """Find indeces of closest `target` elements for elements in `source`.
     -

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -230,16 +230,22 @@ class PupilTopic:
 
 
 class PupilDataBisector:
-    def __init__(self, data: fm.PLData = fm.PLData([], [], [])):
-        self._bisectors = collections.defaultdict(pm.Mutable_Bisector)
-        self._init_from_data(data)
+    def __init__(self, data: T.Optional[fm.PLData] = None, bisectors=None):
+        if bisectors is not None:
+            self._bisectors = bisectors
+        else:
+            if data is None:
+                data = fm.PLData([], [], [])
+            self._bisectors = self._bisectors_from_data(data)
 
-    def _init_from_data(self, data: fm.PLData):
+    def _bisectors_from_data(self, data: fm.PLData):
+        _bisectors = {}
         for pupil_topic, data in self._group_data_by_pupil_topic(data).items():
-            assert pupil_topic not in self._bisectors
+            assert pupil_topic not in _bisectors
             assert len(data.topics) == len(data.data) == len(data.timestamps)
-            bisector = pm.Mutable_Bisector(data.data, data.timestamps)
-            self._bisectors[pupil_topic] = bisector
+            bisector = pm.Bisector(data.data, data.timestamps)
+            _bisectors[pupil_topic] = bisector
+        return _bisectors
 
     def init_dict_for_window(self, ts_window):
         init_dict = collections.defaultdict(list)

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -48,8 +48,8 @@ class Bisector(object):
                 )
             )
         elif not len(data):
-            self.data = np.asarray([])
-            self.data_ts = np.asarray([])
+            self.data = np.array([])
+            self.data_ts = np.array([])
             self.sorted_idc = []
         else:
             self.data_ts = np.asarray(data_ts)

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -48,7 +48,7 @@ class Bisector(object):
                 )
             )
         elif not len(data):
-            self.data = []
+            self.data = np.asarray([])
             self.data_ts = np.asarray([])
             self.sorted_idc = []
         else:
@@ -120,7 +120,7 @@ class Mutable_Bisector(Bisector):
     def insert(self, timestamp, datum):
         insert_idx = np.searchsorted(self.data_ts, timestamp)
         self.data_ts = np.insert(self.data_ts, insert_idx, timestamp)
-        self.data.insert(insert_idx, datum)
+        self.data = np.insert(self.data, insert_idx, datum)
 
 
 class Affiliator(Bisector):

--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -289,19 +289,6 @@ class PupilDataBisector:
                 continue
         raise ValueError
 
-    def append(self, topic, datum, timestamp):
-        pupil_topic = PupilTopic.create(topic, datum)
-        self._bisectors[pupil_topic].insert(timestamp, datum)
-
-    def clear(self):
-        self._bisectors.clear()
-
-    def copy(self):
-        copy = type(self)()
-        for topic, bisector in self._bisectors.items():
-            copy._bisectors[topic] = bisector.copy()
-        return copy
-
     def __bool__(self):
         return any(self._bisectors.values())
 

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -322,9 +322,6 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         # Start offline pupil detection if not complete yet:
         self.eye_video_loc = [None, None]
         self.eye_frame_num = [0, 0]
-        # TODO: Figure out the number of frames independent of cached 3d detection
-        # self.eye_frame_num[0] = len(pupil_data_from_cache[0, "3d"])
-        # self.eye_frame_num[1] = len(pupil_data_from_cache[1, "3d"])
 
         # start processes
         for eye_id in range(2):

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -318,8 +318,12 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.eye_video_loc = [None, None]
 
         self.eye_frame_num = [0, 0]
-        self.eye_frame_num[0] = len(self._pupil_data_store[0, "3d"]) #TODO: Figure out the number of frames independent of 3d detection
-        self.eye_frame_num[1] = len(self._pupil_data_store[1, "3d"]) #TODO: Figure out the number of frames independent of 3d detection
+        self.eye_frame_num[0] = len(
+            self._pupil_data_store[0, "3d"]
+        )  # TODO: Figure out the number of frames independent of 3d detection
+        self.eye_frame_num[1] = len(
+            self._pupil_data_store[1, "3d"]
+        )  # TODO: Figure out the number of frames independent of 3d detection
 
         self.pause_switch = None
         self.detection_paused = False
@@ -332,7 +336,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         # either we did not start them or they failed to start (mono setup etc)
         # either way we are done and can publish
         if self.eye_video_loc == [None, None]:
-            self.correlate_publish()
+            self.publish_existing()
 
     def start_eye_process(self, eye_id):
         potential_locs = [
@@ -372,8 +376,9 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         total = sum(self.eye_frame_num)
         if total:
             return min(
-                #TODO: Figure out the number of frames independent of 3d detection
-                len(self._pupil_data_store[..., "3d"]) / total, 1.0
+                # TODO: Figure out the number of frames independent of 3d detection
+                len(self._pupil_data_store[..., "3d"]) / total,
+                1.0,
             )
         else:
             return 0.0
@@ -405,10 +410,15 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                             self.stop_eye_process(eyeid)
                             break
                     if self.eye_video_loc == [None, None]:
-                        self.correlate_publish()
+                        self.publish_new()
+
         self.menu_icon.indicator_stop = self.detection_progress
 
-    def correlate_publish(self):
+    def publish_existing(self):
+        self.g_pool.pupil_positions = self._pupil_data_store.copy()
+        self._pupil_changed_announcer.announce_existing()
+
+    def publish_new(self):
         self.g_pool.pupil_positions = self._pupil_data_store.copy()
         self._pupil_changed_announcer.announce_new()
         logger.debug("pupil positions changed")

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -290,6 +290,8 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
     def __init__(self, g_pool):
         super().__init__(g_pool)
+        self._detection_paused = False
+
         zmq_ctx = zmq.Context()
         self.data_sub = zmq_tools.Msg_Receiver(
             zmq_ctx,
@@ -311,32 +313,23 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
         self.detection_status = session_meta_data["detection_status"]
 
-        self._pupil_data_store = pm.PupilDataBisector.load_from_file(
+        self._pupil_data_store = pm.PupilDataCollector()
+        pupil_data_from_cache = pm.PupilDataBisector.load_from_file(
             self.data_dir, self.session_data_name
         )
+        self.publish_existing(pupil_data_from_cache)
 
+        # Start offline pupil detection if not complete yet:
         self.eye_video_loc = [None, None]
-
         self.eye_frame_num = [0, 0]
-        self.eye_frame_num[0] = len(
-            self._pupil_data_store[0, "3d"]
-        )  # TODO: Figure out the number of frames independent of 3d detection
-        self.eye_frame_num[1] = len(
-            self._pupil_data_store[1, "3d"]
-        )  # TODO: Figure out the number of frames independent of 3d detection
-
-        self.pause_switch = None
-        self.detection_paused = False
+        # TODO: Figure out the number of frames independent of cached 3d detection
+        # self.eye_frame_num[0] = len(pupil_data_from_cache[0, "3d"])
+        # self.eye_frame_num[1] = len(pupil_data_from_cache[1, "3d"])
 
         # start processes
         for eye_id in range(2):
             if self.detection_status[eye_id] != "complete":
                 self.start_eye_process(eye_id)
-
-        # either we did not start them or they failed to start (mono setup etc)
-        # either way we are done and can publish
-        if self.eye_video_loc == [None, None]:
-            self.publish_existing()
 
     def start_eye_process(self, eye_id):
         potential_locs = [
@@ -374,12 +367,10 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
     @property
     def detection_progress(self) -> float:
         total = sum(self.eye_frame_num)
+        # TODO: Figure out the number of frames independent of 3d detection
+        detected = self._pupil_data_store.count_collected(detector_tag="3d")
         if total:
-            return min(
-                # TODO: Figure out the number of frames independent of 3d detection
-                len(self._pupil_data_store[..., "3d"]) / total,
-                1.0,
-            )
+            return min(detected / total, 1.0,)
         else:
             return 0.0
 
@@ -399,7 +390,6 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                 assert pm.PupilTopic.match(topic, eye_id=pupil_datum["id"])
                 timestamp = pupil_datum["timestamp"]
                 self._pupil_data_store.append(topic, pupil_datum, timestamp)
-                self._pupil_data_store.__getitem__.cache_clear()
             else:
                 payload = self.data_sub.deserialize_payload(*remaining_frames)
                 if payload["subject"] == "file_source.video_finished":
@@ -410,16 +400,17 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
                             self.stop_eye_process(eyeid)
                             break
                     if self.eye_video_loc == [None, None]:
-                        self.publish_new()
+                        data = self._pupil_data_store.as_pupil_data_bisector()
+                        self.publish_new(pupil_data_bisector=data)
 
         self.menu_icon.indicator_stop = self.detection_progress
 
-    def publish_existing(self):
-        self.g_pool.pupil_positions = self._pupil_data_store.copy()
+    def publish_existing(self, pupil_data_bisector):
+        self.g_pool.pupil_positions = pupil_data_bisector
         self._pupil_changed_announcer.announce_existing()
 
-    def publish_new(self):
-        self.g_pool.pupil_positions = self._pupil_data_store.copy()
+    def publish_new(self, pupil_data_bisector):
+        self.g_pool.pupil_positions = pupil_data_bisector
         self._pupil_changed_announcer.announce_new()
         logger.debug("pupil positions changed")
         self.save_offline_data()
@@ -439,7 +430,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         self.save_offline_data()
 
     def save_offline_data(self):
-        self._pupil_data_store.save_to_file(self.data_dir, "offline_pupil")
+        self.g_pool.pupil_positions.save_to_file(self.data_dir, "offline_pupil")
         session_data = {}
         session_data["detection_status"] = self.detection_status
         session_data["version"] = self.session_data_version
@@ -449,8 +440,7 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
     def redetect(self):
         self._pupil_data_store.clear()
-        self._pupil_data_store.__getitem__.cache_clear()
-        self.g_pool.pupil_positions = self._pupil_data_store.copy()
+        self.g_pool.pupil_positions = self._pupil_data_store.as_pupil_data_bisector()
         self._pupil_changed_announcer.announce_new()
         self.detection_finished_flag = False
         self.detection_paused = False


### PR DESCRIPTION
Instead of using `Mutable_Bisector`s (which use `nump.insert`), use a timestamp->datum mapping. This has the advantage of being faster and avoids duplicated entries when restarting the detection while there is an existing detection running.

This PR also correctly announces cached pupil data as "existing" instead of "new". This avoids recalculating e.g. offline gaze mappings on restoring a session.