### PR TITLE
Fix deprecated surface warning

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface_marker_aggregate.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_marker_aggregate.py
@@ -26,11 +26,14 @@ class Surface_Marker_Aggregate(object):
     """
 
     @staticmethod
-    def property_equality(x: "Surface_Marker_Aggregate", y: "Surface_Marker_Aggregate") -> bool:
+    def property_equality(
+        x: "Surface_Marker_Aggregate", y: "Surface_Marker_Aggregate"
+    ) -> bool:
         def property_dict(x: Surface_Marker_Aggregate) -> dict:
             x_dict = x.__dict__.copy()
             x_dict["_verts_uv"] = x_dict["_verts_uv"].tolist()
             return x_dict
+
         return property_dict(x) == property_dict(y)
 
     def __init__(

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer.py
@@ -152,7 +152,7 @@ class _Surface_Serializer_V00(_Surface_Serializer_Base):
         # The format of v00 doesn't store any value for "version" key
         surface_definition["version"] = surface_definition.get("version", self.version)
         return super().surface_from_dict(
-            surface_class=surface_class, surface_definition=surface_definition,
+            surface_class=surface_class, surface_definition=surface_definition
         )
 
 

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer.py
@@ -95,11 +95,7 @@ class _Surface_Serializer_Base(abc.ABC):
             for d in surface_definition["registered_markers_dist"]
         ]
 
-        deprecated_definition = True
-        try:
-            deprecated_definition = surface_definition["deprecated"]
-        except KeyError:
-            pass
+        deprecated_definition = surface_definition.get("deprecated", True)
 
         if deprecated_definition:
             logger.warning(

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer.py
@@ -95,12 +95,13 @@ class _Surface_Serializer_Base(abc.ABC):
             for d in surface_definition["registered_markers_dist"]
         ]
 
-        deprecated_definition = None
+        deprecated_definition = True
         try:
             deprecated_definition = surface_definition["deprecated"]
         except KeyError:
             pass
-        else:
+
+        if deprecated_definition:
             logger.warning(
                 "You have loaded an old and deprecated surface definition! "
                 "Please re-define this surface for increased mapping accuracy!"

--- a/pupil_src/shared_modules/surface_tracker/surface_serializer.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_serializer.py
@@ -15,11 +15,15 @@ import logging
 import os
 import typing
 
-from .surface import Surface
-from .surface import Surface_Marker_Aggregate
-from .surface_marker import Surface_Marker_UID, Surface_Marker_Type, Surface_Marker_TagID
-from .surface_marker import create_surface_marker_uid, parse_surface_marker_tag_id, parse_surface_marker_type
-
+from .surface import Surface, Surface_Marker_Aggregate
+from .surface_marker import (
+    Surface_Marker_TagID,
+    Surface_Marker_Type,
+    Surface_Marker_UID,
+    create_surface_marker_uid,
+    parse_surface_marker_tag_id,
+    parse_surface_marker_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,18 +33,21 @@ class InvalidSurfaceDefinition(Exception):
 
 
 class _Surface_Serializer_Base(abc.ABC):
-
     @property
     @abc.abstractmethod
     def version(self) -> int:
         pass
 
     @abc.abstractmethod
-    def dict_from_surface_marker_aggregate(self, surface_marker_aggregate: Surface_Marker_Aggregate) -> dict:
+    def dict_from_surface_marker_aggregate(
+        self, surface_marker_aggregate: Surface_Marker_Aggregate
+    ) -> dict:
         pass
 
     @abc.abstractmethod
-    def surface_marker_aggregate_from_dict(self, surface_marker_aggregate_dict: dict) -> Surface_Marker_Aggregate:
+    def surface_marker_aggregate_from_dict(
+        self, surface_marker_aggregate_dict: dict
+    ) -> Surface_Marker_Aggregate:
         pass
 
     def dict_from_surface(self, surface: Surface) -> dict:
@@ -48,11 +55,11 @@ class _Surface_Serializer_Base(abc.ABC):
 
         reg_markers = [
             dict_from_marker_aggregate(marker_aggregate)
-            for marker_aggregate in surface._registered_markers_undist.values() #TODO: Provide a public property for this
+            for marker_aggregate in surface._registered_markers_undist.values()  # TODO: Provide a public property for this
         ]
         registered_markers_dist = [
             dict_from_marker_aggregate(marker_aggregate)
-            for marker_aggregate in surface._registered_markers_dist.values() #TODO: Provide a public property for this
+            for marker_aggregate in surface._registered_markers_dist.values()  # TODO: Provide a public property for this
         ]
         return {
             "version": self.version,
@@ -65,8 +72,12 @@ class _Surface_Serializer_Base(abc.ABC):
         }
 
     def surface_from_dict(self, surface_class, surface_definition: dict) -> Surface:
-        assert isinstance(surface_class, type(object)), f"surface_class must be a class: {surface_class}"
-        assert issubclass(surface_class, Surface), f"surface_class must be a subclass of Surface: {surface_class}"
+        assert isinstance(
+            surface_class, type(object)
+        ), f"surface_class must be a class: {surface_class}"
+        assert issubclass(
+            surface_class, Surface
+        ), f"surface_class must be a subclass of Surface: {surface_class}"
 
         expected_version = self.version
         actual_version = surface_definition["version"]
@@ -76,8 +87,13 @@ class _Surface_Serializer_Base(abc.ABC):
 
         marker_aggregate_from_dict = self.surface_marker_aggregate_from_dict
 
-        marker_aggregates_undist = [marker_aggregate_from_dict(d) for d in surface_definition["reg_markers" ]]
-        marker_aggregates_dist = [marker_aggregate_from_dict(d) for d in surface_definition["registered_markers_dist"]]
+        marker_aggregates_undist = [
+            marker_aggregate_from_dict(d) for d in surface_definition["reg_markers"]
+        ]
+        marker_aggregates_dist = [
+            marker_aggregate_from_dict(d)
+            for d in surface_definition["registered_markers_dist"]
+        ]
 
         deprecated_definition = None
         try:
@@ -104,7 +120,9 @@ class _Surface_Serializer_V00(_Surface_Serializer_Base):
 
     version = 0
 
-    def dict_from_surface_marker_aggregate(self, surface_marker_aggregate: Surface_Marker_Aggregate) -> dict:
+    def dict_from_surface_marker_aggregate(
+        self, surface_marker_aggregate: Surface_Marker_Aggregate
+    ) -> dict:
         id = parse_surface_marker_tag_id(uid=surface_marker_aggregate.uid)
         marker_type = parse_surface_marker_type(uid=surface_marker_aggregate.uid)
         if marker_type != Surface_Marker_Type.SQUARE:
@@ -115,12 +133,14 @@ class _Surface_Serializer_V00(_Surface_Serializer_Base):
             verts_uv = [v.tolist() for v in verts_uv]
         return {"id": id, "verts_uv": verts_uv}
 
-    def surface_marker_aggregate_from_dict(self, surface_marker_aggregate_dict: dict) -> Surface_Marker_Aggregate:
+    def surface_marker_aggregate_from_dict(
+        self, surface_marker_aggregate_dict: dict
+    ) -> Surface_Marker_Aggregate:
         tag_id = surface_marker_aggregate_dict["id"]
         uid = create_surface_marker_uid(
             marker_type=Surface_Marker_Type.SQUARE,
             tag_family=None,
-            tag_id=Surface_Marker_TagID(tag_id)
+            tag_id=Surface_Marker_TagID(tag_id),
         )
         verts_uv = surface_marker_aggregate_dict["verts_uv"]
         return Surface_Marker_Aggregate(uid=uid, verts_uv=verts_uv)
@@ -135,8 +155,7 @@ class _Surface_Serializer_V00(_Surface_Serializer_Base):
         # The format of v00 doesn't store any value for "version" key
         surface_definition["version"] = surface_definition.get("version", self.version)
         return super().surface_from_dict(
-            surface_class=surface_class,
-            surface_definition=surface_definition,
+            surface_class=surface_class, surface_definition=surface_definition,
         )
 
 
@@ -144,14 +163,18 @@ class _Surface_Serializer_V01(_Surface_Serializer_Base):
 
     version = 1
 
-    def dict_from_surface_marker_aggregate(self, surface_marker_aggregate: Surface_Marker_Aggregate) -> dict:
+    def dict_from_surface_marker_aggregate(
+        self, surface_marker_aggregate: Surface_Marker_Aggregate
+    ) -> dict:
         uid = str(surface_marker_aggregate.uid)
         verts_uv = surface_marker_aggregate.verts_uv
         if verts_uv is not None:
             verts_uv = [v.tolist() for v in verts_uv]
         return {"uid": uid, "verts_uv": verts_uv}
 
-    def surface_marker_aggregate_from_dict(self, surface_marker_aggregate_dict: dict) -> Surface_Marker_Aggregate:
+    def surface_marker_aggregate_from_dict(
+        self, surface_marker_aggregate_dict: dict
+    ) -> Surface_Marker_Aggregate:
         uid = surface_marker_aggregate_dict["uid"]
         verts_uv = surface_marker_aggregate_dict["verts_uv"]
         return Surface_Marker_Aggregate(uid=uid, verts_uv=verts_uv)

--- a/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker_offline.py
@@ -340,7 +340,11 @@ class Surface_Tracker_Offline(Observable, Surface_Tracker, Analysis_Plugin_Base)
             surf_idx = self.surfaces.index(surface)
             gaze_on_surf = self.gaze_on_surf_buffer[surf_idx]
             gaze_on_surf = itertools.chain.from_iterable(gaze_on_surf)
-            gaze_on_surf = (g for g in gaze_on_surf if g["confidence"] >= self.g_pool.min_data_confidence)
+            gaze_on_surf = (
+                g
+                for g in gaze_on_surf
+                if g["confidence"] >= self.g_pool.min_data_confidence
+            )
             gaze_on_surf = list(gaze_on_surf)
             surface.update_heatmap(gaze_on_surf)
 

--- a/pupil_src/shared_modules/surface_tracker/surface_tracker_online.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker_online.py
@@ -132,7 +132,11 @@ class Surface_Tracker_Online(Surface_Tracker):
     def _update_surface_heatmaps(self):
         for surface in self.surfaces:
             gaze_on_surf = surface.gaze_history
-            gaze_on_surf = (g for g in gaze_on_surf if g["confidence"] >= self.g_pool.min_data_confidence)
+            gaze_on_surf = (
+                g
+                for g in gaze_on_surf
+                if g["confidence"] >= self.g_pool.min_data_confidence
+            )
             gaze_on_surf = list(gaze_on_surf)
             surface.update_heatmap(gaze_on_surf)
 


### PR DESCRIPTION
@romanroibu I stumbled upon this by accident. It's actually not in Capture, but a problem with Player.

Player would complain wrongly about deprecated surface definitions when in fact they were not.

Note that most of the diff is applying black.
Take a look at the ~~first~~ second commit.
The `deprecated_definition` is a boolean that can also be `False` when not deprecated.

I wanted to test that this will still correctly warn with deprecated surfaces.
@romanroibu maybe you can help me out here:
I had a recording with both `surface_definitions` and `surface_definitions_v01` and deleted the `_v01` file.
To be sure I also deleted the marker cache.
However with this branch I did **not** get the warning upon opening the modified recording with Player.
I investigated a bit and it seems that the `surface_definitions` file had `deprecated: False` encoded into it.
I'm not sure if that makes any sense?
Maybe you can verify that this still correctly warns when using deprecated surface definitions?

Edit by @papr:

### For reference
- pre v1.13: `surface_definitions`
  - do not include undistorted surface definitions
  - do not have a `deprecated` key
  - do not have a `version` key
- in v1.13:
  - **incorrect implementation of "deprecated surfaces"-warning**
  - pre v1.13 `surface_definitions` are backed up to `surface_definitions_deprecated`
  - if `world.intrinsics` is present pre v1.13 `surface_definitions` will be upgraded to v1.13 `surface_definitions`
    - include **approximated** undistorted surface definitions
    - have `deprecated` key set to `True`
    - do not have a `version` key
- since https://github.com/pupil-labs/pupil/pull/1586/commits/e9787dfc5361dfc7b97c12536341a4d4c1467a64 (v1.16/17)
  - `surface_definitions` are assigned an implicit version (`0`), only include square marker surfaces
  - `surface_definitions_v01` are assigned an explicit version (`1`), include square marker and apriltag surfaces