### PR TITLE
Ignore macOS-specific meta files when using glob

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
+++ b/pupil_src/shared_modules/gaze_producer/model/legacy/calibration_storage_updater.py
@@ -33,7 +33,7 @@ class CalibrationStorageUpdater(CalibrationStorage):
         if not calib_dir.is_dir():
             return  # TODO: Raise exception - "calibrations" must be a directory
 
-        for calib_path in sorted(calib_dir.glob("*.plcal")):
+        for calib_path in sorted(calib_dir.glob("[!.]*.plcal")):
             calib_dict = fm.load_object(calib_path)
             version = calib_dict.get("version", None)
             data = calib_dict.get("data", None)

--- a/pupil_src/shared_modules/vis_watermark.py
+++ b/pupil_src/shared_modules/vis_watermark.py
@@ -35,7 +35,7 @@ class Vis_Watermark(Visualizer_Plugin_Base):
         self.menu = None
 
         available_files = glob(
-            os.path.join(self.g_pool.user_dir, "*png")
+            os.path.join(self.g_pool.user_dir, "[!.]*png")
         )  # we only look for png's
         self.available_files = [
             f for f in available_files if cv2.imread(f, -1).shape[2] == 4


### PR DESCRIPTION
On some occasions, macOS stores file attributes in meta files that use `._` as prefix. These are matched in cases were we use glob with a pattern starting with `*`.

This PR excludes files starting with `.` to avoid matching the meta files and causing issues down the line.

All other use cases of glob in the project either exclude `.`-prefixed files already or use a concrete prefix which avoids matching meta files.