### PR TITLE
Store HMD eye_translations in session settings

### DIFF
--- a/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_hmd.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_hmd.py
@@ -162,3 +162,9 @@ class GazerHMD3D(Gazer3D):
         ref_3d = np.array([ref["mm_pos"] for ref in ref_data])
         assert ref_3d.shape == (len(ref_data), 3), ref_3d
         return ref_3d
+
+    def get_init_dict(self):
+        return {
+            **super().get_init_dict(),
+            "eye_translations": self.__eye_translations,
+        }


### PR DESCRIPTION
These are required for starting the HMDGazer and thus restoration from
session settings will fail otherwise.

This is a quick fix preventing the crash.
The more general question is if we want the HMD gazer to start at all, I'll create a ticket for that.