### PR TITLE
Prevent crash when rendering eyeball outline with negative values

### DIFF
--- a/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
+++ b/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
@@ -100,7 +100,6 @@ class PupilRenderer(ImageManipulator):
                     f"eye_ball: {eye_ball}\n"
                     f"{type(e)}: {e}"
                 )
-                pass
 
     def render_ellipse(self, image, ellipse, color):
         outline = self.get_ellipse_points(

--- a/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
+++ b/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
@@ -10,9 +10,12 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import abc
+import logging
 
 import cv2
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class ImageManipulator(metaclass=abc.ABCMeta):
@@ -86,9 +89,17 @@ class PupilRenderer(ImageManipulator):
                     color=(26, 230, 0, 255 * pupil_position["model_confidence"]),
                     thickness=2,
                 )
-            except ValueError:
-                # Happens when converting 'nan' to int
-                # TODO: Investigate why results are sometimes 'nan'
+            except Exception as e:
+                # Known issues:
+                #   - Sometimes raises ValueError when some components of the eye_ball
+                #     are 'nan'. TODO: Investigate where the 'nan' comes from.
+                #   - There are reports of negative eye_ball axes, raising cv2.error.
+                #     TODO: Investigate cause in detectors.
+                logger.debug(
+                    "Error rendering 3D eye-ball outline! Skipping...\n"
+                    f"eye_ball: {eye_ball}\n"
+                    f"{type(e)}: {e}"
+                )
                 pass
 
     def render_ellipse(self, image, ellipse, color):


### PR DESCRIPTION
Fixes #1912 

I added better logging for potential errors here.
Example output for the recording from #1912:

```
player - [DEBUG] video_overlay.utils.image_manipulation: Error rendering 3D eye-ball outline! Skipping...
eye_ball: {'center': (246.79170715146995, 209.36043689754123), 'axes': (-639.8371093372608, -639.8371093372608), 'angle': 90.0}
<class 'cv2.error'>: OpenCV(4.2.0) /io/opencv/modules/imgproc/src/drawing.cpp:1927: error: (-215:Assertion failed) axes.width >= 0 && axes.height >= 0 && thickness <= MAX_THICKNESS && 0 <= shift && shift <= XY_SHIFT in function 'ellipse'
```