### PR TITLE
Fix camera model loading

### DIFF
--- a/pupil_src/shared_modules/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/camera_intrinsics_estimation.py
@@ -277,7 +277,7 @@ class Camera_Intrinsics_Estimation(Plugin):
                     (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, max_iter, eps),
                 )
                 camera_model = Fisheye_Dist_Camera(
-                    camera_matrix, dist_coefs, img_shape, self.g_pool.capture.name
+                    self.g_pool.capture.name, img_shape, camera_matrix, dist_coefs
                 )
             elif self.dist_mode == "Radial":
                 rms, camera_matrix, dist_coefs, rvecs, tvecs = cv2.calibrateCamera(
@@ -288,7 +288,7 @@ class Camera_Intrinsics_Estimation(Plugin):
                     None,
                 )
                 camera_model = Radial_Dist_Camera(
-                    camera_matrix, dist_coefs, img_shape, self.g_pool.capture.name
+                    self.g_pool.capture.name, img_shape, camera_matrix, dist_coefs
                 )
             else:
                 raise ValueError("Unkown distortion model: {}".format(self.dist_mode))

--- a/pupil_src/shared_modules/camera_models.py
+++ b/pupil_src/shared_modules/camera_models.py
@@ -216,10 +216,6 @@ class Camera_Model(abc.ABC):
     ):
         ...
 
-    @abc.abstractmethod
-    def save(self, directory: str, custom_name: typing.Optional[str] = None):
-        ...
-
     subclass_by_cam_type = dict()
 
     def __init_subclass__(cls, *args, **kwargs):

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -116,10 +116,10 @@ class HMD_Streaming_Source(Base_Source):
             if self.projection_matrix is not None:
                 distortion = [[0.0, 0.0, 0.0, 0.0, 0.0]]
                 self._intrinsics = Radial_Dist_Camera(
-                    self.projection_matrix, distortion, self.frame_size, self.name
+                    self.name, self.frame_size, self.projection_matrix, distortion
                 )
             else:
-                self._intrinsics = Dummy_Camera(self.frame_size, self.name)
+                self._intrinsics = Dummy_Camera(self.name, self.frame_size)
         return self._intrinsics
 
     @intrinsics.setter


### PR DESCRIPTION
This fixes a bug where loading dummy intrinsics from file would crash because the `Dummy_Camera` constructor does not consistently overwrite the parent constructor. I moved name and resolution to the start from for all constructors as these are the least likely to change and adjusted the `Dummy_Camera` constructor to be consistent with the others.

This bug surfaced now after #1992 where I fixed that saved dummy intrinsics would always be loaded via the radial camera model instead of the dummy camera model (therefore the dummy constructor was never used when loading from file).