### PR TITLE
Remove storage dependency on plugin instances

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -55,20 +55,24 @@ class GazeFromOfflineCalibration(GazeProducerBase):
 
     def _setup_storages(self):
         self._reference_location_storage = model.ReferenceLocationStorage(
-            self.g_pool.rec_dir, plugin=self
+            self.g_pool.rec_dir
         )
         self._calibration_storage = model.CalibrationStorage(
             rec_dir=self.g_pool.rec_dir,
-            plugin=self,
             get_recording_index_range=self._recording_index_range,
             recording_uuid=self._recording_uuid,
         )
         self._gaze_mapper_storage = model.GazeMapperStorage(
             self._calibration_storage,
             rec_dir=self.g_pool.rec_dir,
-            plugin=self,
             get_recording_index_range=self._recording_index_range,
         )
+
+    def cleanup(self):
+        super().cleanup()
+        self._reference_location_storage.save_to_disk()
+        self._calibration_storage.save_to_disk()
+        self._gaze_mapper_storage.save_to_disk()
 
     def _setup_controllers(self):
         self._reference_detection_controller = controller.ReferenceDetectionController(

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -33,8 +33,7 @@ logger = logging.getLogger(__name__)
 class CalibrationStorage(Storage, Observable):
     _calibration_suffix = "plcal"
 
-    def __init__(self, rec_dir, plugin, get_recording_index_range, recording_uuid):
-        super().__init__(plugin)
+    def __init__(self, rec_dir, get_recording_index_range, recording_uuid):
         self._rec_dir = rec_dir
         self._get_recording_index_range = get_recording_index_range
         self._recording_uuid = str(recording_uuid)

--- a/pupil_src/shared_modules/gaze_producer/model/gaze_mapper_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/gaze_mapper_storage.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class GazeMapperStorage(SingleFileStorage, Observable):
-    def __init__(self, calibration_storage, rec_dir, plugin, get_recording_index_range):
-        super().__init__(rec_dir, plugin)
+    def __init__(self, calibration_storage, rec_dir, get_recording_index_range):
+        super().__init__(rec_dir)
         self._calibration_storage = calibration_storage
         self._get_recording_index_range = get_recording_index_range
         self._gaze_mappers = []

--- a/pupil_src/shared_modules/gaze_producer/model/reference_location_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/reference_location_storage.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class ReferenceLocationStorage(SingleFileStorage, Observable):
-    def __init__(self, rec_dir, plugin):
-        super().__init__(rec_dir, plugin)
+    def __init__(self, rec_dir):
+        super().__init__(rec_dir)
         self._reference_locations = {}
         self._load_from_disk()
 

--- a/pupil_src/shared_modules/storage.py
+++ b/pupil_src/shared_modules/storage.py
@@ -60,9 +60,6 @@ class StorageItem(abc.ABC):
 
 
 class Storage(abc.ABC):
-    def __init__(self, plugin):
-        plugin.add_observer("cleanup", self._on_cleanup)
-
     def __iter__(self):
         return iter(self.items)
 
@@ -111,9 +108,6 @@ class Storage(abc.ABC):
             return None
         return dict_representation.get("data", None)
 
-    def _on_cleanup(self):
-        self.save_to_disk()
-
     @staticmethod
     def get_valid_filename(file_name):
         """
@@ -138,8 +132,7 @@ class SingleFileStorage(Storage, abc.ABC):
     Storage that can save and load all items from / to a single file
     """
 
-    def __init__(self, rec_dir, plugin):
-        super().__init__(plugin)
+    def __init__(self, rec_dir):
         self._rec_dir = rec_dir
 
     def save_to_disk(self):

--- a/pupil_src/shared_modules/video_overlay/controllers/overlay_manager.py
+++ b/pupil_src/shared_modules/video_overlay/controllers/overlay_manager.py
@@ -16,11 +16,10 @@ from video_overlay.workers.overlay_renderer import OverlayRenderer
 
 
 class OverlayManager(SingleFileStorage):
-    def __init__(self, rec_dir, plugin):
-        super().__init__(rec_dir, plugin)
+    def __init__(self, rec_dir):
+        super().__init__(rec_dir)
         self._overlays = []
         self._load_from_disk()
-        self._patch_on_cleanup(plugin)
 
     @property
     def _storage_file_name(self):
@@ -54,12 +53,3 @@ class OverlayManager(SingleFileStorage):
     def remove_overlay(self, overlay):
         self._overlays.remove(overlay)
         self.save_to_disk()
-
-    def _patch_on_cleanup(self, plugin):
-        """Patches cleanup observer to trigger on get_init_dict().
-
-        Save current settings to disk on get_init_dict() instead of cleanup().
-        This ensures that the World Video Exporter loads the most recent settings.
-        """
-        plugin.remove_observer("cleanup", self._on_cleanup)
-        plugin.add_observer("get_init_dict", self._on_cleanup)

--- a/pupil_src/shared_modules/video_overlay/plugins/generic_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/generic_overlay.py
@@ -27,7 +27,13 @@ class Video_Overlay(Observable, Plugin):
 
     def __init__(self, g_pool):
         super().__init__(g_pool)
-        self.manager = OverlayManager(g_pool.rec_dir, self)
+        self.manager = OverlayManager(g_pool.rec_dir)
+
+    def get_init_dict(self):
+        # Save current settings to disk, ensures that the World Video Exporter
+        # loads the most recent settings.
+        self.manager.save_to_disk()
+        return super().get_init_dict()
 
     def recent_events(self, events):
         if "frame" in events:


### PR DESCRIPTION
This is a pure refactoring PR, removing the dependency of `Storage` instances on a `Plugin` instance. No existing behavior should change.

**Architectural Reasoning**
There's no reason why a `Storage` should know about the `Plugin` ecosystem or anything else Pupil-related. The only reason for the `Plugin` instances being passed through was to hook into `Plugin.cleanup()` for storing the items in the `Storage` to disk. However, this was not even desired in all cases, as we had a very hacky workaround for changing this logic in `OverlayManager`.

I simply added manual calls to `save_to_disk()` in the appropriate places, imo making it much more obvious what's happening. Of course now you shouldn't forget to make those calls, but then again you have to freedom not to make them if it is not appropriate for your use case.

**Other Benefits**
Besides these architectural reasons, removing this dependency will also allow us to update storage versions much easier. Since we don't yet have plugins in the `update_recording()` workflow, we could not simply create a `Storage` instance and let it manage its updates itself, but needed to hackily use class-methods and copied code in order to avoid a `Storage` construction. With this refactoring, it should be possible to easily make the required upgrade for `CalibrationStorage` items from version 2 to 3 for the upcoming v2.1 release by instantiating a `CalibrationStorage` and letting it update its items.