### PR TITLE
Prevent eye window crash from ellipse2Poly issues

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_2d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_2d.py
@@ -33,11 +33,16 @@ def draw_ellipse(
         # Known issues:
         #   - There are reports of negative eye_ball axes when drawing the 3D eyeball
         #     outline, which will raise cv2.error. TODO: Investigate cause in detectors.
+        #   - There was a case where all values in the ellipse where 'NaN', which raises
+        #     ValueError: cannot convert float NaN to integer. TODO: Investigate how we
+        #     even got here, since calls to this function are confidence-gated!
         logger.debug(
             "Error drawing ellipse! Skipping...\n"
-            f"ellipse: {ellipse}\n"
-            f"{type(e)}: {e}"
+            f"Ellipse: {ellipse}\n"
+            f"Color: {rgba}\n"
+            f"Error: {type(e)}: {e}"
         )
+        return
 
     draw_polyline(pts, thickness, RGBA(*rgba))
     if draw_center:


### PR DESCRIPTION
TLDR: the missing `return` would cause a crash later on.

There was a new error type that could happen here, so I extended the logging and comments as well. Additionally, the previous error handling was not correct, as we would still crash when running the code below without `pts` being computed.