### PR TITLE
Disable read only buttons in post-hoc calibration menu

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -132,7 +132,7 @@ def player(
         )
 
         assert VersionFormat(pyglui_version) >= VersionFormat(
-            "1.27"
+            "1.28"
         ), "pyglui out of date, please upgrade to newest version"
 
         process_was_interrupted = False

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -178,6 +178,12 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         if self.__check_delete_button_click_is_allowed(should_log_reason_as_error=True):
             super()._on_click_delete()
 
+    def _on_change_current_item(self, item):
+        super()._on_change_current_item(item)
+        if self._ui_button_duplicate:
+            self._ui_button_duplicate.read_only = not self.__check_duplicate_button_click_is_allowed(should_log_reason_as_error=False)
+        if self._ui_button_delete:
+            self._ui_button_delete.read_only = not self.__check_delete_button_click_is_allowed(should_log_reason_as_error=False)
 
     def _on_name_change(self, new_name):
         self._calibration_storage.rename(self.current_item, new_name)

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -36,6 +36,9 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
 
         self.menu.collapsed = True
 
+        self._ui_button_duplicate = None
+        self._ui_button_delete = None
+
         calibration_controller.add_observer(
             "on_calibration_computed", self._on_calibration_computed
         )
@@ -72,6 +75,16 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
                 self._create_calculate_button(calibration),
             ]
         )
+
+    def _create_duplicate_button(self):
+        # Save a reference to the created duplicate button
+        self._ui_button_duplicate = super()._create_duplicate_button()
+        return self._ui_button_duplicate
+
+    def _create_delete_button(self):
+        # Save a reference to the created delete button
+        self._ui_button_delete = super()._create_delete_button()
+        return self._ui_button_delete
 
     def _create_name_input(self, calibration):
         return ui.Text_Input(

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -158,29 +158,13 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _on_click_duplicate_button(self):
-        if not self._calibration_controller.is_from_same_recording(self.current_item):
-            logger.error("Cannot duplicate calibrations from other recordings!")
-            return
-
-        if not self.current_item.is_offline_calibration:
-            logger.error("Cannot duplicate pre-recorded calibrations!")
-            return
-
-        super()._on_click_duplicate_button()
+        if self.__check_duplicate_button_click_is_allowed(should_log_reason_as_error=True):
+            super()._on_click_duplicate_button()
 
     def _on_click_delete(self):
-        if self.current_item is None:
-            return
+        if self.__check_delete_button_click_is_allowed(should_log_reason_as_error=True):
+            super()._on_click_delete()
 
-        if not self._calibration_controller.is_from_same_recording(self.current_item):
-            logger.error("Cannot delete calibrations from other recordings!")
-            return
-
-        if not self.current_item.is_offline_calibration:
-            logger.error("Cannot delete pre-recorded calibrations!")
-            return
-
-        super()._on_click_delete()
 
     def _on_name_change(self, new_name):
         self._calibration_storage.rename(self.current_item, new_name)
@@ -204,3 +188,32 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
 
     def _on_calculation_could_not_be_started(self):
         self.render()
+
+    def __check_duplicate_button_click_is_allowed(self, should_log_reason_as_error: bool):
+        if not self._calibration_controller.is_from_same_recording(self.current_item):
+            if should_log_reason_as_error:
+                logger.error("Cannot duplicate calibrations from other recordings!")
+            return False
+
+        if not self.current_item.is_offline_calibration:
+            if should_log_reason_as_error:
+                logger.error("Cannot duplicate pre-recorded calibrations!")
+            return False
+
+        return True
+
+    def __check_delete_button_click_is_allowed(self, should_log_reason_as_error: bool):
+        if self.current_item is None:
+            return False
+
+        if not self._calibration_controller.is_from_same_recording(self.current_item):
+            if should_log_reason_as_error:
+                logger.error("Cannot delete calibrations from other recordings!")
+            return False
+
+        if not self.current_item.is_offline_calibration:
+            if should_log_reason_as_error:
+                logger.error("Cannot delete pre-recorded calibrations!")
+            return False
+        
+        return True

--- a/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/calibration_menu.py
@@ -171,7 +171,9 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
         )
 
     def _on_click_duplicate_button(self):
-        if self.__check_duplicate_button_click_is_allowed(should_log_reason_as_error=True):
+        if self.__check_duplicate_button_click_is_allowed(
+            should_log_reason_as_error=True
+        ):
             super()._on_click_duplicate_button()
 
     def _on_click_delete(self):
@@ -181,9 +183,13 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
     def _on_change_current_item(self, item):
         super()._on_change_current_item(item)
         if self._ui_button_duplicate:
-            self._ui_button_duplicate.read_only = not self.__check_duplicate_button_click_is_allowed(should_log_reason_as_error=False)
+            self._ui_button_duplicate.read_only = not self.__check_duplicate_button_click_is_allowed(
+                should_log_reason_as_error=False
+            )
         if self._ui_button_delete:
-            self._ui_button_delete.read_only = not self.__check_delete_button_click_is_allowed(should_log_reason_as_error=False)
+            self._ui_button_delete.read_only = not self.__check_delete_button_click_is_allowed(
+                should_log_reason_as_error=False
+            )
 
     def _on_name_change(self, new_name):
         self._calibration_storage.rename(self.current_item, new_name)
@@ -208,7 +214,9 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
     def _on_calculation_could_not_be_started(self):
         self.render()
 
-    def __check_duplicate_button_click_is_allowed(self, should_log_reason_as_error: bool):
+    def __check_duplicate_button_click_is_allowed(
+        self, should_log_reason_as_error: bool
+    ):
         if not self._calibration_controller.is_from_same_recording(self.current_item):
             if should_log_reason_as_error:
                 logger.error("Cannot duplicate calibrations from other recordings!")
@@ -234,5 +242,5 @@ class CalibrationMenu(plugin_ui.StorageEditMenu):
             if should_log_reason_as_error:
                 logger.error("Cannot delete pre-recorded calibrations!")
             return False
-        
+
         return True

--- a/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
@@ -27,6 +27,7 @@ class StorageEditMenu(plugin_ui.SelectAndRefreshMenu, abc.ABC):
 
     new_button_label = "New"
     duplicate_button_label = "Duplicate Current Configuration"
+    delete_button_label = "Delete"
 
     def __init__(self, storage):
         super().__init__()
@@ -73,9 +74,14 @@ class StorageEditMenu(plugin_ui.SelectAndRefreshMenu, abc.ABC):
             label=self.duplicate_button_label, function=self._on_click_duplicate_button
         )
 
+    def _create_delete_button(self):
+        return ui.Button(
+            label=self.delete_button_label, function=self._on_click_delete
+        )
+
     def render_item(self, item, menu):
         self._render_custom_ui(item, menu)
-        menu.append(ui.Button(label="Delete", function=self._on_click_delete))
+        menu.append(self._create_delete_button())
 
     def _on_click_new_button(self):
         new_item = self._new_item()

--- a/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/storage_edit_menu.py
@@ -75,9 +75,7 @@ class StorageEditMenu(plugin_ui.SelectAndRefreshMenu, abc.ABC):
         )
 
     def _create_delete_button(self):
-        return ui.Button(
-            label=self.delete_button_label, function=self._on_click_delete
-        )
+        return ui.Button(label=self.delete_button_label, function=self._on_click_delete)
 
     def render_item(self, item, menu):
         self._render_custom_ui(item, menu)


### PR DESCRIPTION
This PR ensures that the `Duplicate` and `Delete` buttons in Post-hoc Calibration menu are disabled, if those actions are not available and would generate an error log. This happens when the calibration is from a different recording, or the calibration is pre-recorded.

EDIT: Requires https://github.com/pupil-labs/pyglui/releases/tag/v1.28 or later