### PR TITLE
Ensure frame publisher restarts when restarting NetworkAPIPlugin

### DIFF
--- a/pupil_src/shared_modules/network_api/controller/frame_publisher_controller.py
+++ b/pupil_src/shared_modules/network_api/controller/frame_publisher_controller.py
@@ -20,9 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 class FramePublisherController(Observable):
-    def on_frame_publisher_did_start(self, format: FrameFormat):
-        logger.debug(f"on_frame_publisher_did_start({format})")
-
+    def on_format_changed(self):
+        logger.debug(f"on_format_changed({self.__frame_format})")
 
     def __init__(self, format="jpeg", **kwargs):
         self.__frame_format = FrameFormat(format)
@@ -38,7 +37,7 @@ class FramePublisherController(Observable):
     @frame_format.setter
     def frame_format(self, value):
         self.__frame_format = FrameFormat(value)
-        self.on_frame_publisher_did_start(format=self.__frame_format)
+        self.on_format_changed()
 
     def create_world_frame_dicts_from_frame(self, frame) -> T.List[dict]:
         if not frame:

--- a/pupil_src/shared_modules/network_api/controller/frame_publisher_controller.py
+++ b/pupil_src/shared_modules/network_api/controller/frame_publisher_controller.py
@@ -23,8 +23,6 @@ class FramePublisherController(Observable):
     def on_frame_publisher_did_start(self, format: FrameFormat):
         logger.debug(f"on_frame_publisher_did_start({format})")
 
-    def on_frame_publisher_did_stop(self):
-        logger.debug(f"on_frame_publisher_did_stop")
 
     def __init__(self, format="jpeg", **kwargs):
         self.__frame_format = FrameFormat(format)
@@ -32,9 +30,6 @@ class FramePublisherController(Observable):
 
     def get_init_dict(self):
         return {"format": self.__frame_format.value}
-
-    def cleanup(self):
-        self.on_frame_publisher_did_stop()
 
     @property
     def frame_format(self):

--- a/pupil_src/shared_modules/network_api/network_api_plugin.py
+++ b/pupil_src/shared_modules/network_api/network_api_plugin.py
@@ -42,6 +42,9 @@ class NetworkApiPlugin(Plugin):
             "on_format_changed", self.frame_publisher_announce_current_format
         )
 
+        # Let existing eye-processes know about current frame publishing format
+        self.frame_publisher_announce_current_format()
+
         # Pupil Remote setup
         self.__pupil_remote = PupilRemoteController(g_pool, **kwargs)
         self.__pupil_remote.add_observer(

--- a/pupil_src/shared_modules/network_api/network_api_plugin.py
+++ b/pupil_src/shared_modules/network_api/network_api_plugin.py
@@ -11,9 +11,7 @@ See COPYING and COPYING.LESSER for license details.
 import logging
 
 from plugin import Plugin
-from pyglui import ui
 
-from .model import FrameFormat
 from .controller import FramePublisherController
 from .controller import PupilRemoteController
 from .ui import FramePublisherMenu

--- a/pupil_src/shared_modules/network_api/network_api_plugin.py
+++ b/pupil_src/shared_modules/network_api/network_api_plugin.py
@@ -41,9 +41,6 @@ class NetworkApiPlugin(Plugin):
         self.__frame_publisher.add_observer(
             "on_frame_publisher_did_start", self.on_frame_publisher_did_start
         )
-        self.__frame_publisher.add_observer(
-            "on_frame_publisher_did_stop", self.on_frame_publisher_did_stop
-        )
 
         # Pupil Remote setup
         self.__pupil_remote = PupilRemoteController(g_pool, **kwargs)
@@ -65,7 +62,7 @@ class NetworkApiPlugin(Plugin):
         }
 
     def cleanup(self):
-        self.__frame_publisher.cleanup()
+        self.frame_publisher_announce_stop()
         self.__frame_publisher = None
         self.__pupil_remote.cleanup()
         self.__pupil_remote = None
@@ -114,7 +111,7 @@ class NetworkApiPlugin(Plugin):
     def on_frame_publisher_did_start(self, format: FrameFormat):
         self.notify_all({"subject": "frame_publishing.started", "format": format.value})
 
-    def on_frame_publisher_did_stop(self):
+    def frame_publisher_announce_stop(self):
         self.notify_all({"subject": "frame_publishing.stopped"})
 
     def on_pupil_remote_server_did_start(self, address: str):


### PR DESCRIPTION
A restart of the `NetworkAPIPlugin` would cause the frame publishing to stop.

The bug occurred in HMD-Eyes, where the eye preview was not updating when connecting.
This was caused by HMD-Eyes sending a start-plugin notification to ensure that `NetworkAPIPlugin` is running.
Since we allow replacing plugins _by class_ this would result in a restart.

I removed the start/stop logic from the `FramePublisherController`, since it is actually always started.
The `NetworkAPIPlugin` now sends a start notification in `__init__()` which fixes the behavior.