### PR TITLE
updated the build binary link in documenation

### DIFF
--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -129,8 +129,8 @@ The following steps require you to store dynamic libraries in the `pupil_externa
 
 #### FFMPEG
 
-- Download FFMPEG v4.0 Windows shared binaries from [ffmpeg](https://github.com/BtbN/FFmpeg-Builds/releases)
-- Unzip ffmpeg-shared to your work dir
+- [Download FFMPEG v4.0 Windows **shared** binaries](https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2020-10-12-12-31/ffmpeg-n4.3.1-20-g8a2acdc6da-win64-lgpl-shared-4.3.zip)
+- Unzip `ffmpeg-*-shared-4.3.zip` to your work dir
 - Copy the following 8 `.dll` files to `pupil_external`
     - `avcodec-58.dll`
     - `avdevice-58.dll`

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -129,7 +129,7 @@ The following steps require you to store dynamic libraries in the `pupil_externa
 
 #### FFMPEG
 
-- Download FFMPEG v4.0 Windows shared binaries from [ffmpeg](http://ffmpeg.zeranoe.com/builds/)
+- Download FFMPEG v4.0 Windows shared binaries from [ffmpeg](https://github.com/BtbN/FFmpeg-Builds/releases)
 - Unzip ffmpeg-shared to your work dir
 - Copy the following 8 `.dll` files to `pupil_external`
     - `avcodec-58.dll`


### PR DESCRIPTION
The window's build binary service, zeranoe, was shut down and a replacement was needed. This is in reference  to issue #2016 