### PR TITLE
Prevent Capture from crashing during calibration when there is no reference data 

### DIFF
--- a/pupil_src/shared_modules/gaze_mapping/gazer_base.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_base.py
@@ -210,9 +210,10 @@ class GazerBase(abc.ABC, Plugin):
                 self._announce_calibration_failure(reason=err.message)
             except Exception as err:
                 import traceback
+
                 logger.debug(traceback.format_exc())
                 if raise_calibration_error:
-                    raise CalibrationError() from err # Let offline calibration handle this one!
+                    raise CalibrationError() from err  # Let offline calibration handle this one!
                 logger.error("Calibration Failed!")
                 self.alive = False
                 try:

--- a/pupil_src/shared_modules/gaze_mapping/gazer_base.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_base.py
@@ -44,6 +44,14 @@ class NotEnoughDataError(CalibrationError):
     message = "Not sufficient data available."
 
 
+class NotEnoughPupilDataError(NotEnoughDataError):
+    message = "Not sufficient pupil data available."
+
+
+class NotEnoughReferenceDataError(NotEnoughDataError):
+    message = "Not sufficient reference data available."
+
+
 class FitDidNotConvergeError(CalibrationError):
     message = "Model fit did not converge."
 
@@ -263,7 +271,9 @@ class GazerBase(abc.ABC, Plugin):
             pupil_data, self.g_pool.min_calibration_confidence
         )
         if not pupil_data:
-            raise NotEnoughDataError
+            raise NotEnoughPupilDataError
+        if not ref_data:
+            raise NotEnoughReferenceDataError
         # match pupil to reference data (left, right, and binocular)
         matches = self.match_pupil_to_ref(pupil_data, ref_data)
         if matches.binocular[0]:

--- a/pupil_src/shared_modules/gaze_mapping/gazer_base.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_base.py
@@ -202,10 +202,16 @@ class GazerBase(abc.ABC, Plugin):
                 self._announce_calibration_failure(reason=CalibrationError.__name__)
             except Exception as err:
                 import traceback
-
-                self._announce_calibration_failure(reason=err.__class__.__name__)
                 logger.debug(traceback.format_exc())
-                raise CalibrationError() from err
+                if raise_calibration_error:
+                    raise CalibrationError() from err # Let offline calibration handle this one!
+                logger.error("Calibration Failed!")
+                self.alive = False
+                try:
+                    reason = err.args[0]
+                except (AttributeError, IndexError):
+                    reason = err.__class__.__name__
+                self._announce_calibration_failure(reason=reason)
             else:
                 self._announce_calibration_success()
                 self._announce_calibration_result(params=self.get_params())

--- a/pupil_src/shared_modules/gaze_mapping/gazer_base.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_base.py
@@ -202,12 +202,12 @@ class GazerBase(abc.ABC, Plugin):
             self._announce_calibration_setup(calib_data=calib_data)
             try:
                 self.fit_on_calib_data(calib_data)
-            except CalibrationError:
+            except CalibrationError as err:
                 if raise_calibration_error:
                     raise  # Let offline calibration handle this one!
                 logger.error("Calibration Failed!")
                 self.alive = False
-                self._announce_calibration_failure(reason=CalibrationError.__name__)
+                self._announce_calibration_failure(reason=err.message)
             except Exception as err:
                 import traceback
                 logger.debug(traceback.format_exc())

--- a/pupil_src/shared_modules/gaze_mapping/utils.py
+++ b/pupil_src/shared_modules/gaze_mapping/utils.py
@@ -32,8 +32,8 @@ def _filter_pupil_list_by_confidence(pupil_list, threshold):
 
 
 def _match_data_batch(pupil_list, ref_list):
-    assert pupil_list
-    assert ref_list
+    assert pupil_list, "No pupil data to match"
+    assert ref_list, "No reference data to match"
     pupil0 = [p for p in pupil_list if p["id"] == 0]
     pupil1 = [p for p in pupil_list if p["id"] == 1]
 


### PR DESCRIPTION
Fixes #1924 