### PR TITLE
Fix crash when calibrating 2D monocularly

### DIFF
--- a/pupil_src/shared_modules/gaze_mapping/gazer_2d.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_2d.py
@@ -45,11 +45,17 @@ class Model2D(Model):
         return self._is_fitted
 
     def set_params(self, **params):
+        if params == {}:
+            return
         for key, value in params.items():
             setattr(self._regressor, key, np.asarray(value))
         self._is_fitted = True
 
     def get_params(self):
+        has_coef = hasattr(self._regressor, "coef_")
+        has_intercept = hasattr(self._regressor, "intercept_")
+        if not has_coef or not has_intercept:
+            return {}
         return {
             "coef_": self._regressor.coef_.tolist(),
             "intercept_": self._regressor.intercept_.tolist(),


### PR DESCRIPTION
Currently, the 2D gazer crashes if not all models are fit successfully, e.g. during monocular calibrations. In these cases, access to the model parameters fails. This PR checks if a model was fit successfully before attempting to access the model parameters.

Issue traceback:
```py
Traceback (most recent call last):
  File "launchables/world.py", line 642, in world
  File "launchables/world.py", line 409, in handle_notifications
  File "shared_modules/plugin.py", line 391, in add
  File "shared_modules/gaze_mapping/gazer_base.py", line 226, in __init__
  File "shared_modules/gaze_mapping/gazer_base.py", line 245, in get_params
  File "shared_modules/gaze_mapping/gazer_2d.py", line 54, in get_params
AttributeError: 'LinearRegression' object has no attribute 'coef_'
```