### PR TITLE
Prevent duplication of recorded calibration

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -147,10 +147,15 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _on_click_duplicate_button(self):
-        if self._calibration_controller.is_from_same_recording(self.current_item):
-            super()._on_click_duplicate_button()
-        else:
+        if not self._calibration_controller.is_from_same_recording(self.current_item):
             logger.error("Cannot duplicate calibrations from other recordings!")
+            return
+
+        if not self.current_item.is_offline_calibration:
+            logger.error("Cannot duplicate pre-recorded calibrations!")
+            return
+
+        super()._on_click_duplicate_button()
 
     def _on_name_change(self, new_name):
         self._calibration_storage.rename(self.current_item, new_name)


### PR DESCRIPTION
This PR fixes that recorded calibrations can be duplicated.
The changes will only make sense once #1932 has been merged. 

Since they are not modifiable, duplicating them does not make sense as the copy would also be non-modifiable.
