### PR TITLE
Detect reference locations only on button press

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
@@ -29,14 +29,21 @@ class CalculateAllController:
 
     def calculate_all(self):
         """
-        (Re)Calculate all calibrations and gaze mappings with their respective
-        current settings. If there are no reference locations in the storage,
-        first the current reference detector is run.
+        Detect reference locations if none available. Then (re)calculate all
+        calibrations and gaze mappers.
         """
         if self._reference_location_storage.is_empty:
             task = self._reference_detection_controller.start_detection()
             task.add_observer("on_completed", self._on_reference_detection_completed)
         else:
+            self._calculate_all_calibrations()
+
+    def calculate_all_if_references_available(self):
+        """
+        (Re)calculate all calibrations and gaze mappers if reference locations are
+        available.
+        """
+        if not self._reference_location_storage.is_empty:
             self._calculate_all_calibrations()
 
     def _on_reference_detection_completed(self, _):

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -49,7 +49,8 @@ class GazeFromOfflineCalibration(GazeProducerBase):
             "pupil_positions", g_pool.rec_dir, plugin=self
         )
         self._pupil_changed_listener.add_observer(
-            "on_data_changed", self._calculate_all_controller.calculate_all
+            "on_data_changed",
+            self._calculate_all_controller.calculate_all_if_references_available,
         )
 
     def _setup_storages(self):


### PR DESCRIPTION
`calculate_all()` is called on button press and also when pupil data changes.
We don't want to run reference location detection in any automatic workflow since it can take quite a while and consumes a lot of resources.