### PR TITLE
Fix eye overlay plugin video file filter

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/recording.py
+++ b/pupil_src/shared_modules/pupil_recording/recording.py
@@ -113,6 +113,9 @@ class PupilRecording:
                 "eye0", "eye1", mode=PupilRecording.FileFilter.FilterMode.UNION
             )
 
+        def eye_id(self, eye_id: int) -> FilterType:
+            return self.filter(f"eye{eye_id}")
+
         def videos(self) -> FilterType:
             return self.filter("videos")
 

--- a/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
@@ -97,15 +97,9 @@ class Eye_Overlay(Observable, Plugin):
         return overlay
 
     def _video_path_for_eye(self, eye_id: int) -> str:
-        rec_dir = self.g_pool.rec_dir
-
-        # Create eye video file filter for eye_id
-        file_filter = PupilRecording.FileFilter(rec_dir)
-        file_filter = file_filter.eye_id(eye_id)
-        file_filter = file_filter.videos()
-
         # Get all eye videos for eye_id
-        eye_videos = list(file_filter)
+        recording = PupilRecording(self.g_pool.rec_dir)
+        eye_videos = list(recording.files().videos().eye_id(eye_id))
 
         if eye_videos:
             return str(eye_videos[0])

--- a/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
+++ b/pupil_src/shared_modules/video_overlay/plugins/eye_overlay.py
@@ -21,6 +21,8 @@ from video_overlay.models.config import Configuration
 from video_overlay.ui.management import UIManagementEyes
 from video_overlay.utils.constraints import ConstraintedValue, BooleanConstraint
 
+from pupil_recording import PupilRecording
+
 
 class Eye_Overlay(Observable, Plugin):
     icon_chr = chr(0xEC02)
@@ -94,14 +96,20 @@ class Eye_Overlay(Observable, Plugin):
         )
         return overlay
 
-    def _video_path_for_eye(self, eye_id):
+    def _video_path_for_eye(self, eye_id: int) -> str:
         rec_dir = self.g_pool.rec_dir
-        video_file_pattern = "eye{}.*".format(eye_id)
-        video_path_pattern = os.path.join(rec_dir, video_file_pattern)
-        try:
-            video_path_candidates = glob.iglob(video_path_pattern)
-            return next(video_path_candidates)
-        except StopIteration:
+
+        # Create eye video file filter for eye_id
+        file_filter = PupilRecording.FileFilter(rec_dir)
+        file_filter = file_filter.eye_id(eye_id)
+        file_filter = file_filter.videos()
+
+        # Get all eye videos for eye_id
+        eye_videos = list(file_filter)
+
+        if eye_videos:
+            return str(eye_videos[0])
+        else:
             return "/not/found/eye{}.mp4".format(eye_id)
 
     def get_init_dict(self):

--- a/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
+++ b/pupil_src/shared_modules/video_overlay/utils/image_manipulation.py
@@ -18,6 +18,10 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+def float_to_int(value: float) -> int:
+    return int(value) if np.isfinite(value) else 0
+
+
 class ImageManipulator(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def apply_to(self, image, parameter, **kwargs):
@@ -73,7 +77,9 @@ class PupilRenderer(ImageManipulator):
     def render_pupil_3d(self, image, pupil_position):
         el = pupil_position["ellipse"]
 
-        conf = int(pupil_position["confidence"] * 255)
+        conf = pupil_position["confidence"] * 255
+        conf = float_to_int(conf)
+
         self.render_ellipse(image, el, color=(0, 0, 255, conf))
 
         if pupil_position["model_confidence"] <= 0.0:
@@ -112,7 +118,8 @@ class PupilRenderer(ImageManipulator):
         outline = [np.asarray(outline, dtype="i")]
         cv2.polylines(image, outline, True, color, thickness=1)
 
-        center = (int(ellipse["center"][0]), int(ellipse["center"][1]))
+        center = ellipse["center"]
+        center = (float_to_int(center[0]), float_to_int(center[1]))
         cv2.circle(image, center, 5, color, thickness=-1)
 
     @staticmethod


### PR DESCRIPTION
This PR fixes issues related to the eye overlay plugin that caused crashes when the confidence value was not valid (`inf` or `nan`). Additionally, it fixes the way this plugin was searching for eye videos in the recordings and was causing it to mistakenly use `eye1.instrinsics` as a video source.

---
[Click-Up Task](https://app.clickup.com/t/8jxww7)
