### PR TITLE
Add build instructions for glfw-3.3 to ubuntu docs

### DIFF
--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -9,7 +9,22 @@ Pupil requires Python 3.6 or higher. Please check this [resource](https://askubu
 
 ```sh
 sudo apt-get update
-sudo apt install -y pkg-config git cmake build-essential nasm wget python3-setuptools libusb-1.0-0-dev  python3-dev python3-pip python3-numpy python3-scipy libglew-dev libglfw3-dev libtbb-dev
+sudo apt install -y pkg-config git cmake build-essential nasm wget python3-setuptools libusb-1.0-0-dev  python3-dev python3-pip python3-numpy python3-scipy libglew-dev libtbb-dev
+```
+
+## glfw
+Pupil requires glfw v3.3.2, which you can install from source with:
+```sh
+sudo apt install xorg-dev
+git clone https://github.com/glfw/glfw
+cd glfw
+git checkout 3.3.2
+mkdir build
+cd build
+cmake -DBUILD_SHARED_LIBS=ON ..
+make
+sudo make install
+sudo ldconfig
 ```
 
 ## ffmpeg3

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -7,7 +7,7 @@ Most of this works via **apt**! Just copy paste into the terminal and listen to 
 ## General Dependencies
 
 ```sh
-sudo apt install -y pkg-config git cmake build-essential nasm wget python3-setuptools libusb-1.0-0-dev  python3-dev python3-pip python3-numpy python3-scipy libglew-dev libglfw3-dev libtbb-dev
+sudo apt install -y pkg-config git cmake build-essential nasm wget python3-setuptools libusb-1.0-0-dev  python3-dev python3-pip python3-numpy python3-scipy libglew-dev libtbb-dev
 
 # ffmpeg >= 3.2
 sudo apt install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev ffmpeg x264 x265 libportaudio2 portaudio19-dev
@@ -18,6 +18,21 @@ sudo apt install -y python3-opencv libopencv-dev
 # 3D Eye model dependencies
 sudo apt install -y libgoogle-glog-dev libatlas-base-dev libeigen3-dev
 sudo apt install -y libceres-dev
+```
+
+## glfw
+Pupil requires glfw v3.3.2, which you can install from source with:
+```sh
+sudo apt install xorg-dev
+git clone https://github.com/glfw/glfw
+cd glfw
+git checkout 3.3.2
+mkdir build
+cd build
+cmake -DBUILD_SHARED_LIBS=ON ..
+make
+sudo make install
+sudo ldconfig
 ```
 
 ## Turbojpeg


### PR DESCRIPTION
GLFW 3.3 is not available via `apt` on Ubuntu < 20.04, so you need to build it manually on 17.10 or 18.04.
Added build instructions to the docs and removed `libglfw-3` from the `apt` commands.

PR to master as this is docs related.