### PR TITLE
Clarify CalculateAllController reference logic

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
@@ -33,21 +33,11 @@ class CalculateAllController:
         current settings. If there are no reference locations in the storage,
         first the current reference detector is run.
         """
-        if self.does_detect_references:
+        if self._reference_location_storage.is_empty:
             task = self._reference_detection_controller.start_detection()
             task.add_observer("on_completed", self._on_reference_detection_completed)
         else:
             self._calculate_all_calibrations()
-
-    @property
-    def does_detect_references(self):
-        """
-        True if the controller would first detect reference locations in calculate_all()
-        """
-        at_least_one_reference_location = any(
-            True for _ in self._reference_location_storage
-        )
-        return not at_least_one_reference_location
 
     def _on_reference_detection_completed(self, _):
         self._calculate_all_calibrations()

--- a/pupil_src/shared_modules/gaze_producer/ui/on_top_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/on_top_menu.py
@@ -19,6 +19,7 @@ class OnTopMenu:
         self._calculate_all_button = None
 
         self._calculate_all_controller = calculate_all_controller
+        self._reference_location_storage = reference_location_storage
 
         reference_location_storage.add_observer(
             "add", self._on_reference_storage_changed
@@ -56,7 +57,7 @@ class OnTopMenu:
 
     @property
     def _calculate_all_button_label(self):
-        if self._calculate_all_controller.does_detect_references:
+        if self._reference_location_storage.is_empty:
             return "Detect References, Calculate All Calibrations and Mappings"
         else:
             return "Calculate All Calibrations and Mappings"

--- a/pupil_src/shared_modules/storage.py
+++ b/pupil_src/shared_modules/storage.py
@@ -63,6 +63,14 @@ class Storage(abc.ABC):
     def __iter__(self):
         return iter(self.items)
 
+    @property
+    def is_empty(self):
+        try:
+            next(iter(self))
+            return False
+        except StopIteration:
+            return True
+
     @abc.abstractmethod
     def add(self, item):
         pass


### PR DESCRIPTION
Refactoring PR for clarifying the logic in the `CalculateAllController` for when the reference detection is run and when not.
This PR will be useful for fixing a bug in the control flow for `calculate_all()`.

I think the idea was to abstract away the logic into a single property of the `CalculateAllController`, which the controller and the UI will then query. But the UI actually hooks already into the reference location storage for updating the button text, so we know that this button text is dependent of the storage. Therefore, just querying the storage for both decisions in controller and UI seems to be a clearer solution.

Since we never specify whether a storage needs to have a fixed size, I used the `Iterable` interface to compute whether the storage is empty.