### PR TITLE
Remove unnecessary on_resize call

### DIFF
--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -511,7 +511,6 @@ def world(
             f_width, f_height = g_pool.capture.frame_size
             f_width += int(icon_bar_width * g_pool.gui.scale)
             glfw.glfwSetWindowSize(main_window, f_width, f_height)
-            on_resize(main_window, f_width, f_height)
 
         general_settings.append(ui.Button("Reset window size", set_window_size))
         general_settings.append(


### PR DESCRIPTION
glfwSetWindowSize triggers a frame buffer change which will call on_resize with appropriate parameters.

This fixes an issue on Mac retina displays which caused the world window to flicker after clicking the "Reset window size" button as on_resize() was not called with the window frame buffer size but with the window size. On retina displays, these are different which cause the issue to appear.