### PR TITLE
Choreography plugins: Only call update_ui() in Capture

### DIFF
--- a/pupil_src/shared_modules/calibration_choreography/base_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/base_plugin.py
@@ -448,7 +448,8 @@ class CalibrationChoreographyPlugin(Plugin):
         )
         if self.shows_action_buttons:
             self.__ui_button_validation.read_only = (
-                self.selected_gazer_class is not self.g_pool.active_gaze_mapping_plugin.__class__
+                self.selected_gazer_class
+                is not self.g_pool.active_gaze_mapping_plugin.__class__
             )
 
     def deinit_ui(self):
@@ -531,7 +532,10 @@ class CalibrationChoreographyPlugin(Plugin):
 
     def _perform_start(self):
         if self.__is_active:
-            logger.debug("[PROGRAMMING ERROR] Called _perform_start on an already active calibration choreography.")
+            logger.debug(
+                "[PROGRAMMING ERROR] Called _perform_start on an already active "
+                "calibration choreography."
+            )
             return
 
         current_mode = self.__current_mode
@@ -558,7 +562,10 @@ class CalibrationChoreographyPlugin(Plugin):
 
     def _perform_stop(self):
         if not self.__is_active:
-            logger.debug("[PROGRAMMING ERROR] Called _perform_stop on an already inactive calibration choreography.")
+            logger.debug(
+                "[PROGRAMMING ERROR] Called _perform_stop on an already inactive "
+                "calibration choreography."
+            )
             return
 
         current_mode = self.__current_mode

--- a/pupil_src/shared_modules/calibration_choreography/base_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/base_plugin.py
@@ -491,9 +491,7 @@ class CalibrationChoreographyPlugin(Plugin):
         try:
             note = ChoreographyNotification.from_dict(note_dict)
         except ValueError:
-            note_name = note_dict.get("topic", None) or note_dict.get("subject", None)
-            logger.debug(f"Disregarding notification: {note_name}")
-            return
+            return  # Unknown/unexpected notification, not handling it
 
         if note.action == ChoreographyAction.SHOULD_START:
             if self.is_active:

--- a/pupil_src/shared_modules/calibration_choreography/base_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/base_plugin.py
@@ -465,7 +465,10 @@ class CalibrationChoreographyPlugin(Plugin):
         self.__ui_button_validation = None
 
     def recent_events(self, events):
-        self.update_ui()
+        if self.g_pool.app == "capture":
+            # UI is only initialized in Capture. In other applications, i.e. Service,
+            # calling this function will crash with an AttributeError.
+            self.update_ui()
 
     def on_notify(self, note_dict):
         """Handles choreography notifications

--- a/pupil_src/shared_modules/calibration_choreography/hmd_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/hmd_plugin.py
@@ -75,9 +75,7 @@ class _BaseHMDChoreographyPlugin(CalibrationChoreographyPlugin):
         try:
             note = ChoreographyNotification.from_dict(note_dict)
         except ValueError:
-            note_name = note_dict.get("topic", None) or note_dict.get("subject", None)
-            logger.debug(f"Disregarding notification: {note_name}")
-            return
+            return  # Unknown/unexpected notification, not handling it
         else:
             if note.action == ChoreographyAction.SHOULD_START and not self.is_active:
                 self._prepare_perform_start_from_notification(note_dict)


### PR DESCRIPTION
Fixes HMD3DChoreographyPlugin crash in Service, as Service does not initialize any plugin UI. See dedicated change commit: https://github.com/pupil-labs/pupil/commit/e2d5170d046d9ec1e580380f1cc94f6ea899dc9b