### PR TITLE
Fix NameError when not overwriting selection_label

### DIFF
--- a/pupil_src/shared_modules/calibration_choreography/base_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/base_plugin.py
@@ -125,7 +125,7 @@ class CalibrationChoreographyPlugin(Plugin):
 
     @classmethod
     def selection_label(cls) -> str:
-        return self.label
+        return cls.label
 
     @classmethod
     def selection_order(cls) -> float:


### PR DESCRIPTION
The code would crash when a child-class did not overwrite `selection_label` as the base class implementation was faulty.

This didn't happen internally as all our child classes overwrite `selection_label`, but the HMD plugin didn't, so I found this while testing HMD.