### PR TITLE
Ensure calculate_all creates defaults

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
@@ -43,6 +43,9 @@ class CalculateAllController:
         self._calculate_all_calibrations()
 
     def _calculate_all_calibrations(self):
+        if self._calibration_storage.is_empty:
+            self._calibration_storage.add_default_calibration()
+
         for calibration in self._calibration_storage:
             calculation_possible = (
                 self._calibration_controller.is_from_same_recording(calibration)

--- a/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/calculate_all_controller.py
@@ -46,6 +46,9 @@ class CalculateAllController:
         if self._calibration_storage.is_empty:
             self._calibration_storage.add_default_calibration()
 
+        if self._gaze_mapper_storage.is_empty:
+            self._gaze_mapper_storage.add_default_gaze_mapper()
+
         for calibration in self._calibration_storage:
             calculation_possible = (
                 self._calibration_controller.is_from_same_recording(calibration)

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -40,9 +40,9 @@ class CalibrationStorage(Storage, Observable):
         self._calibrations = []
         self._load_from_disk()
         if not self._calibrations:
-            self._add_default_calibration()
+            self.add_default_calibration()
 
-    def _add_default_calibration(self):
+    def add_default_calibration(self):
         self.add(self.create_default_calibration())
 
     def create_default_calibration(self):

--- a/pupil_src/shared_modules/gaze_producer/model/gaze_mapper_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/gaze_mapper_storage.py
@@ -30,9 +30,9 @@ class GazeMapperStorage(SingleFileStorage, Observable):
         self._gaze_mappers = []
         self._load_from_disk()
         if not self._gaze_mappers:
-            self._add_default_gaze_mapper()
+            self.add_default_gaze_mapper()
 
-    def _add_default_gaze_mapper(self):
+    def add_default_gaze_mapper(self):
         self.add(self.create_default_gaze_mapper())
 
     def create_default_gaze_mapper(self):


### PR DESCRIPTION
When pressing `Calculate all` when no calibration or no gaze mapper exists, nothing will happen.
We want a default calibration and gaze mapper to appear.