### PR TITLE
Pass eye camera focal_length to 3D detector

### DIFF
--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -235,6 +235,12 @@ class Camera_Model(abc.ABC):
     def update_dist_coefs(self, dist_coefs):
         self.D = np.asanyarray(dist_coefs).reshape(self.D.shape)
 
+    @property
+    def focal_length(self):
+        fx = self.K[0, 0]
+        fy = self.K[1, 1]
+        return (fx + fy) / 2
+
     @abc.abstractmethod
     def undistort(self, img: np.ndarray) -> np.ndarray:
         ...

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -153,6 +153,10 @@ default_intrinsics = {
 }
 
 # Add measured intrinsics for the eyes (once for each ID for easy lookup)
+# TODO: From these intrinsics only the focal lengths were measured. The principal points
+# are just default values (half the resolution) and there's no distortion model for now.
+# At some later point we should measure the full intrinsics and replace existing
+# intrinsics with a recording upgrade.
 for eye_id in (0, 1):
     default_intrinsics.update(
         {

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -356,7 +356,7 @@ class Camera_Model(abc.ABC):
             if intrinsics_dict["version"] < __version__:
                 logger.warning("Deprecated camera intrinsics found.")
                 logger.info(
-                    "Please recalculate the camera intrinsics using the Camera "
+                    "Please recalculate the camera intrinsics using the Camera"
                     " Intrinsics Estimation."
                 )
                 os.rename(
@@ -365,12 +365,11 @@ class Camera_Model(abc.ABC):
                 )
 
             intrinsics = intrinsics_dict[str(resolution)]
-            logger.info("Previously recorded intrinsics found and loaded!")
+            logger.info("Loading previously recorded intrinsics!")
         except Exception:
-            logger.info(
-                "No recorded intrinsics found for camera {} at resolution {}".format(
-                    cam_name, resolution
-                )
+            logger.debug(
+                f"No recorded intrinsics found for camera {cam_name} at resolution"
+                f" {resolution}"
             )
 
             if (
@@ -381,7 +380,15 @@ class Camera_Model(abc.ABC):
                 intrinsics = default_intrinsics[cam_name][str(resolution)]
             else:
                 logger.warning(
-                    "No default intrinsics available! Loading dummy intrinsics!"
+                    f"No camera intrinsics available for camera {cam_name} at"
+                    f" resolution {resolution}!"
+                )
+                logger.warning(
+                    "Loading dummy intrinsics, which might decrease accuracy!"
+                )
+                logger.warning(
+                    "Consider selecting a different resolution, or running the Camera"
+                    " Instrinsics Estimation!"
                 )
                 return Dummy_Camera(resolution, cam_name)
 

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -22,9 +22,9 @@ from file_methods import load_object, save_object
 logger = logging.getLogger(__name__)
 __version__ = 1
 
-# These are world camera intrinsics that we recorded. They are estimates and generalize
-# our setup. Its always better to estimate intrinsics for each camera again.
-default_world_intrinsics = {
+# These are camera intrinsics that we recorded. They are estimates and generalize our
+# setup. Its always better to estimate intrinsics for each camera again.
+default_intrinsics = {
     "Pupil Cam1 ID2": {
         "(640, 480)": {
             "dist_coefs": [
@@ -151,6 +151,73 @@ default_world_intrinsics = {
         }
     },
 }
+
+# Add measured intrinsics for the eyes (once for each ID for easy lookup)
+for eye_id in (0, 1):
+    default_intrinsics.update(
+        {
+            f"Pupil Cam1 ID{eye_id}": {
+                "(320, 240)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [338.456035, 0.0, 160],
+                        [0.0, 339.871543, 120],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+                "(640, 480)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [670.785555, 0.0, 320],
+                        [0.0, 670.837798, 240],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+            },
+            f"Pupil Cam2 ID{eye_id}": {
+                "(192, 192)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [282.976877, 0.0, 96],
+                        [0.0, 283.561467, 96],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+                "(400, 400)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [561.471804, 0.0, 200],
+                        [0.0, 562.494105, 200],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+            },
+            f"Pupil Cam3 ID{eye_id}": {
+                "(192, 192)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [140.0, 0.0, 96],
+                        [0.0, 140.0, 96],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+                "(400, 400)": {
+                    "dist_coefs": [[0.0, 0.0, 0.0, 0.0, 0.0]],
+                    "camera_matrix": [
+                        [278.50, 0.0, 200],
+                        [0.0, 278.55, 200],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "cam_type": "radial",
+                },
+            },
+        }
+    )
 
 
 class Camera_Model(abc.ABC):
@@ -305,11 +372,11 @@ class Camera_Model(abc.ABC):
             )
 
             if (
-                cam_name in default_world_intrinsics
-                and str(resolution) in default_world_intrinsics[cam_name]
+                cam_name in default_intrinsics
+                and str(resolution) in default_intrinsics[cam_name]
             ):
                 logger.info("Loading default intrinsics!")
-                intrinsics = default_world_intrinsics[cam_name][str(resolution)]
+                intrinsics = default_intrinsics[cam_name][str(resolution)]
             else:
                 logger.warning(
                     "No default intrinsics available! Loading dummy intrinsics!"

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -289,10 +289,6 @@ class Camera_Model(abc.ABC):
     ):
         ...
 
-    @abc.abstractmethod
-    def save(self, directory: str, custom_name: typing.Optional[str] = None):
-        ...
-
     subclass_by_cam_type = dict()
 
     def __init_subclass__(cls, *args, **kwargs):

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -299,6 +299,13 @@ class Plugin(object):
         self.menu = None
         self.menu_icon = None
 
+    @property
+    def ui_available(self):
+        try:
+            return self.menu is not None
+        except AttributeError:
+            return False
+
     def __monkeypatch_gl_display_error_checking(self):
         # Monkeypatch gl_display functions to include error checking. This is because we
         # often receive OpenGL errors as results of buggy pyglui code that gets called

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -32,9 +32,9 @@ from .visualizer_3d import Eye_Visualizer
 
 logger = logging.getLogger(__name__)
 
-if VersionFormat(pupil_detectors.__version__) < VersionFormat("1.0.5"):
+if VersionFormat(pupil_detectors.__version__) < VersionFormat("1.1.1"):
     msg = (
-        f"This version of Pupil requires pupil_detectors >= 1.0.5."
+        f"This version of Pupil requires pupil_detectors >= 1.1.1."
         f" You are running with pupil_detectors == {pupil_detectors.__version__}."
         f" Please upgrade to a newer version!"
     )

--- a/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/detector_3d_plugin.py
@@ -66,9 +66,22 @@ class Detector3DPlugin(PupilDetectorPlugin):
         # initialize plugin with a detector instance, safe to call multiple times
         self._detector_internal = detector
         self.proxy = PropertyProxy(self.detector_3d)
+
+        # In case of re-initialization, we need to close the debug window or else we
+        # leak the opengl window. We can open the new one again afterwards.
+        try:
+            debug_window_was_open = self.is_debug_window_open
+        except AttributeError:
+            # debug window does not exist yet
+            debug_window_was_open = False
+        if debug_window_was_open:
+            self.debug_window_close()
         self.debugVisualizer3D = Eye_Visualizer(
             self.g_pool, self.detector_3d.focal_length()
         )
+        if debug_window_was_open:
+            self.debug_window_open()
+
         self._last_focal_length = self.detector_3d.focal_length()
         if self.ui_available:
             # ui was wrapped around old detector, need to re-init for new one

--- a/pupil_src/shared_modules/pupil_recording/info/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/info/__init__.py
@@ -14,7 +14,9 @@ from .recording_info import RecordingInfoFile
 from .recording_info_2_0 import _RecordingInfoFile_2_0
 from .recording_info_2_1 import _RecordingInfoFile_2_1
 from .recording_info_2_2 import _RecordingInfoFile_2_2
+from .recording_info_2_3 import _RecordingInfoFile_2_3
 
 RecordingInfoFile.register_child_class(Version("2.0"), _RecordingInfoFile_2_0)
 RecordingInfoFile.register_child_class(Version("2.1"), _RecordingInfoFile_2_1)
 RecordingInfoFile.register_child_class(Version("2.2"), _RecordingInfoFile_2_2)
+RecordingInfoFile.register_child_class(Version("2.3"), _RecordingInfoFile_2_3)

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_2_3.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_2_3.py
@@ -1,0 +1,28 @@
+"""
+(*)~---------------------------------------------------------------------------
+Pupil - eye tracking platform
+Copyright (C) 2012-2020 Pupil Labs
+
+Distributed under the terms of the GNU
+Lesser General Public License (LGPL v3.0).
+See COPYING and COPYING.LESSER for license details.
+---------------------------------------------------------------------------~(*)
+"""
+
+from . import RecordingInfoFile, Version
+from .recording_info_2_2 import _RecordingInfoFile_2_2
+from . import recording_info_utils as utils
+
+
+class _RecordingInfoFile_2_3(_RecordingInfoFile_2_2):
+    @property
+    def meta_version(self) -> Version:
+        return Version("2.3")
+
+    @property
+    def _private_key_schema(self) -> RecordingInfoFile._KeyValueSchema:
+        return {
+            **super()._private_key_schema,
+            # overwrite meta_version key from parent
+            "meta_version": (utils.validator_version_string, lambda _: "2.3"),
+        }

--- a/pupil_src/shared_modules/pupil_recording/update/new_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/new_style.py
@@ -35,7 +35,7 @@ def recording_update_to_latest_new_style(rec_dir: str):
         info_file = update_newstyle_20_21(rec_dir)
     if info_file.meta_version < parse_version("2.2"):
         info_file = update_newstyle_21_22(rec_dir)
-    if info_file.meta_version < Version("2.3"):
+    if info_file.meta_version < parse_version("2.3"):
         info_file = update_newstyle_22_23(rec_dir)
 
 
@@ -136,7 +136,7 @@ def update_newstyle_22_23(rec_dir: str):
     # update info file
     old_info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
     new_info_file = RecordingInfoFile.create_empty_file(
-        rec_dir, fixed_version=Version("2.3")
+        rec_dir, fixed_version=parse_version("2.3")
     )
     new_info_file.update_writeable_properties_from(old_info_file)
     new_info_file.save_file()

--- a/pupil_src/shared_modules/pupil_recording/update/new_style.py
+++ b/pupil_src/shared_modules/pupil_recording/update/new_style.py
@@ -10,8 +10,10 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import logging
+import re
 from pathlib import Path
 
+import camera_models as cm
 import file_methods as fm
 from version_utils import get_version
 
@@ -33,6 +35,8 @@ def recording_update_to_latest_new_style(rec_dir: str):
         info_file = update_newstyle_20_21(rec_dir)
     if info_file.meta_version < Version("2.2"):
         info_file = update_newstyle_21_22(rec_dir)
+    if info_file.meta_version < Version("2.3"):
+        info_file = update_newstyle_22_23(rec_dir)
 
 
 def check_min_player_version(info_file: RecordingInfoFile):
@@ -96,6 +100,45 @@ def update_newstyle_21_22(rec_dir: str):
     old_info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
     new_info_file = RecordingInfoFile.create_empty_file(
         rec_dir, fixed_version=Version("2.2")
+    )
+    new_info_file.update_writeable_properties_from(old_info_file)
+    new_info_file.save_file()
+    return new_info_file
+
+
+def update_newstyle_22_23(rec_dir: str):
+    # Pupil detectors now use eye camera intrinsics. Previously we did not include those
+    # in the recording, so now the dummy intrinsics would be used. These do not have an
+    # appropriate focal length value for the 3D pupil detector. Instead we will just add
+    # all default intrinsics for Cam1 and Cam2 eye cameras to the recording. The correct
+    # one will be picked according to the resolution later on. This isnot optimal, if
+    # the recording uses Cam3, but there is no way of inferring this and we just assume
+    # the probability that it is Cam2 is much higher.
+
+    # Make sure we don't overwrite any existing eye intrinsics, although there should be
+    # none at this point, except if someone copied them over from a later recording into
+    # an un-updated recording!
+    if any((Path(rec_dir) / f"eye{eye_id}.intrinsics").exists() for eye_id in (0, 1)):
+        logger.error(
+            "Found recorded eye intrinsics! These must have been copied over manually!"
+            " Will not patch eye intrinsics automatically!"
+        )
+    else:
+        for cam, data in cm.default_intrinsics.items():
+            match = re.match(r"Pupil Cam[12] ID(?P<eye_id>[01])", cam)
+            if match is None:
+                continue
+
+            eye_id = match.group("eye_id")
+            for resolution in data.keys():
+                logger.info(f"Patching eye intrinsics for {cam}{resolution}.")
+                intrinsics = cm.Camera_Model.from_default(cam, resolution)
+                intrinsics.save(rec_dir, f"eye{eye_id}")
+
+    # update info file
+    old_info_file = RecordingInfoFile.read_file_from_recording(rec_dir)
+    new_info_file = RecordingInfoFile.create_empty_file(
+        rec_dir, fixed_version=Version("2.3")
     )
     new_info_file.update_writeable_properties_from(old_info_file)
     new_info_file.save_file()

--- a/pupil_src/shared_modules/pupil_recording/update/update_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/update/update_utils.py
@@ -31,7 +31,7 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
     # Make sure the default value always correlates to the frame size of BrokenStream
     frame_size = (1280, 720)
     # TODO: Due to the naming conventions for multipart-recordings, we can't
-    # easily lookup 'any' video name in the default_world_intrinsics, since it
+    # easily lookup 'any' video name in the default_intrinsics, since it
     # might be a multipart recording. Therefore we need to compute a hint here
     # for the lookup. This could be improved.
     camera_hint = ""
@@ -41,7 +41,7 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
         except av.AVError:
             continue
 
-        for camera in cm.default_world_intrinsics:
+        for camera in cm.default_intrinsics:
             if camera in video.name:
                 camera_hint = camera
                 break


### PR DESCRIPTION
This PR uses the eye camera intrinsics (specifically focal_length) to get a more accurate 3D eyeball position estimate.

Depends on [pupil-detectors](https://github.com/pupil-labs/pupil-detectors) v1.1.1, upgrade with
```
pip install -U pupil-detectors
```

**Summary**
- Added known intrinsics for the eye cameras to camera_models.py
- On recording stop, current eye camera intrinsics are saved to the recording (like with world.intrinsics)
- The 3D detector is initialized with `g_pool.capture.intrinsics.focal_length` (cannot be changed at runtime)
- On focal_length changes (e.g. by changing the resolution), the 3D detector and all dependent UI is re-initialized
- Added clear warnings that loading dummy intrinsics is not good
- Added upgrade mechanism (RecordingInfo v2.3) which creates eye(0/1).intrinsics files when opening an older recording, as these will be tried to load from. To make it easy, we just serialize all intrinsics for eye cameras Cam1 and Cam2, the correct intrinsics will be picked later based on the actual resolution. This is not correct if Cam3 was used to recording, but there is no way of figuring this out.

**Tests**
1) Run Capture and open the 3D detector debug window while wearing a headset. The eyeball-center z coordinate should be relatively stable (+/-5mm). Switch the resolution of the eye camera. The debug window reopens with a reset model. After stabilizing, the eyeball-center z coordinate should settle down to the same value as with the other resolution (+/-5mm).

2) Make a recording, the recording should contain `eye0.intrinsics` and `eye1.intrinsics` files.

3) Open the recording in player and check that the post-hoc pupil detection works fine.

4) Open an older recording in player and check that the post-hoc pupil detection works fine. The recording should contain `eye0.intrinsics` and `eye1.intrinsics` files afterwards.

5) Open a fresh pupil mobile recording in player and check that the post-hoc pupil detection works fine. The recording should contain `eye0.intrinsics` and `eye1.intrinsics` files afterwards.