### PR TITLE
Support PI headset on/off classifier data

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -28,7 +28,7 @@ from . import update_utils
 
 logger = logging.getLogger(__name__)
 
-NEWEST_SUPPORTED_VERSION = Version("1.2")
+NEWEST_SUPPORTED_VERSION = Version("1.3")
 
 
 def transform_invisible_to_corresponding_new_style(rec_dir: str):

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -144,14 +144,15 @@ def _convert_gaze(recording: PupilRecording):
         "topic": "gaze.pi",
         "norm_pos": None,
         "timestamp": None,
-        "confidence": 1.0,
+        "confidence": None,
     }
     with fm.PLData_Writer(recording.rec_dir, "gaze") as writer:
-        for ((x, y), ts) in pi_gaze_items(root_dir=recording.rec_dir):
+        for ((x, y), ts, conf) in pi_gaze_items(root_dir=recording.rec_dir):
             template_datum["timestamp"] = ts
             template_datum["norm_pos"] = m.normalize(
                 (x, y), size=(width, height), flip_y=True
             )
+            template_datum["confidence"] = conf
             writer.append(template_datum)
         logger.info(f"Converted {len(writer.ts_queue)} gaze positions.")
 

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -515,14 +515,14 @@ def pi_gaze_items(root_dir):
             timestamps = timestamps[:size]
 
         conf_data = load_worn_data(find_worn_path(timestamps_path))
-        if conf_data and len(conf_data) != len(timestamps):
+        if conf_data is not None and len(conf_data) != len(timestamps):
             logger.warning(
                 f"There is a mismatch between the number of confidence data ({len(conf_data)}) "
                 f"and the number of timestamps ({len(timestamps)})! Not using confidence data."
             )
             conf_data = None
 
-        if not conf_data:
+        if conf_data is not None:
             conf_data = (1.0 for _ in range(len(timestamps)))
 
         yield from zip(raw_data, timestamps, conf_data)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -518,4 +518,16 @@ def pi_gaze_items(root_dir):
             size = min(len(raw_data), len(timestamps))
             raw_data = raw_data[:size]
             timestamps = timestamps[:size]
-        yield from zip(raw_data, timestamps)
+
+        conf_data = load_worn_data(find_worn_path(timestamps_path))
+        if conf_data and len(conf_data) != len(timestamps):
+            logger.warning(
+                f"There is a mismatch between the number of confidence data ({len(conf_data)}) "
+                f"and the number of timestamps ({len(timestamps)})! Not using confidence data."
+            )
+            conf_data = None
+
+        if not conf_data:
+            conf_data = (1.0 for _ in range(len(timestamps)))
+
+        yield from zip(raw_data, timestamps, conf_data)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -468,6 +468,16 @@ def pi_gaze_items(root_dir):
         assert raw_path.exists(), f"The file does not exist at path: {raw_path}"
         return raw_path
 
+    def find_worn_path(timestamps_path):
+        worn_name = timestamps_path.name
+        worn_name = worn_name.replace("gaze", "worn")
+        worn_name = worn_name.replace("_timestamps", "")
+        worn_path = timestamps_path.with_name(worn_name).with_suffix(".raw")
+        if worn_path.exists():
+            return worn_path
+        else:
+            return None
+
     def load_timestamps_data(path):
         timestamps = np.load(str(path))
         return timestamps
@@ -477,6 +487,18 @@ def pi_gaze_items(root_dir):
         raw_data_dtype = raw_data.dtype
         raw_data.shape = (-1, 2)
         return np.asarray(raw_data, dtype=raw_data_dtype)
+
+    def load_worn_data(path):
+        if not (path and path.exists()):
+            return None
+
+        def confidence_from_uint8(uint8: int) -> float:
+            conf = uint8 / 255.0
+            conf = max(0.0, min(conf, 1.0))
+            return float(conf)
+
+        with open(path, "rb") as fh:
+            return [confidence_from_uint8(uint8) for uint8 in fh.read()]
 
     # This pattern will match any filename that:
     # - starts with "gaze ps"

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -522,7 +522,7 @@ def pi_gaze_items(root_dir):
             )
             conf_data = None
 
-        if conf_data is not None:
+        if conf_data is None:
             conf_data = (1.0 for _ in range(len(timestamps)))
 
         yield from zip(raw_data, timestamps, conf_data)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -492,13 +492,8 @@ def pi_gaze_items(root_dir):
         if not (path and path.exists()):
             return None
 
-        def confidence_from_uint8(uint8: int) -> float:
-            conf = uint8 / 255.0
-            conf = max(0.0, min(conf, 1.0))
-            return float(conf)
-
-        with open(path, "rb") as fh:
-            return [confidence_from_uint8(uint8) for uint8 in fh.read()]
+        confidences = np.fromfile(str(path), "<u1") / 255.0
+        return np.clip(confidences, 0.0, 1.0)
 
     # This pattern will match any filename that:
     # - starts with "gaze ps"


### PR DESCRIPTION
This PR adds support for integrating the output of the headset on/off classifier data into gaze data confidence for Pupil Invisible recordings. Previously, the confidence of gaze data for such recordings was always set to `1.0`. The new implementation sets the confidence to `0.0` if the classifier output for the given gaze datum is `0` (which means `off`), or `1.0` if the output is `255` (`on`). If the classifier data file is missing, the implementation falls back to the old implementation of setting the confidence to `1.0`.
