### PR TITLE
Use only 2d confidence in realtime blink detector

### DIFF
--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -115,7 +115,10 @@ class Blink_Detection(Analysis_Plugin_Base):
     def recent_events(self, events={}):
         events["blinks"] = []
         self._recent_blink = None
-        self.history.extend(events.get("pupil", []))
+
+        pupil = events.get("pupil", [])
+        pupil = filter(lambda p: "2d" in p["topic"], pupil)
+        self.history.extend(pupil)
 
         try:
             ts_oldest = self.history[0]["timestamp"]


### PR DESCRIPTION
Since we run 2d and 3d pupil detection in parallel, we need to filter one type of pupil data in order to get a clean confidence signal. Since the 2d confidence signal provides sharper confidence drops during blinks, this PR changes the real-time blink detector to only use that signal.

This makes the real-time blink detector consistent with the post-hoc detector d2516d29bca3704044759d84d0e9c09a2c474a34