### PR TITLE
Fix modifiable recorded calibrations

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/model/calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration.py
@@ -130,10 +130,7 @@ class Calibration(StorageItem):
     )
 
     def __assert_property_consistency(self):
-        if self.__is_offline_calibration:
-            pass
-        else:
-            if self.__calib_params is not None:
-                raise ValueError(
-                    f"Unexpected calib_params argument for pre-recorded calibration"
-                )
+        if not self.__is_offline_calibration and self.__calib_params is None:
+            raise ValueError(
+                f"Missing calib_params for pre-recorded calibration '{self.name}'"
+            )

--- a/pupil_src/shared_modules/gaze_producer/model/calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration.py
@@ -51,14 +51,6 @@ class Calibration(StorageItem):
         self.__is_offline_calibration = is_offline_calibration
         self.__calib_params = calib_params
 
-        # Assert all properties are consistent
-        try:
-            self.__assert_property_consistency()
-        except ValueError:
-            raise
-        except Exception as err:
-            raise ValueError(str(err))
-
     @property
     def is_offline_calibration(self) -> bool:
         return self.__is_offline_calibration
@@ -79,12 +71,6 @@ class Calibration(StorageItem):
             self.__is_offline_calibration = is_offline_calibration
         if calib_params is not ...:
             self.__calib_params = calib_params
-        try:
-            self.__assert_property_consistency()
-        except ValueError:
-            raise
-        except Exception as err:
-            raise ValueError(str(err))
 
     @staticmethod
     def from_dict(dict_: dict) -> "Calibration":
@@ -98,7 +84,6 @@ class Calibration(StorageItem):
 
     @property
     def as_dict(self) -> dict:
-        self.__assert_property_consistency()  # sanity check
         dict_ = {k: v(self) for (k, v) in self.__schema}
         return dict_
 
@@ -128,9 +113,3 @@ class Calibration(StorageItem):
         ("is_offline_calibration", lambda self: self.__is_offline_calibration),
         ("calib_params", lambda self: self.__calib_params),
     )
-
-    def __assert_property_consistency(self):
-        if not self.__is_offline_calibration and self.__calib_params is None:
-            raise ValueError(
-                f"Missing calib_params for pre-recorded calibration '{self.name}'"
-            )

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -76,7 +76,7 @@ class CalibrationStorage(Storage, Observable):
             gazer_class_name=result_notification.gazer_class_name,
             frame_index_range=self._get_recording_index_range(),
             minimum_confidence=0.8,
-            is_offline_calibration=True,
+            is_offline_calibration=False,
             status="Not calculated yet",
             calib_params=result_notification.params,
         )


### PR DESCRIPTION
This PR fixes that recorded calibration are displayed as modifiable.

I would also argue for removing `__assert_property_consistency()` completely.
To me, it's not clear when this should be called and when not.
It's called twice in a very general (?) try-except:
```python
try:
    self.__assert_property_consistency()
except ValueError:
    raise
except Exception as err:
    raise ValueError(str(err))
```
and once without any try-except, just raising (and probably crashing):
```python
@property
def as_dict(self) -> dict:
    self.__assert_property_consistency()  # sanity check
    dict_ = {k: v(self) for (k, v) in self.__schema}
    return dict_
```