### PR TITLE
Fix updating imported v1 calibs

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
+++ b/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
@@ -14,6 +14,7 @@ import typing as T
 import file_methods as fm
 from gaze_producer.model.calibration import Calibration
 from gaze_producer.model.calibration_storage import CalibrationStorage
+from pupil_recording import PupilRecording
 
 from .calibration_v1 import CalibrationV1
 
@@ -53,7 +54,7 @@ class CalibrationStorageUpdater(CalibrationStorage):
                         )
                         continue  # Success
                 except Exception as err:
-                    logger.debug(str(err))
+                    logger.warning(str(err))
 
             # Failed to update
             logger.warning(
@@ -63,6 +64,15 @@ class CalibrationStorageUpdater(CalibrationStorage):
     @classmethod
     def __update_and_save_calibration_v1_as_latest_version(cls, rec_dir, data):
         legacy_calibration = CalibrationV1.from_tuple(data)
+
+        recording_uuid = str(PupilRecording(rec_dir).meta_info.recording_uuid)
+        is_imported = legacy_calibration.recording_uuid != recording_uuid
+        if is_imported:
+            raise ValueError(
+                "Updating imported (read-only) calibrations is not supported. "
+                f"{legacy_calibration.name}"
+            )
+
         updated_calibration = legacy_calibration.updated()
         cls._save_calibration_to_file(
             rec_dir, updated_calibration, overwrite_if_exists=False

--- a/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
+++ b/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
@@ -48,7 +48,7 @@ class CalibrationStorageUpdater(CalibrationStorage):
             elif data is not None:
                 try:
                     if version == CalibrationV1.version == 1:
-                        cls.__update_and_save_calibration_v1_as_latest_verson(
+                        cls.__update_and_save_calibration_v1_as_latest_version(
                             rec_dir, data
                         )
                         continue  # Success
@@ -61,7 +61,7 @@ class CalibrationStorageUpdater(CalibrationStorage):
             )
 
     @classmethod
-    def __update_and_save_calibration_v1_as_latest_verson(cls, rec_dir, data):
+    def __update_and_save_calibration_v1_as_latest_version(cls, rec_dir, data):
         legacy_calibration = CalibrationV1.from_tuple(data)
         updated_calibration = legacy_calibration.updated()
         cls._save_calibration_to_file(


### PR DESCRIPTION
This PR fixes that imported v1 offline calibration from a different recording will be updated to v2.
No read-only calibrations (recorded or imported) should be updated.

Please note:
I consider this a _quick fix_.
I don't like duplicating the `recording_uuid == calib.recording_uuid` already a third time, but unfortunately there is no easy way of using one of the other methods here without rewriting a lot of other code.
I would have liked if the update mechanism was a member function of the `CalibrationStorage`, but I guess that was not possible since it's `__init__()` has so many side-effects and non-inverted dependencies.
Maybe you have additional thoughts on that.