### PR TITLE
Coord_System: Avoid zero-width dimensions

### DIFF
--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -188,6 +188,12 @@ class Coord_System(object):
 
     def __init__(self, left, right, bottom, top):
         super(Coord_System, self).__init__()
+        if left == right:
+            left -= 1
+            right += 1
+        if top == bottom:
+            top -= 1
+            bottom += 1
         self.bounds = left, right, bottom, top
 
     def __enter__(self):


### PR DESCRIPTION
`glOrtho` does not allow zero-width dimensions. Users of Coord_System should not have to care about this implementation detail. Therefore, Coord_system replaces the zero-width dimensions appropriately to avoid an error down the line.

This fixes an issue with pupil producer timelines who do not span a sufficiently large coordinate system due to an insufficient amount of data.