### PR TITLE
Fix serialization issue in zmq log handler

### DIFF
--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -153,7 +153,7 @@ class Msg_Streamer(ZMQ_Socket):
         the contents of the iterable in '__raw_data__'
         require exposing the pyhton memoryview interface.
         """
-        assert deprecated is (), "Depracted use of send()"
+        assert deprecated == (), "Depracted use of send()"
         assert "topic" in payload, "`topic` field required in {}".format(payload)
 
         if "__raw_data__" not in payload:

--- a/pupil_src/shared_modules/zmq_tools.py
+++ b/pupil_src/shared_modules/zmq_tools.py
@@ -42,6 +42,8 @@ class ZMQ_handler(logging.Handler):
         try:
             self.socket.send(record_dict)
         except TypeError:
+            # stringify message in case it is not a string yet
+            record_dict["msg"] = str(record_dict["msg"])
             # stringify `exc_info` since it includes unserializable objects
             if record_dict["exc_info"]:  # do not convert if it is None
                 record_dict["exc_info"] = str(record_dict["exc_info"])


### PR DESCRIPTION
Previously, the zmq log handler's exception handling expected the "msg" field to be a string. If an object is passed that is not msgpack-serializable, the exeception handling will fail, e.g logger.debug([uuid.uuid4()]). This PR solves this issue by converting the "msg" field to a string in case of an initial serialization failure.