### PR TITLE
Update PyAV on travis

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,6 +1,7 @@
 python -m pip install -U pip
 
 pip install -U git+https://github.com/pupil-labs/pyndsi
+pip install -U git+https://github.com/pupil-labs/PyAV
 pip install scikit-learn
 
 pip install pytest==5.2.2


### PR DESCRIPTION
Since v2.0 we were getting errors on CI.
This was simply because we were running with an old PyAV version.