### PR TITLE
Prevent calibrations with unavailable gazers from being added

### DIFF
--- a/pupil_src/shared_modules/accuracy_visualizer.py
+++ b/pupil_src/shared_modules/accuracy_visualizer.py
@@ -80,7 +80,9 @@ class ValidationInput:
         self.__gazer_class = None
         self.__gazer_params = None
 
-    def update(self, gazer_class_name: str, gazer_params=..., pupil_list=..., ref_list=...):
+    def update(
+        self, gazer_class_name: str, gazer_params=..., pupil_list=..., ref_list=...
+    ):
         if (
             self.gazer_class_name is not None
             and self.gazer_class_name != gazer_class_name

--- a/pupil_src/shared_modules/accuracy_visualizer.py
+++ b/pupil_src/shared_modules/accuracy_visualizer.py
@@ -26,7 +26,7 @@ from calibration_choreography import (
 )
 from plugin import Plugin
 
-from gaze_mapping import registered_gazer_classes_by_class_name
+from gaze_mapping import gazer_classes_by_class_name, registered_gazer_classes
 from gaze_mapping.notifications import (
     CalibrationSetupNotification,
     CalibrationResultNotification,
@@ -107,7 +107,7 @@ class ValidationInput:
             logger.info("Accuracy visualization is disabled for HMD calibration")
             return None
 
-        gazers_by_name = registered_gazer_classes_by_class_name()
+        gazers_by_name = gazer_classes_by_class_name(registered_gazer_classes())
 
         try:
             gazer_cls = gazers_by_name[gazer_class_name]

--- a/pupil_src/shared_modules/gaze_mapping/__init__.py
+++ b/pupil_src/shared_modules/gaze_mapping/__init__.py
@@ -19,12 +19,18 @@ def registered_gazer_classes() -> list:
     return gazer_base.GazerBase.registered_gazer_classes()
 
 
-def registered_gazer_labels_by_class_names() -> dict:
-    return {cls.__name__: cls.label for cls in registered_gazer_classes()}
+def user_selectable_gazer_classes() -> list:
+    gazers = registered_gazer_classes()
+    gazers = filter(lambda g: g is not GazerHMD3D, gazers)
+    return list(gazers)
 
 
-def registered_gazer_classes_by_class_name() -> dict:
-    return {cls.__name__: cls for cls in registered_gazer_classes()}
+def gazer_labels_by_class_names(gazers: list) -> dict:
+    return {cls.__name__: cls.label for cls in gazers}
+
+
+def gazer_classes_by_class_name(gazers: list) -> dict:
+    return {cls.__name__: cls for cls in gazers}
 
 
 default_gazer_class = Gazer3D

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -20,7 +20,11 @@ import make_unique
 from storage import Storage
 from gaze_producer import model
 from observable import Observable
-from gaze_mapping import default_gazer_class
+from gaze_mapping import (
+    default_gazer_class,
+    user_selectable_gazer_classes,
+    gazer_classes_by_class_name,
+)
 from gaze_mapping.notifications import (
     CalibrationSetupNotification,
     CalibrationResultNotification,
@@ -114,7 +118,14 @@ class CalibrationStorage(Storage, Observable):
                 + "\n".join(f"- {c.name} ({c.unique_id})" for c in self._calibrations)
             )
             return
-
+        registered_gazer_class_names = set(
+            gazer_classes_by_class_name(user_selectable_gazer_classes()).keys()
+        )
+        if calibration.gazer_class_name not in registered_gazer_class_names:
+            logger.warning(
+                f"Did not add calibration {calibration.name} ({calibration.unique_id}) because gaze mapping method ({calibration.gazer_class_name}) is not available."
+            )
+            return
         self._calibrations.append(calibration)
         self._calibrations.sort(key=lambda c: c.name)
 

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -22,6 +22,7 @@ from gaze_producer import model
 from observable import Observable
 from gaze_mapping import (
     default_gazer_class,
+    registered_gazer_classes,
     user_selectable_gazer_classes,
     gazer_classes_by_class_name,
 )
@@ -118,10 +119,16 @@ class CalibrationStorage(Storage, Observable):
                 + "\n".join(f"- {c.name} ({c.unique_id})" for c in self._calibrations)
             )
             return
-        registered_gazer_class_names = set(
-            gazer_classes_by_class_name(user_selectable_gazer_classes()).keys()
+        is_calib_editable = (
+            self._from_same_recording(calibration)
+            and calibration.is_offline_calibration
         )
-        if calibration.gazer_class_name not in registered_gazer_class_names:
+        if is_calib_editable:
+            available_gazer_classes = user_selectable_gazer_classes()
+        else:
+            available_gazer_classes = registered_gazer_classes()
+        gazer_class_names = gazer_classes_by_class_name(available_gazer_classes).keys()
+        if calibration.gazer_class_name not in gazer_class_names:
             logger.warning(
                 f"Did not add calibration {calibration.name} ({calibration.unique_id}) because gaze mapping method ({calibration.gazer_class_name}) is not available."
             )

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -20,7 +20,7 @@ import make_unique
 from storage import Storage
 from gaze_producer import model
 from observable import Observable
-from gaze_mapping import default_gazer_class, registered_gazer_labels_by_class_names
+from gaze_mapping import default_gazer_class
 from gaze_mapping.notifications import (
     CalibrationSetupNotification,
     CalibrationResultNotification,

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -13,7 +13,7 @@ import logging
 from pyglui import ui
 
 from gaze_producer import ui as plugin_ui
-from gaze_mapping import registered_gazer_labels_by_class_names
+from gaze_mapping import gazer_labels_by_class_names, registered_gazer_classes
 
 logger = logging.getLogger(__name__)
 
@@ -85,12 +85,15 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _create_mapping_method_selector(self, calibration):
+        gazers = registered_gazer_classes()
+        gazers_map = gazer_labels_by_class_names(gazers)
+
         return ui.Selector(
             "gazer_class_name",
             calibration,
             label="Gaze Mapping",
-            labels=list(registered_gazer_labels_by_class_names().values()),
-            selection=list(registered_gazer_labels_by_class_names().keys()),
+            labels=list(gazers_map.values()),
+            selection=list(gazers_map.keys()),
         )
 
     def _create_min_confidence_slider(self, calibration):
@@ -120,8 +123,10 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _info_text_for_calibration_from_other_recording(self, calibration):
+        gazers = registered_gazer_classes()
         gazer_class_name = calibration.gazer_class_name
-        gazer_label = registered_gazer_labels_by_class_names()[gazer_class_name]
+        gazer_label = gazer_labels_by_class_names(gazers)[gazer_class_name]
+
         if calibration.params:
             return (
                 f"This {gazer_label} calibration was copied from another recording. "
@@ -139,8 +144,10 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         menu.append(ui.Info_Text(self._info_text_for_online_calibration(calibration)))
 
     def _info_text_for_online_calibration(self, calibration):
+        gazers = registered_gazer_classes()
         gazer_class_name = calibration.gazer_class_name
-        gazer_label = registered_gazer_labels_by_class_names()[gazer_class_name]
+        gazer_label = gazer_labels_by_class_names(gazers)[gazer_class_name]
+
         return (
             f"This {gazer_label} calibration was created before or during the "
             "recording. It is ready to be used in gaze mappers."

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -13,7 +13,7 @@ import logging
 from pyglui import ui
 
 from gaze_producer import ui as plugin_ui
-from gaze_mapping import gazer_labels_by_class_names, registered_gazer_classes
+from gaze_mapping import gazer_labels_by_class_names, registered_gazer_classes, user_selectable_gazer_classes
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _create_mapping_method_selector(self, calibration):
-        gazers = registered_gazer_classes()
+        gazers = user_selectable_gazer_classes()
         gazers_map = gazer_labels_by_class_names(gazers)
 
         return ui.Selector(

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -13,7 +13,11 @@ import logging
 from pyglui import ui
 
 from gaze_producer import ui as plugin_ui
-from gaze_mapping import gazer_labels_by_class_names, registered_gazer_classes, user_selectable_gazer_classes
+from gaze_mapping import (
+    gazer_labels_by_class_names,
+    registered_gazer_classes,
+    user_selectable_gazer_classes,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/pupil_src/shared_modules/gaze_producer/worker/create_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/create_calibration.py
@@ -15,7 +15,11 @@ from types import SimpleNamespace
 import player_methods as pm
 import tasklib.background
 from gaze_producer import model
-from gaze_mapping import gazer_classes_by_class_name, registered_gazer_classes, CalibrationError
+from gaze_mapping import (
+    gazer_classes_by_class_name,
+    registered_gazer_classes,
+    CalibrationError,
+)
 from methods import normalize
 
 from .fake_gpool import FakeGPool

--- a/pupil_src/shared_modules/gaze_producer/worker/create_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/create_calibration.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 import player_methods as pm
 import tasklib.background
 from gaze_producer import model
-from gaze_mapping import registered_gazer_classes_by_class_name, CalibrationError
+from gaze_mapping import gazer_classes_by_class_name, registered_gazer_classes, CalibrationError
 from methods import normalize
 
 from .fake_gpool import FakeGPool
@@ -68,7 +68,7 @@ def _create_calibration(
     # This is needed to support user-provided gazers
     fake_gpool.import_runtime_plugins()
 
-    gazers_by_name = registered_gazer_classes_by_class_name()
+    gazers_by_name = gazer_classes_by_class_name(registered_gazer_classes())
 
     try:
         gazer_class = gazers_by_name[gazer_class_name]

--- a/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/map_gaze.py
@@ -11,7 +11,7 @@ See COPYING and COPYING.LESSER for license details.
 import file_methods as fm
 import player_methods as pm
 import tasklib
-from gaze_mapping import registered_gazer_classes_by_class_name
+from gaze_mapping import gazer_classes_by_class_name, registered_gazer_classes
 
 from .fake_gpool import FakeGPool
 
@@ -60,7 +60,7 @@ def _map_gaze(
     shared_memory,
 ):
     fake_gpool.import_runtime_plugins()
-    gazers_by_name = registered_gazer_classes_by_class_name()
+    gazers_by_name = gazer_classes_by_class_name(registered_gazer_classes())
     gazer_cls = gazers_by_name[gazer_class_name]
     gazer = gazer_cls(fake_gpool, params=gazer_params)
 

--- a/pupil_src/shared_modules/gaze_producer/worker/validate_gaze.py
+++ b/pupil_src/shared_modules/gaze_producer/worker/validate_gaze.py
@@ -13,7 +13,7 @@ from accuracy_visualizer import Accuracy_Visualizer
 from methods import normalize
 import player_methods as pm
 
-from gaze_mapping import registered_gazer_classes_by_class_name
+from gaze_mapping import gazer_classes_by_class_name, registered_gazer_classes
 
 from .fake_gpool import FakeGPool
 
@@ -61,7 +61,7 @@ def validate(
     refs_in_validation_range,
 ):
     g_pool.import_runtime_plugins()
-    gazers_by_name = registered_gazer_classes_by_class_name()
+    gazers_by_name = gazer_classes_by_class_name(registered_gazer_classes())
     gazer_class = gazers_by_name[gazer_class_name]
 
     pupil_list = pupils_in_validation_range


### PR DESCRIPTION
Prevent calibrations with unavailable gazers classes (custom gazer classes, `GazerHMD3D`) from being added to `CalibrationStorage`.
