### PR TITLE
Patch pyre.zhelper.cdll

### DIFF
--- a/pupil_src/shared_modules/hololens_relay.py
+++ b/pupil_src/shared_modules/hololens_relay.py
@@ -18,7 +18,9 @@ from pyre import zhelper
 from pyglui import ui
 from plugin import Plugin
 import logging
+import os_utils
 
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 
 

--- a/pupil_src/shared_modules/network_api/controller/pupil_remote_controller.py
+++ b/pupil_src/shared_modules/network_api/controller/pupil_remote_controller.py
@@ -16,9 +16,10 @@ import zmq
 import zmq_tools
 from pyre import zhelper
 
+import os_utils
 from observable import Observable
 
-
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 
 

--- a/pupil_src/shared_modules/os_utils.py
+++ b/pupil_src/shared_modules/os_utils.py
@@ -58,6 +58,53 @@ else:
             return etype is KeyboardInterrupt
 
 
+def patch_pyre_zhelper_cdll():
+    """Fixes https://github.com/pupil-labs/pupil/issues/1919
+    
+    When running the v2.0 bundle on macOS 10.14, `ctypes.CDLL("libSystem.dylib")` fails
+    to load which is required by pyre.zhelper. `libSystem.dylib` is not part of the
+    bundle on purpose, as `ctypes.CDLL` is usually able to fallback to the system-
+    provided library at `/usr/lib/libSystem.dylib`.
+
+    The fallback mechanism is provided by the $DYLD_FALLBACK_LIBRARY_PATH variable.
+    PyInstaller makes use of it to inject the bundle path to prioritize bundled
+    libraries over system libraries:
+    https://github.com/pyinstaller/pyinstaller/blob/v3.6/PyInstaller/loader/pyiboot01_bootstrap.py#L203
+
+    Upon inspection, `/usr/lib` is correcly present in $DYLD_FALLBACK_LIBRARY_PATH when
+    running the macOS bundle on macOS 10.14. This indicates an underlying deeper issue.
+
+    Curiously, `ctypes.util.find_library("libSystem.dylib")` works as expected and
+    returns `/usr/lib/libSystem.dylib` when running the above setup. This patch makes
+    use of that fact by implementing an additional fallback that attempts to load the
+    initially missing library based on its absolute path.
+
+    As `pyre.zhelper` is the only place calling `ctypes.CDLL("libSystem.dylib")`, we
+    will only patch this specific CDLL instance.
+
+    This patch will only be applied if the problematic setup is detected.
+    """
+    running_from_bundle = getattr(sys, "frozen", False)
+    if os_name != "Darwin" or not running_from_bundle:
+        return
+
+    import ctypes.util
+    import pyre.zhelper
+
+    class AbsolutePathFallbackCDLL(ctypes.CDLL):
+        def __init__(self, name, *args, **kwargs):
+            try:
+                super().__init__(name, *args, **kwargs)
+            except Exception:
+                abs_library_path = ctypes.util.find_library(name)
+                if abs_library_path is not None:
+                    super().__init__(abs_library_path, *args, **kwargs)
+                else:
+                    raise
+
+    pyre.zhelper.CDLL = AbsolutePathFallbackCDLL
+
+
 if __name__ == "__main__":
     with Prevent_Idle_Sleep():
         pass

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -17,7 +17,9 @@ from zmq_tools import Msg_Dispatcher, Msg_Receiver
 import msgpack as serializer
 
 import logging
+import os_utils
 
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 
 

--- a/pupil_src/shared_modules/remote_recorder.py
+++ b/pupil_src/shared_modules/remote_recorder.py
@@ -14,8 +14,10 @@ import logging
 import ndsi
 from pyglui import ui
 
+import os_utils
 from plugin import Plugin
 
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 
 # Suppress pyre debug logs (except beacon)

--- a/pupil_src/shared_modules/time_sync.py
+++ b/pupil_src/shared_modules/time_sync.py
@@ -19,7 +19,9 @@ from network_time_sync import Clock_Sync_Master, Clock_Sync_Follower
 import random
 
 import logging
+import os_utils
 
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -16,6 +16,7 @@ import ndsi
 from packaging.version import Version
 from pyglui import ui
 
+import os_utils
 from camera_models import load_intrinsics
 
 from .base_backend import Base_Manager, Base_Source, SourceInfo
@@ -28,7 +29,7 @@ try:
 except (ImportError, AssertionError):
     raise Exception("pyndsi version is too old. Please upgrade!") from None
 
-
+os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)
 
 # Suppress pyre debug logs (except beacon)


### PR DESCRIPTION
Fixes https://github.com/pupil-labs/pupil/issues/1919

When running the v2.0 bundle on macOS 10.14, `ctypes.CDLL("libSystem.dylib")` fails
to load which is required by pyre.zhelper. `libSystem.dylib` is not part of the
bundle on purpose, as `ctypes.CDLL` is usually able to fallback to the system-
provided library at `/usr/lib/libSystem.dylib`.

The fallback mechanism is provided by the $DYLD_FALLBACK_LIBRARY_PATH variable.
PyInstaller makes use of it to inject the bundle path to prioritize bundled
libraries over system libraries:
https://github.com/pyinstaller/pyinstaller/blob/v3.6/PyInstaller/loader/pyiboot01_bootstrap.py#L203

Upon inspection, `/usr/lib` is correcly present in $DYLD_FALLBACK_LIBRARY_PATH when
running the macOS bundle on macOS 10.14. This indicates an underlying deeper issue.

Curiously, `ctypes.util.find_library("libSystem.dylib")` works as expected and
returns `/usr/lib/libSystem.dylib` when running the above setup. This patch makes
use of that fact by implementing an additional fallback that attempts to load the
initially missing library based on its absolute path.

As `pyre.zhelper` is the only place calling `ctypes.CDLL("libSystem.dylib")`, we
will only patch this specific CDLL instance.

This patch will only be applied if the problematic setup is detected.