### PR TITLE
Fix comment rot, pointing to renamed function

### DIFF
--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -314,7 +314,7 @@ def world(
             ("Log_Display", {}),
             ("Dummy_Gaze_Mapper", {}),
             ("Display_Recent_Gaze", {}),
-            # Calibration choreography plugin is added bellow by calling
+            # Calibration choreography plugin is added below by calling
             # patch_loaded_plugins_with_choreography_plugin
             ("Recorder", {}),
             ("NetworkApiPlugin", {}),

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -315,7 +315,7 @@ def world(
             ("Dummy_Gaze_Mapper", {}),
             ("Display_Recent_Gaze", {}),
             # Calibration choreography plugin is added bellow by calling
-            # patch_world_session_settings_with_choreography_plugin
+            # patch_loaded_plugins_with_choreography_plugin
             ("Recorder", {}),
             ("NetworkApiPlugin", {}),
             ("Fixation_Detector", {}),


### PR DESCRIPTION
The function was renamed, the comment wasn't.