### PR TITLE
TS Lookup Table: Return unmodified ts if no invalid ts were found

### DIFF
--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -264,6 +264,10 @@ class Video:
         time_diff = np.diff(timestamps)
         invalid_idc = np.flatnonzero(time_diff < 0)
 
+        has_invalid_idc = invalid_idc.shape[0] > 0
+        if not has_invalid_idc:
+            return timestamps
+
         # Check edge case where last timestamp causes negative jump
         last_ts_is_invalid = invalid_idc[-1] == timestamps.shape[0] - 2
         if last_ts_is_invalid:


### PR DESCRIPTION
Fixes regression in #2026 where `_fix_negative_time_jumps()` would crash with an index error if no invalid_idc were found.

ts =timestamps