### PR TITLE
Fix FPS drop on macOS for occluded windows

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -577,6 +577,16 @@ def eye(
 
         frame = None
 
+        if platform.system() == "Darwin":
+            # On macOS, calls to glfw.swap_buffers() deliberately take longer in case of
+            # occluded windows, based on the swap interval value. This causes an FPS drop
+            # and leads to problems when recording. To side-step this behaviour, the swap
+            # interval is set to zero.
+            #
+            # Read more about window occlusion on macOS here:
+            # https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/WorkWhenVisible.html
+            glfw.swap_interval(0)
+
         # Event loop
         while not glfw.window_should_close(main_window):
 

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -703,6 +703,16 @@ def world(
         ipc_pub.notify({"subject": "world_process.started"})
         logger.warning("Process started.")
 
+        if platform.system() == "Darwin":
+            # On macOS, calls to glfw.swap_buffers() deliberately take longer in case of
+            # occluded windows, based on the swap interval value. This causes an FPS drop
+            # and leads to problems when recording. To side-step this behaviour, the swap
+            # interval is set to zero.
+            #
+            # Read more about window occlusion on macOS here:
+            # https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/WorkWhenVisible.html
+            glfw.swap_interval(0)
+
         # Event loop
         while not glfw.window_should_close(main_window) and not process_was_interrupted:
 


### PR DESCRIPTION
This PR fixes an issue on macOS that caused FPS drops when the window becomes occluded.

---

[ClickUp Task](https://app.clickup.com/t/7cnn4h)
