### PR TITLE
Fix double item deletion crash

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -169,6 +169,9 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         super()._on_click_duplicate_button()
 
     def _on_click_delete(self):
+        if self.current_item is None:
+            return
+
         if not self._calibration_controller.is_from_same_recording(self.current_item):
             logger.error("Cannot delete calibrations from other recordings!")
             return

--- a/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
@@ -96,6 +96,8 @@ class StorageEditMenu(plugin_ui.SelectAndRefreshMenu, abc.ABC):
         self.render()
 
     def _on_click_delete(self):
+        if self.current_item is None:
+            return
         current_index = self.items.index(self.current_item)
         self._storage.delete(self.current_item)
         current_index = min(current_index, len(self.items) - 1)


### PR DESCRIPTION
Fixes part of the issue described in #1918:

When hitting the **Delete** button multiple times when the UI is blocked, Player would crash on resume.
On current develop it will not crash anymore, but display `Error: Cannot delete calibrations from other recordings!`, which is also wrong.

This happens on Windows (maybe on macOS, too?), but not on Linux.
The reason is that spawning processes on Windows takes so long that the UI freezes for a second, which is enough time to double-click the delete button.

I caught the case in the base UI for completeness but needed to handle it also in the calibration UI because this is where the wrong error message would be thrown.