### PR TITLE
Use ceres version 1.14 before port to C++14

### DIFF
--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -133,6 +133,7 @@ The build and install the Ceres solver:
 ```sh
 git clone https://ceres-solver.googlesource.com/ceres-solver
 cd ceres-solver
+git checkout 1.14.0
 mkdir build && cd build
 cmake .. -DBUILD_SHARED_LIBS=ON
 make -j3


### PR DESCRIPTION
The latest upstream version of ceres is not compatible with C++11 anymore and needs to be compiled with C++14.
We need ceres for building the pupil-detectors library, who's build-pipeline currently uses C++11 exclusively.
Therefore pupil-detectors won't compile with the headers from the latest ceres.
An easy temporary workaround is to build ceres from the last version that supported C++11: v1.14