### PR TITLE
Remove duplicated state logic in PluginTaskManager

### DIFF
--- a/pupil_src/shared_modules/tasklib/manager.py
+++ b/pupil_src/shared_modules/tasklib/manager.py
@@ -100,9 +100,9 @@ class PluginTaskManager:
         for task in self._tasks.copy():
             if not task.started:
                 task.start()
-            elif task.running:
+            if task.running:
                 task.update()
-            elif task.ended:
+            if task.ended:
                 self._tasks.remove(task)
 
     def on_cleanup(self):


### PR DESCRIPTION
This is a pure refactoring PR, no behavior should change.

The `PluginTaskManager` previously remembered the state of its tasks by splitting them into two lists (added vs running), although the tasks also know their state (and even own it). This can cause problems (there are even comments for when these assumptions were wrong in the past). Refactoring the `PluginTaskManager`  in this way to cleanup the behavior will make a planned bugfix for background tasks much easier.

@papr @romanroibu Please make sure to test every dependant of the `PluginTaskManager` that they still work the same way as before:
- `GazeFromOfflineCalibration`
- `Offline_Head_Pose_Tracker`
- `Online_Head_Pose_Tracker`