### PR TITLE
Cleanup camera models

### DIFF
--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -250,7 +250,7 @@ class Camera_Model(abc.ABC):
             "resolution": self.resolution,
             "cam_type": self.cam_type,
         }
-        # Try to load previous camera intrinsics
+        # Try to load previously recorded camera intrinsics
         save_path = os.path.join(
             directory, "{}.intrinsics".format(cam_name.replace(" ", "_"))
         )
@@ -272,7 +272,7 @@ class Camera_Model(abc.ABC):
     def from_file(directory, cam_name, resolution):
         """
         Loads recorded intrinsics for the given camera and resolution. If no recorded
-        intrinsics are available we fall back on default values.
+        intrinsics are available we fall back to default values.
         :param directory: The directory in which to look for the intrinsincs file
         :param cam_name: Name of the camera, e.g. 'Pupil Cam 1 ID2'
         :param resolution: Camera resolution given as a tuple.
@@ -311,8 +311,9 @@ class Camera_Model(abc.ABC):
                 logger.info("Loading default intrinsics!")
                 intrinsics = default_world_intrinsics[cam_name][str(resolution)]
             else:
-                logger.info("No default intrinsics available!")
-                logger.warning("Loading dummy intrinsics!")
+                logger.warning(
+                    "No default intrinsics available! Loading dummy intrinsics!"
+                )
                 return Dummy_Camera(resolution, cam_name)
 
         cam_type = intrinsics["cam_type"]

--- a/pupil_src/shared_modules/pupil_recording/update/old_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/old_style.py
@@ -21,9 +21,9 @@ import av
 import numpy as np
 from scipy.interpolate import interp1d
 
-import camera_models as cm
 import csv_utils
 import file_methods as fm
+from camera_models import Camera_Model
 from version_utils import VersionFormat
 
 from .. import Version
@@ -507,7 +507,7 @@ def update_recording_v111_v113(rec_dir):
         f = world_video.streams.video[0].format
         resolution = f.width, f.height
 
-        intrinsics = cm.load_intrinsics(rec_dir, "world", resolution)
+        intrinsics = Camera_Model.from_file(rec_dir, "world", resolution)
 
         DEPRECATED_SQUARE_MARKER_KEY = "realtime_square_marker_surfaces"
         if DEPRECATED_SQUARE_MARKER_KEY not in surface_definitions_dict:

--- a/pupil_src/shared_modules/pupil_recording/update/update_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/update/update_utils.py
@@ -31,7 +31,7 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
     # Make sure the default value always correlates to the frame size of BrokenStream
     frame_size = (1280, 720)
     # TODO: Due to the naming conventions for multipart-recordings, we can't
-    # easily lookup 'any' video name in the pre_recorded_calibrations, since it
+    # easily lookup 'any' video name in the default_world_intrinsics, since it
     # might be a multipart recording. Therefore we need to compute a hint here
     # for the lookup. This could be improved.
     camera_hint = ""
@@ -41,7 +41,7 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
         except av.AVError:
             continue
 
-        for camera in cm.pre_recorded_calibrations:
+        for camera in cm.default_world_intrinsics:
             if camera in video.name:
                 camera_hint = camera
                 break

--- a/pupil_src/shared_modules/pupil_recording/update/update_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/update/update_utils.py
@@ -51,7 +51,7 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
         )
         break
 
-    intrinsics = cm.load_intrinsics(rec_dir, camera_hint, frame_size)
+    intrinsics = cm.Camera_Model.from_file(rec_dir, camera_hint, frame_size)
     intrinsics.save(rec_dir, "world")
 
 

--- a/pupil_src/shared_modules/video_capture/__init__.py
+++ b/pupil_src/shared_modules/video_capture/__init__.py
@@ -28,8 +28,6 @@ from glob import glob
 
 import numpy as np
 
-from camera_models import load_intrinsics
-
 from .base_backend import (
     Base_Manager,
     Base_Source,

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -22,7 +22,7 @@ import av
 import numpy as np
 from pyglui import ui
 
-from camera_models import load_intrinsics
+from camera_models import Camera_Model
 from pupil_recording import PupilRecording
 
 from .base_backend import Base_Manager, Base_Source, EndofVideoError, Playback_Source
@@ -245,7 +245,7 @@ class File_Source(Playback_Source, Base_Source):
         self.buffering = buffered_decoding
         # Load video split for first frame
         self.reset_video()
-        self._intrinsics = load_intrinsics(rec, set_name, self.frame_size)
+        self._intrinsics = Camera_Model.from_file(rec, set_name, self.frame_size)
 
         self.show_plugin_menu = show_plugin_menu
 

--- a/pupil_src/shared_modules/video_capture/ndsi_backend.py
+++ b/pupil_src/shared_modules/video_capture/ndsi_backend.py
@@ -17,7 +17,7 @@ from packaging.version import Version
 from pyglui import ui
 
 import os_utils
-from camera_models import load_intrinsics
+from camera_models import Camera_Model
 
 from .base_backend import Base_Manager, Base_Source, SourceInfo
 
@@ -221,7 +221,7 @@ class NDSI_Source(Base_Source):
     @property
     def intrinsics(self):
         if self._intrinsics is None or self._intrinsics.resolution != self.frame_size:
-            self._intrinsics = load_intrinsics(
+            self._intrinsics = Camera_Model.from_file(
                 self.g_pool.user_dir, self.name, self.frame_size
             )
         return self._intrinsics

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -23,7 +23,7 @@ from pyglui import cygl, ui
 
 import gl_utils
 import uvc
-from camera_models import load_intrinsics
+from camera_models import Camera_Model
 from version_utils import VersionFormat
 
 from .base_backend import Base_Manager, Base_Source, InitialisationError, SourceInfo
@@ -135,7 +135,7 @@ class UVC_Source(Base_Source):
             self.frame_size_backup = frame_size
             self.frame_rate_backup = frame_rate
             self.exposure_time_backup = None
-            self._intrinsics = load_intrinsics(
+            self._intrinsics = Camera_Model.from_file(
                 self.g_pool.user_dir, self.name, self.frame_size
             )
         else:
@@ -556,7 +556,7 @@ class UVC_Source(Base_Source):
         self.uvc_capture.frame_size = size
         self.frame_size_backup = size
 
-        self._intrinsics = load_intrinsics(
+        self._intrinsics = Camera_Model.from_file(
             self.g_pool.user_dir, self.name, self.frame_size
         )
 


### PR DESCRIPTION
This is a refactoring PR, cleaning up the code and logic used in camera_models.py.
It will make it easier to integrate eye camera intrinsics for correct usage of the focal length in the 3D detector later on.

Summary of changes:
1. Moved all duplicated code between the radial and fish-eye camera into the existing base class

2. Used a factory pattern and proper base-class registration for file (de)serialization of camera models.
It seems that there also was some bug caused by the previous logic, but it did not have any visible effect:
Saved dummy intrinsics would be loaded as a radial camera model instead of the dummy camera model.

3. I reworded all uses of "calibration" referring to intrinsics to "intrinsics". Also fixed inconsistent usage of "pre-recorded", sometimes meaning "included in the recording" and sometimes meaning "default values that we recorded previously at the company".