### PR TITLE
Ensure collapsed menubar for unloaded previously selected plugins

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -434,6 +434,11 @@ def eye(
 
         # load last gui configuration
         g_pool.gui.configuration = session_settings.get("ui_config", {})
+        # If previously selected plugin was not loaded this time, we will have an
+        # expanded menubar without any menu selected. We need to ensure the menubar is
+        # collapsed in this case.
+        if all(submenu.collapsed for submenu in g_pool.menubar.elements):
+            g_pool.menubar.collapsed = True
 
         # set up performance graphs
         pid = os.getpid()

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -548,6 +548,11 @@ def player(
         toggle_general_settings(True)
 
         g_pool.gui.configuration = session_settings.get("ui_config", {})
+        # If previously selected plugin was not loaded this time, we will have an
+        # expanded menubar without any menu selected. We need to ensure the menubar is
+        # collapsed in this case.
+        if all(submenu.collapsed for submenu in g_pool.menubar.elements):
+            g_pool.menubar.collapsed = True
 
         # gl_state settings
         gl_utils.basic_gl_setup()

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -607,6 +607,11 @@ def world(
 
         # now that we have a proper window we can load the last gui configuration
         g_pool.gui.configuration = session_settings.get("ui_config", {})
+        # If previously selected plugin was not loaded this time, we will have an
+        # expanded menubar without any menu selected. We need to ensure the menubar is
+        # collapsed in this case.
+        if all(submenu.collapsed for submenu in g_pool.menubar.elements):
+            g_pool.menubar.collapsed = True
 
         # create a timer to control window update frequency
         window_update_timer = timer(1 / 60)


### PR DESCRIPTION
Fixes #1977 

The problem is that pyglui will not ensure a consistent UI when setting the ui-configuration from the session settings.
If the menubar was expanded previously with a plugin that is now not loaded (e.g. because it is not session persistent), the menubar will still be expanded without any plugin selected. We can ensure this consistency manually after restoring the session settings.

I have tested this in Capture and Player with the following custom plugin. I have _not_ tested this in the eye-process, as this is not so easy. But the code should work as well in case we ever have a non-session-persistent eye plugin.

#### Custom plugin for testing
```python
from plugin import Plugin
from pyglui import ui


class MenubarCollapseTestPlugin(Plugin):
    def init_ui(self):
        self.add_menu()
        self.menu.label = "MenubarCollapseTestPlugin"
        self.menu.append(ui.Info_Text("Dummy Text"))

    def deinit_ui(self):
        self.remove_menu()

    def get_init_dict(self):
        raise NotImplementedError()
```