### PR TITLE
Improve Observable

### DIFF
--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -141,13 +141,13 @@ def _get_wrapper_and_create_if_not_exists(obj, method_name):
         return observed_method
     elif not inspect.ismethod(observed_method):
         raise TypeError(
-            "Attribute {} of object {} is not a method but {} and, thus, "
-            "cannot be observed!".format(method_name, obj, observed_method)
+            f"Attribute '{method_name}' of object {obj} is not a method but "
+            f"{observed_method} and, thus, cannot be observed!"
         )
     elif _is_classmethod(obj, method_name):
         raise TypeError(
-            "Attribute {} of object {} is a class method and, thus, "
-            "cannot be observed!".format(method_name, obj)
+            f"Attribute '{method_name}' of object {obj} is a class method and, thus, "
+            "cannot be observed!"
         )
     elif _method_was_modified(obj, method_name):
         raise TypeError(
@@ -209,8 +209,8 @@ def _get_wrapper_or_raise_if_not_exists(obj, method_name):
     observable_wrapper = getattr(obj, method_name)
     if not isinstance(observable_wrapper, _ObservableMethodWrapper):
         raise TypeError(
-            "Attribute {} of object {} is not observable. You never added an "
-            "observer to this!".format(method_name, obj)
+            f"Attribute '{method_name}' of object {obj} is not observable. You never "
+            "added an observer to this!"
         )
     return observable_wrapper
 
@@ -265,7 +265,7 @@ class _ObservableMethodWrapper:
             self._observers.remove(observer)
         except ValueError:
             raise ValueError(
-                "No observer {} found that could be removed!".format(observer)
+                f"No observer {observer} found that could be removed!"
             ) from None
 
     def remove_all_observers(self):

--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -13,8 +13,6 @@ import functools
 import inspect
 import weakref
 
-from attr import has
-
 
 class ObserverError(Exception):
     pass

--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -145,7 +145,7 @@ def _get_wrapper_and_create_if_not_exists(obj, method_name):
     elif not inspect.ismethod(observed_method):
         raise TypeError(
             f"Attribute '{method_name}' of object {obj} is not a method but "
-            f"{observed_method} and, thus, cannot be observed!"
+            f"{type(observed_method)} and, thus, cannot be observed!"
         )
     elif _is_classmethod(obj, method_name):
         raise TypeError(

--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -235,7 +235,7 @@ class _ObservableMethodWrapper:
         setattr(self._obj_ref(), self._method_name, self)
 
     def remove_wrapper(self):
-        setattr(obj, self._method_name, self._get_wrapped_bound_method())
+        setattr(self._obj_ref(), self._method_name, self._get_wrapped_bound_method())
         self._was_removed = True
 
     def _get_wrapped_bound_method(self):

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -260,6 +260,14 @@ class TestRemovingObservers:
         # at this point the list of observers is empty
         observable.remove_all_observers("bound_method")
 
+    def test_wrapper_can_be_removed(self, observable):
+        original_method = observable.bound_method
+        observable.add_observer("bound_method", lambda: None)
+        observable.bound_method.remove_wrapper()
+        method_after_removal = observable.bound_method
+
+        assert method_after_removal == original_method
+
 
 class TestExceptionThrowingMethods:
     class FakeException(Exception):

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -57,6 +57,17 @@ class TestObservabilityOfMethods:
         with pytest.raises(TypeError):
             observable.add_observer("class_method", observer)
 
+    def test_modified_methods_are_not_observable(self, observable, observer):
+        class FakeClass:
+            def fake_method(self):
+                pass
+
+        fake_class_instance = FakeClass()
+        observable.modified_method = fake_class_instance.fake_method
+
+        with pytest.raises(TypeError):
+            observable.add_observer("modified_method", observer)
+
 
 class TestDifferentKindsOfObservers:
     def test_bound_method_without_arguments_can_be_observer(self, observable):

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -176,6 +176,34 @@ class TestObserverCalls:
         assert observer1_called and observer2_called and observer3_called
 
 
+class TestWrappedMethodCalls:
+    def test_wrapped_functions_are_called_with_right_arguments(self):
+        mock_function = mock.Mock()
+
+        class FakeObservable(Observable):
+            def method(self, arg1, arg2):
+                mock_function(arg1, arg2)
+
+        observable = FakeObservable()
+        observable.add_observer("method", lambda arg1, arg2: None)
+
+        observable.method(1, 2)
+
+        mock_function.assert_called_once_with(1, 2)
+
+    def test_wrapped_functions_return_values(self):
+        class FakeObservable(Observable):
+            def method(self):
+                return 1
+
+        observable = FakeObservable()
+        observable.add_observer("method", lambda: None)
+
+        ret_val = observable.method()
+
+        assert ret_val == 1
+
+
 class TestRemovingObservers:
     def test_observers_that_are_functions_can_be_removed(self, observable):
         observer = mock.Mock()

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -49,6 +49,13 @@ class TestObservabilityOfMethods:
     def test_bound_method_is_observable(self, observable, observer):
         observable.add_observer("bound_method", observer)
 
+    def test_bound_method_from_parent_class_is_observable(self, observer):
+        class FakeObservableChild(FakeObservable):
+            pass
+
+        observable_child = FakeObservableChild()
+        observable_child.add_observer("bound_method", observer)
+
     def test_static_method_is_not_observable(self, observable, observer):
         with pytest.raises(TypeError):
             observable.add_observer("static_method", observer)

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -333,16 +333,15 @@ class TestDeletingObserverObjects:
         mock_function.assert_any_call()
 
 
-@pytest.fixture()
-def disable_generational_garbage_collection():
-    gc_enabled = gc.isenabled()
-    gc.disable()
-    yield
-    if gc_enabled:
-        gc.enable()
-
-
 class TestDeletingObservableObjects:
+    @pytest.fixture()
+    def disable_generational_garbage_collection(self):
+        gc_enabled = gc.isenabled()
+        gc.disable()
+        yield
+        if gc_enabled:
+            gc.enable()
+
     def test_observable_object_can_be_freed_by_reference_counting(
         self, disable_generational_garbage_collection
     ):

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -14,7 +14,7 @@ from unittest import mock
 
 import pytest
 
-from observable import Observable, ObserverError
+from observable import Observable, ObserverError, ReplaceWrapperError
 
 
 class FakeObservable(Observable):
@@ -391,3 +391,15 @@ def test_observers_can_be_observed(observable):
     mock_function.assert_has_calls(
         [mock.call("First"), mock.call("Second")], any_order=False
     )
+
+
+class TestWrapperProtectionDescriptor:
+    def test_wrapped_functions_cannot_be_set(self, observable):
+        observable.add_observer("bound_method", lambda: None)
+        with pytest.raises(ReplaceWrapperError):
+            observable.bound_method = 42
+
+    def test_other_instances_without_wrapper_can_be_set(self, observable):
+        observable.add_observer("bound_method", lambda: None)
+        unwrapped_observable = FakeObservable()
+        unwrapped_observable.bound_method = 42


### PR DESCRIPTION
@papr please add more reviewers as you see fit.

- Currently, the wrapper stores a reference to the wrapped function causing a reference cycle. This prevents garbage collection by reference counting. This is fixed by using a weakref to the object and referencing only the unbound method.
- I added test cases that test if wrapped methods still work before being wrapped (this is not related to the changed wrapper, these should have already been tested in the previous version)
- Use f-strings instead of `format` because we require Python >=3.6
- Add a descriptor for wrapped methods that prevents them from being replaced

I tested the code with python 3.6.10 and 3.8.2