### PR TITLE
Fix recorder crash on version formatting

### DIFF
--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -333,7 +333,7 @@ class Recorder(System_Plugin_Base):
         self.meta_info.recording_software_name = (
             RecordingInfoFile.RECORDING_SOFTWARE_NAME_PUPIL_CAPTURE
         )
-        self.meta_info.recording_software_version = self.g_pool.version.vstring
+        self.meta_info.recording_software_version = str(self.g_pool.version)
         self.meta_info.recording_name = self.session_name
         self.meta_info.start_time_synced_s = start_time_synced
         self.meta_info.start_time_system_s = self.start_time


### PR DESCRIPTION
This PR fixes a crash on starting a recording. The code was using an attribute from the old `Version` class that was recently replaced.

