### PR TITLE
Introduce UniqueTaskManager to avoid duplicated post-hoc calibration background processes

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
@@ -51,7 +51,7 @@ class CalibrationController(Observable):
         )
         task.add_observer("on_completed", on_calibration_completed)
         task.add_observer("on_exception", tasklib.raise_exception)
-        self._task_manager.add_task(task)
+        self._task_manager.add_task(task, identifier=calibration.unique_id)
         return task
 
     def on_calibration_computed(self, calibration):

--- a/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calibration_controller.py
@@ -51,7 +51,9 @@ class CalibrationController(Observable):
         )
         task.add_observer("on_completed", on_calibration_completed)
         task.add_observer("on_exception", tasklib.raise_exception)
-        self._task_manager.add_task(task, identifier=calibration.unique_id)
+        self._task_manager.add_task(
+            task, identifier=f"{calibration.unique_id}-calibration"
+        )
         return task
 
     def on_calibration_computed(self, calibration):

--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -69,7 +69,7 @@ class GazeMapperController(Observable):
         except worker.map_gaze.NotEnoughPupilData:
             self._abort_calculation(gaze_mapper, "There is no pupil data to be mapped!")
             return None
-        self._task_manager.add_task(task)
+        self._task_manager.add_task(task, identifier=gaze_mapper.unique_id)
         logger.info("Start gaze mapping for '{}'".format(gaze_mapper.name))
 
     def _abort_calculation(self, gaze_mapper, error_message):

--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -69,7 +69,7 @@ class GazeMapperController(Observable):
         except worker.map_gaze.NotEnoughPupilData:
             self._abort_calculation(gaze_mapper, "There is no pupil data to be mapped!")
             return None
-        self._task_manager.add_task(task, identifier=gaze_mapper.unique_id)
+        self._task_manager.add_task(task, identifier=f"{gaze_mapper.unique_id}-mapping")
         logger.info("Start gaze mapping for '{}'".format(gaze_mapper.name))
 
     def _abort_calculation(self, gaze_mapper, error_message):
@@ -179,7 +179,9 @@ class GazeMapperController(Observable):
         )
         task.add_observer("on_completed", validation_completed)
         task.add_observer("on_exception", tasklib.raise_exception)
-        self._task_manager.add_task(task)
+        self._task_manager.add_task(
+            task, identifier=f"{gaze_mapper.unique_id}-validating"
+        )
 
     def get_valid_calibration_or_none(self, gaze_mapper):
         return self._calibration_storage.get_or_none(gaze_mapper.calibration_unique_id)

--- a/pupil_src/shared_modules/gaze_producer/controller/reference_location_controllers.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/reference_location_controllers.py
@@ -41,7 +41,9 @@ class ReferenceDetectionController(Observable):
         )
         self._detection_task.add_observer("on_yield", on_detection_yields)
         self._detection_task.add_observer("on_completed", on_detection_completed)
-        self._task_manager.add_task(self._detection_task)
+        self._task_manager.add_task(
+            self._detection_task, identifier="reference_detection"
+        )
         return self._detection_task
 
     def on_detection_started(self, detection_task):

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -12,7 +12,6 @@ import data_changed
 from gaze_producer import controller, model
 from gaze_producer import ui as plugin_ui
 from gaze_producer.gaze_producer_base import GazeProducerBase
-from observable import Observable
 from plugin_timeline import PluginTimeline
 from pupil_recording import PupilRecording
 from tasklib.manager import UniqueTaskManager

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -15,7 +15,7 @@ from gaze_producer.gaze_producer_base import GazeProducerBase
 from observable import Observable
 from plugin_timeline import PluginTimeline
 from pupil_recording import PupilRecording
-from tasklib.manager import PluginTaskManager
+from tasklib.manager import UniqueTaskManager
 
 
 # IMPORTANT: GazeProducerBase needs to be THE LAST in the list of bases, otherwise
@@ -37,7 +37,7 @@ class GazeFromOfflineCalibration(GazeProducerBase):
 
         self.inject_plugin_dependencies()
 
-        self._task_manager = PluginTaskManager(plugin=self)
+        self._task_manager = UniqueTaskManager(plugin=self)
 
         self._recording_uuid = PupilRecording(g_pool.rec_dir).meta_info.recording_uuid
 

--- a/pupil_src/shared_modules/tasklib/manager.py
+++ b/pupil_src/shared_modules/tasklib/manager.py
@@ -125,10 +125,8 @@ class UniqueTaskManager(PluginTaskManager):
         UniqueTaskManager._patch_task(task_new, identifier)
         task_duplicated = self._get_duplicated_task(identifier)
         if task_duplicated is not None:
-            logger.debug(
-                f"{self} replacing queued task '{task_duplicated.process.name}' "
-                f"({identifier})"
-            )
+            state = "running" if task_duplicated.running else "queued"
+            logger.debug(f"Replacing {state} task with ID '{identifier}'")
             if task_duplicated.running:
                 task_duplicated.kill(grace_period=None)
             self._tasks.remove(task_duplicated)

--- a/pupil_src/shared_modules/tasklib/manager.py
+++ b/pupil_src/shared_modules/tasklib/manager.py
@@ -10,6 +10,9 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import tasklib.background
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PluginTaskManager:
@@ -122,6 +125,10 @@ class UniqueTaskManager(PluginTaskManager):
         UniqueTaskManager._patch_task(task_new, identifier)
         task_duplicated = self._get_duplicated_task(identifier)
         if task_duplicated is not None:
+            logger.debug(
+                f"{self} replacing queued task '{task_duplicated.process.name}' "
+                f"({identifier})"
+            )
             if task_duplicated.running:
                 task_duplicated.kill(grace_period=None)
             self._tasks.remove(task_duplicated)


### PR DESCRIPTION
Previously, a user could start multiple background tasks by accident by clicking the `Recalculate` button in the post-hoc calibration UI multiple times. This PR introduces a simple `PluginTaskManager` (previously used) subclass that replaces existing tasks that use a common identifier as the new task. By using the calibration/gaze mapper unique ids as identifiers, there can only be one active task for each calibration/gaze mapper.