### PR TITLE
Fix post-hoc calibration timeline update

### DIFF
--- a/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
+++ b/pupil_src/shared_modules/gaze_producer/controller/gaze_mapper_controller.py
@@ -47,6 +47,9 @@ class GazeMapperController(Observable):
     def set_validation_range_from_current_trim_marks(self, gaze_mapper):
         gaze_mapper.validation_index_range = self._get_current_trim_mark_range()
 
+    def set_calibration_unique_id(self, gaze_mapper, calibration_unique_id):
+        gaze_mapper.calibration_unique_id = calibration_unique_id
+
     def calculate(self, gaze_mapper):
         self._reset_gaze_mapper_results(gaze_mapper)
         calibration = self.get_valid_calibration_or_none(gaze_mapper)

--- a/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_menu.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_menu.py
@@ -95,12 +95,18 @@ class GazeMapperMenu(plugin_ui.StorageEditMenu):
             labels.append("[Invalid Calibration]")
             selection.append(gaze_mapper.calibration_unique_id)
 
+        def calibration_setter(calibration_unique_id):
+            self._gaze_mapper_controller.set_calibration_unique_id(
+                gaze_mapper, calibration_unique_id
+            )
+
         return ui.Selector(
             "calibration_unique_id",
             gaze_mapper,
             label="Calibration",
             selection=selection,
             labels=labels,
+            setter=calibration_setter,
         )
 
     def _create_mapping_range_selector(self, gaze_mapper):

--- a/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_timeline.py
+++ b/pupil_src/shared_modules/gaze_producer/ui/gaze_mapper_timeline.py
@@ -48,6 +48,9 @@ class GazeMapperTimeline:
         self._gaze_mapper_controller.add_observer(
             "publish_all_enabled_mappers", self._on_publish_enabled_mappers
         )
+        self._gaze_mapper_controller.add_observer(
+            "set_calibration_unique_id", self._on_calibration_unique_id_changed,
+        )
 
         self._calibration_controller.add_observer(
             "set_calibration_range_from_current_trim_marks",
@@ -119,4 +122,7 @@ class GazeMapperTimeline:
 
     def _on_calibration_deleted(self, _):
         # the deleted calibration might be used by one of the gaze mappers
+        self.render_parent_timeline()
+
+    def _on_calibration_unique_id_changed(self, _1, _2):
         self.render_parent_timeline()


### PR DESCRIPTION
This PR fixes an issue where changing the calibration in post-hoc gaze mapping would not update the timeline to reflect the calibration's range.

---

##### Steps to reproduce
1. Make a Capture recording including at least one calibration
1. Open recording in Player
1. Select post-hoc gaze calibration
1. At least one calibration should show up as "Recorded Calibration"
1. The "default gaze mapper" has "Recorded Calibration" selected as calibration
1. Create a new "Default Calibration"
1. Change calibration range to something else than the complete recording
1. In the "default gaze mapper" select "default calibration" as calibration
    - [!!!] At this point the calibration range timeline should update to the corresponding range
1. Changing the calibration range again correctly updates the visualisation