### PR TITLE
Fix MutableBisector.insert()

### DIFF
--- a/pupil_src/shared_modules/player_methods.py
+++ b/pupil_src/shared_modules/player_methods.py
@@ -48,7 +48,7 @@ class Bisector(object):
                 )
             )
         elif not len(data):
-            self.data = np.array([])
+            self.data = np.array([], dtype=object)
             self.data_ts = np.array([])
             self.sorted_idc = []
         else:


### PR DESCRIPTION
MutableBisector calls numpy.insert on self.data. The `numpy.insert()` documentation states that it will attempt to convert the inserted value to the dtype of the array. https://numpy.org/doc/1.18/reference/generated/numpy.insert.html

This currently fails for post-hoc annotations and head pose tracking as self.data is not an object-array.