### PR TITLE
Support for Pye3D rework

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -77,7 +77,6 @@ class Pye3DPlugin(PupilDetectorPlugin):
             # could we return in that case?
             raise RuntimeError("No 2D detection result! Needed for pye3D!")
 
-        datum_2d["raw_edges"] = []
         result = self.detector.update_and_detect(
             datum_2d, frame.gray, debug=self.is_debug_window_open
         )

--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -73,7 +73,8 @@ class Pye3DPlugin(PupilDetectorPlugin):
                 datum_2d = datum
                 break
         else:
-            # TODO: make this more stable!
+            # TODO: Should we handle this more gracefully? Can this even happen? What
+            # could we return in that case?
             raise RuntimeError("No 2D detection result! Needed for pye3D!")
 
         datum_2d["raw_edges"] = []

--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -12,11 +12,10 @@ import logging
 
 from pye3d.detector_3d import Detector3D
 from pyglui import ui
-from matplotlib import pyplot as plt
 import pyqtgraph as pq
 
 from .detector_base_plugin import PupilDetectorPlugin
-from .visualizer_2d import draw_eyeball_outline, draw_pupil_outline
+from .visualizer_2d import draw_eyeball_outline, draw_pupil_outline, draw_ellipse
 from .visualizer_pye3d import Eye_Visualizer
 
 logger = logging.getLogger(__name__)
@@ -109,8 +108,26 @@ class Pye3DPlugin(PupilDetectorPlugin):
     def gl_display(self):
         self.debug_window_update()
         if self._recent_detection_result:
-            draw_eyeball_outline(self._recent_detection_result)
-            draw_pupil_outline(self._recent_detection_result)
+            # draw_eyeball_outline(self._recent_detection_result)
+            # draw_pupil_outline(self._recent_detection_result)
+            result = self._recent_detection_result
+            debug_info = result["debug_info"]
+
+            draw_ellipse(
+                ellipse=debug_info["projected_ultra_long_term"],
+                rgba=(0.5, 0, 0, 1),
+                thickness=2,
+            )
+            draw_ellipse(
+                ellipse=debug_info["projected_long_term"],
+                rgba=(0.8, 0.8, 0, 1),
+                thickness=2,
+            )
+            draw_ellipse(
+                ellipse=debug_info["projected_short_term"],
+                rgba=(0, 1, 0, 1),
+                thickness=2,
+            )
 
     def cleanup(self):
         self.debug_window_close()  # if we change detectors, be sure debug window is also closed

--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -47,9 +47,7 @@ class Pye3DPlugin(PupilDetectorPlugin):
             raise RuntimeError("No 2D detection result! Needed for pye3D!")
 
         datum_2d["raw_edges"] = []
-        result = self.detector.update_and_detect(
-            datum_2d, frame.gray, debug_toggle=self.is_debug_window_open
-        )
+        result = self.detector.update_and_detect(datum_2d, frame.gray, debug=True)
 
         eye_id = self.g_pool.eye_id
         result["timestamp"] = frame.timestamp
@@ -123,5 +121,5 @@ class Pye3DPlugin(PupilDetectorPlugin):
     def debug_window_update(self):
         if self.is_debug_window_open:
             self.debugVisualizer3D.update_window(
-                self.g_pool, self.detector.debug_result
+                self.g_pool, self._recent_detection_result
             )

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
@@ -226,6 +226,29 @@ class Eye_Visualizer(Visualizer):
             alpha=1.0,
         )
 
+        bins = np.array(result["debug_info"]["bins"])
+        print(bins)
+        m = np.max(bins)
+        if m > 0:
+            bins = bins / m
+        px_per_bin = result["debug_info"]["px_per_bin"]
+        w, h = bins.shape
+        for row in range(h):
+            for col in range(w):
+
+                x0 = col * px_per_bin
+                x1 = (col + 1) * px_per_bin
+                y0 = row * px_per_bin
+                y1 = (row + 1) * px_per_bin
+
+                glColor4f(1, 0, 0, bins[row, col])
+                glBegin(GL_QUADS)
+                glVertex3f(x0, y0, 0)
+                glVertex3f(x0, y1, 0)
+                glVertex3f(x1, y1, 0)
+                glVertex3f(x1, y0, 0)
+                glEnd()
+
         glLoadMatrixf(self.get_adjusted_pixel_space_matrix(15))
         self.draw_frustum(self.image_width, self.image_height, self.focal_length)
         glLoadMatrixf(self.get_anthropomorphic_matrix())

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
@@ -226,29 +226,6 @@ class Eye_Visualizer(Visualizer):
             alpha=1.0,
         )
 
-        bins = np.array(result["debug_info"]["bins"])
-        print(bins)
-        m = np.max(bins)
-        if m > 0:
-            bins = bins / m
-        px_per_bin = result["debug_info"]["px_per_bin"]
-        w, h = bins.shape
-        for row in range(h):
-            for col in range(w):
-
-                x0 = col * px_per_bin
-                x1 = (col + 1) * px_per_bin
-                y0 = row * px_per_bin
-                y1 = (row + 1) * px_per_bin
-
-                glColor4f(1, 0, 0, bins[row, col])
-                glBegin(GL_QUADS)
-                glVertex3f(x0, y0, 0)
-                glVertex3f(x0, y1, 0)
-                glVertex3f(x1, y1, 0)
-                glVertex3f(x1, y0, 0)
-                glEnd()
-
         glLoadMatrixf(self.get_adjusted_pixel_space_matrix(15))
         self.draw_frustum(self.image_width, self.image_height, self.focal_length)
         glLoadMatrixf(self.get_anthropomorphic_matrix())


### PR DESCRIPTION
This modifies the Pye3D plugin to be compatible with the latest changes on the Pye3D repository.
Specifically, this was tested with https://github.com/pupil-labs/pye3d-detector/commit/71f8c4fae7463c6d31b1f8f6473aa033f11a664c which is as of now the latest master.

Besides adjusting for the new API, this PR also takes care of resetting the detector if the intrinsics change.