### PR TITLE
Fix an edge case in _fix_negative_time_jumps() when the last TS is zero

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -263,9 +263,25 @@ class Video:
         # TODO: what if adjacent timestamps are negative/zero as well?
         time_diff = np.diff(timestamps)
         invalid_idc = np.flatnonzero(time_diff < 0)
+
+        # Check edge case where last timestamp causes negative jump
+        last_ts_is_invalid = invalid_idc[-1] == timestamps.shape[0] - 2
+        if last_ts_is_invalid:
+            # We cannot calculate the mean of adjacent timestamps as the last timestamp
+            # only has a single neighbour. Therefore, we will exclude it from the
+            # general time interpolation and handle this special case afterward.
+            invalid_idc = invalid_idc[:-1]
+
         timestamps[invalid_idc + 1] = np.mean(
             (timestamps[invalid_idc + 2], timestamps[invalid_idc]), axis=0
         )
+
+        if last_ts_is_invalid:
+            # After fixing all previous timestamps, we will now fix the last one
+            last_minus_two, last_minus_one = timestamps[[-3, -2]]
+            time_diff = last_minus_one - last_minus_two
+            timestamps[-1] = last_minus_one + time_diff
+
         return timestamps
 
 


### PR DESCRIPTION
In recordings previous to #1573, it is possible that recordings include zero-valued timestamps. As a workaround, we introduced #1551. This PR fixes an edge case of this workaround. If the last timestamp is zero, `timestamps[invalid_idc + 2]` causes an index error. As a fix, we handle this edge case separately.