### PR TITLE
Allow observing of monkey patched methods

### DIFF
--- a/pupil_src/shared_modules/observable.py
+++ b/pupil_src/shared_modules/observable.py
@@ -315,7 +315,9 @@ class _ObservableMethodWrapper:
     def remove_wrapper(self):
         try:
             setattr(
-                self._obj_ref(), self._method_name, self.get_wrapped_bound_method(),
+                self._obj_ref(),
+                self._method_name,
+                self.get_wrapped_bound_method(),
             )
         except ReplaceWrapperError:
             pass

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -520,6 +520,18 @@ class TestWrapperProtectionDescriptor:
         with pytest.raises(ReplaceWrapperError):
             observable.bound_method = 42
 
+    def test_wrappers_not_in_class_cannot_be_set(self, observable):
+        def fake_method(self):
+            pass
+
+        observable.bound_method = types.MethodType(fake_method, observable)
+        observable.add_observer("bound_method", lambda: None)
+
+        # fake_method is not part of FakeObservable, so the installation of the
+        # protection descriptor needs to account for that
+        with pytest.raises(ReplaceWrapperError):
+            observable.bound_method = 42
+
     def test_other_instances_without_wrapper_can_be_set(self, observable):
         observable.add_observer("bound_method", lambda: None)
         unwrapped_observable = FakeObservable()

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -152,7 +152,19 @@ class TestDifferentKindsOfObservers:
         observable.bound_method()
         mock_function.assert_called_once()
 
-    def test_private_method_cannot_be_observer(self, observable):
+    def test_private_method_cannot_be_observer_from_inside(self, observable):
+        class FakeController:
+            def __private_method(self):
+                pass
+
+            def add_private_observer(self, observable):
+                observable.add_observer("bound_method", self.__private_method)
+
+        controller = FakeController()
+        with pytest.raises(TypeError):
+            controller.add_private_observer(observable)
+
+    def test_private_method_cannot_be_observer_from_outside(self, observable):
         class FakeController:
             def __private_method(self):
                 pass

--- a/pupil_src/tests/test_observable.py
+++ b/pupil_src/tests/test_observable.py
@@ -152,6 +152,20 @@ class TestDifferentKindsOfObservers:
         observable.bound_method()
         mock_function.assert_called_once()
 
+    def test_private_method_cannot_be_observer(self, observable):
+        class FakeController:
+            def __private_method(self):
+                pass
+
+        controller = FakeController()
+        with pytest.raises(TypeError):
+            # in your own class you would just write self.__private_method,
+            # but here we need to give the mangled name, otherwise python tries to
+            # access controller._TestDifferentKindsOfObservers__private_method
+            observable.add_observer(
+                "bound_method", controller._FakeController__private_method
+            )
+
 
 class TestObserverCalls:
     def test_observers_are_called_with_the_same_arguments(self, observable):


### PR DESCRIPTION
This PR allows to observe monkey patched methods (you replace or modify method attributes of a class instance s.t. methods are called that were not in the original class definition).

Additionally, the error when trying to add private methods as observers was made a little more explicit.