### PR TITLE
Add requirements.txt file

### DIFF
--- a/docs/dependencies-macos.md
+++ b/docs/dependencies-macos.md
@@ -67,27 +67,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
 python -m pip install --upgrade pip
-
-pip install cysignals
-pip install cython
-pip install msgpack==0.5.6
-pip install numexpr
-pip install packaging
-pip install psutil
-pip install pyaudio
-pip install pyopengl
-pip install pyzmq
-pip install scikit-learn
-pip install scipy
-pip install glfw
-pip install git+https://github.com/zeromq/pyre
-
-pip install pupil-apriltags
-pip install pupil-detectors
-pip install git+https://github.com/pupil-labs/PyAV
-pip install git+https://github.com/pupil-labs/pyuvc
-pip install git+https://github.com/pupil-labs/pyndsi
-pip install git+https://github.com/pupil-labs/pyglui
+pip install -r requirements.txt
 ```
 
 **NOTE:** Installing **pyglui** might fail on newer versions of **macOS** due to missing OpenGL headers. In this case, you need to install Xcode which comes with the required header files.

--- a/docs/dependencies-macos.md
+++ b/docs/dependencies-macos.md
@@ -62,7 +62,7 @@ make && make install
 
 ### Install Python Libraries
 
-We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil.
+We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil. To install all Python dependencies, you can use the [`requirements.txt`](https://github.com/pupil-labs/pupil/blob/master/requirements.txt) file from the root of the `pupil` repository.
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.

--- a/docs/dependencies-macos.md
+++ b/docs/dependencies-macos.md
@@ -66,7 +66,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip wheel
 pip install -r requirements.txt
 ```
 

--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -152,7 +152,7 @@ sudo ldconfig
 
 ### Install Python Libraries
 
-We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil.
+We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil. To install all Python dependencies, you can use the [`requirements.txt`](https://github.com/pupil-labs/pupil/blob/master/requirements.txt) file from the root of the `pupil` repository.
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.

--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -157,27 +157,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
 python -m pip install --upgrade pip
-
-pip install cysignals
-pip install cython
-pip install msgpack==0.5.6
-pip install numexpr
-pip install packaging
-pip install psutil
-pip install pyaudio
-pip install pyopengl
-pip install pyzmq
-pip install scikit-learn
-pip install scipy
-pip install glfw
-pip install git+https://github.com/zeromq/pyre
-
-pip install pupil-apriltags
-pip install pupil-detectors
-pip install git+https://github.com/pupil-labs/PyAV
-pip install git+https://github.com/pupil-labs/pyuvc
-pip install git+https://github.com/pupil-labs/pyndsi
-pip install git+https://github.com/pupil-labs/pyglui
+pip install -r requirements.txt
 ```
 
 **NOTE**: If you get the error `ImportError: No module named 'cv2'` when trying to run Pupil, please refer to the section [OpenCV Troubleshooting](#opencv-troubleshooting) above.

--- a/docs/dependencies-ubuntu17.md
+++ b/docs/dependencies-ubuntu17.md
@@ -156,7 +156,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip wheel
 pip install -r requirements.txt
 ```
 

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -67,7 +67,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip wheel
 pip install -r requirements.txt
 ```
 

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -63,7 +63,7 @@ sudo udevadm trigger
 
 ### Install Python Libraries
 
-We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil.
+We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil. To install all Python dependencies, you can use the [`requirements.txt`](https://github.com/pupil-labs/pupil/blob/master/requirements.txt) file from the root of the `pupil` repository.
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.

--- a/docs/dependencies-ubuntu18.md
+++ b/docs/dependencies-ubuntu18.md
@@ -68,27 +68,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
 python -m pip install --upgrade pip
-
-pip install cysignals
-pip install cython
-pip install msgpack==0.5.6
-pip install numexpr
-pip install packaging
-pip install psutil
-pip install pyaudio
-pip install pyopengl
-pip install pyzmq
-pip install scikit-learn
-pip install scipy
-pip install glfw
-pip install git+https://github.com/zeromq/pyre
-
-pip install pupil-apriltags
-pip install pupil-detectors
-pip install git+https://github.com/pupil-labs/PyAV
-pip install git+https://github.com/pupil-labs/pyuvc
-pip install git+https://github.com/pupil-labs/pyndsi
-pip install git+https://github.com/pupil-labs/pyglui
+pip install -r requirements.txt
 ```
 
 ### OpenCV Troubleshooting

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -54,7 +54,7 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip wheel
 pip install -r requirements.txt
 ```
 

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -48,10 +48,9 @@ If you downloaded the linked installer:
 - Check the box `Add Python to PATH`. This will add Python to your System PATH Environment Variable.
 - Check the box `Install for all users`. **Note:** By default this will install Python to `C:\Program Files\Python36`. Some build scripts may fail to start Python due to spaces in the path name. So, you may want to consider installing Python to `C:\Python36` instead.
 
-
 ## Install Python Libraries
 
-We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil.
+We recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for running Pupil. To install all Python dependencies, you can use the [`requirements.txt`](https://github.com/pupil-labs/pupil/blob/master/requirements.txt) file from the root of the `pupil` repository.
 
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -58,6 +58,7 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
+**NOTE:** `pyuvc` requires that you download Microsoft Visual C++ 2010 Redistributable from [microsoft](https://www.microsoft.com/en-us/download/details.aspx?id=14632). The `pthreadVC2` lib, which is used by libuvc, depends on `msvcr100.dll`.
 
 ## Modifying Pupil to Work with Windows
 

--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -56,43 +56,9 @@ We recommend using a [virtual environment](https://docs.python.org/3/tutorial/ve
 ```sh
 # Upgrade pip to latest version. This is necessary for some dependencies.
 python -m pip install --upgrade pip
-
-pip install cython
-pip install msgpack==0.5.6
-pip install numexpr
-pip install opencv-python==3.*
-pip install packaging
-pip install psutil
-pip install pyaudio
-pip install pyopengl
-pip install pyzmq
-pip install scikit-learn
-pip install scipy
-pip install glfw
-pip install win_inet_pton
-pip install git+https://github.com/zeromq/pyre
-
-pip install pupil-apriltags
-pip install pupil-detectors
+pip install -r requirements.txt
 ```
 
-## Pupil Labs Python Wheels
-
-In addition to these libraries, you will need to install some Pupil-Labs support libraries. Since building them for Windows is also not automated yet, we provide some prebuilt wheels that you can use. If you want to build the support libraries yourself as well, you will have to look for install instructions on the respective GitHub repositories.
-
-Download the following Python wheels from Pupil Labs github repos:
-
-- [pyglui](https://github.com/pupil-labs/pyglui/releases/latest)
-- [pyav](https://github.com/pupil-labs/pyav/releases/latest)
-- [pyndsi](https://github.com/pupil-labs/pyndsi/releases/latest)
-- [pyuvc](https://github.com/pupil-labs/pyuvc/releases/latest)
-
-`pyuvc` requires that you download Microsoft Visual C++ 2010 Redistributable from [microsoft](https://www.microsoft.com/en-us/download/details.aspx?id=14632). The `pthreadVC2` lib, which is used by libuvc, depends on `msvcr100.dll`.
-
-Open your command prompt and `Run as administrator` in the directory where the wheels are downloaded.
-
-- Install all wheels with `pip install X` (where X is the name of the `.whl` file)
-- You can check that libs are installed with `python import X` statements in the command prompt where `X` is the name of the lib.
 
 ## Modifying Pupil to Work with Windows
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,17 +26,23 @@ pupil-apriltags==1.0.3
 pupil-detectors==1.1.1
 
 # pupil-labs/PyAV 0.4.5
-av @ https://github.com/pupil-labs/PyAV/archive/v0.4.5.zip ; platform_system != "Windows"
+# TODO: Replace the line below with the following:
+# av @ git+https://github.com/pupil-labs/PyAV@v0.4.5 ; platform_system != "Windows"
+# when the branch `add-pyproject` is merged and there is a new release
+av @ git+https://github.com/pupil-labs/PyAV@add-pyproject ; platform_system != "Windows"
 av @ https://github.com/pupil-labs/PyAV/releases/download/v0.4.5/av-0.4.5-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyuvc
-uvc @ https://github.com/pupil-labs/pyuvc/archive/v0.13.zip ; platform_system != "Windows"
+# TODO: Replace the line below with the following:
+# uvc @ git+https://github.com/pupil-labs/pyuvc@v0.13 ; platform_system != "Windows"
+# when there is a new release
+uvc @ git+https://github.com/pupil-labs/pyuvc@master ; platform_system != "Windows"
 uvc @ https://github.com/pupil-labs/pyuvc/releases/download/v0.13/uvc-0.13-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyglui 1.28
-pyglui @ https://github.com/pupil-labs/pyglui/archive/v1.28.zip ; platform_system != "Windows"
+pyglui @ git+https://github.com/pupil-labs/pyglui@v1.28 ; platform_system != "Windows"
 pyglui @ https://github.com/pupil-labs/pyglui/releases/download/v1.28/pyglui-1.28-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyndsi 1.3
-ndsi @ https://github.com/pupil-labs/pyndsi/archive/v1.3.zip ; platform_system != "Windows"
+ndsi @ git+https://github.com/pupil-labs/pyndsi@v1.3 ; platform_system != "Windows"
 ndsi @ https://github.com/pupil-labs/pyndsi/releases/download/v1.3/ndsi-1.3-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyzmq
 scikit-learn
 scipy
 glfw
-git+https://github.com/zeromq/pyre
+pyre @ git+https://github.com/zeromq/pyre
 
 cysignals ; platform_system != "Windows"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,42 @@
+###
+### Third-party
+###
+cython
+msgpack==0.5.6
+numexpr
+packaging
+psutil
+pyaudio
+pyopengl
+pyzmq
+scikit-learn
+scipy
+glfw
+git+https://github.com/zeromq/pyre
+
+cysignals ; platform_system != "Windows"
+
+win_inet_pton ; platform_system == "Windows"
+opencv-python==3.* ; platform_system == "Windows"
+
+###
+### Pupil-Labs
+###
+pupil-apriltags==1.0.3
+pupil-detectors==1.1.1
+
+# pupil-labs/PyAV 0.4.5
+av @ https://github.com/pupil-labs/PyAV/archive/v0.4.5.zip ; platform_system != "Windows"
+av @ https://github.com/pupil-labs/PyAV/releases/download/v0.4.5/av-0.4.5-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+
+# pupil-labs/pyuvc
+uvc @ https://github.com/pupil-labs/pyuvc/archive/v0.13.zip ; platform_system != "Windows"
+uvc @ https://github.com/pupil-labs/pyuvc/releases/download/v0.13/uvc-0.13-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+
+# pupil-labs/pyglui 1.28
+pyglui @ https://github.com/pupil-labs/pyglui/archive/v1.28.zip ; platform_system != "Windows"
+pyglui @ https://github.com/pupil-labs/pyglui/releases/download/v1.28/pyglui-1.28-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+
+# pupil-labs/pyndsi 1.3
+ndsi @ https://github.com/pupil-labs/pyndsi/archive/v1.3.zip ; platform_system != "Windows"
+ndsi @ https://github.com/pupil-labs/pyndsi/releases/download/v1.3/ndsi-1.3-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ av @ git+https://github.com/pupil-labs/PyAV@v0.4.6 ; platform_system != "Windows
 av @ https://github.com/pupil-labs/PyAV/releases/download/v0.4.6/av-0.4.6-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyuvc 0.14
-uvc @ git+https://github.com/pupil-labs/pyuvc@v0.14 ; platform_system != "Windows"
+uvc @ git+https://github.com/pupil-labs/pyuvc@v0.14.1 ; platform_system != "Windows" # Minor patch fixes build issues in pyproject.toml
 uvc @ https://github.com/pupil-labs/pyuvc/releases/download/v0.14/uvc-0.14-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyglui 1.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 cython
 msgpack==0.5.6
 numexpr
-packaging
+packaging>=20.0
 psutil
 pyaudio
 pyopengl

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,24 +25,18 @@ opencv-python==3.* ; platform_system == "Windows"
 pupil-apriltags==1.0.3
 pupil-detectors==1.1.1
 
-# pupil-labs/PyAV 0.4.5
-# TODO: Replace the line below with the following:
-# av @ git+https://github.com/pupil-labs/PyAV@v0.4.5 ; platform_system != "Windows"
-# when the branch `add-pyproject` is merged and there is a new release
-av @ git+https://github.com/pupil-labs/PyAV@add-pyproject ; platform_system != "Windows"
-av @ https://github.com/pupil-labs/PyAV/releases/download/v0.4.5/av-0.4.5-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+# pupil-labs/PyAV 0.4.6
+av @ git+https://github.com/pupil-labs/PyAV@v0.4.6 ; platform_system != "Windows"
+av @ https://github.com/pupil-labs/PyAV/releases/download/v0.4.6/av-0.4.6-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
-# pupil-labs/pyuvc
-# TODO: Replace the line below with the following:
-# uvc @ git+https://github.com/pupil-labs/pyuvc@v0.13 ; platform_system != "Windows"
-# when there is a new release
-uvc @ git+https://github.com/pupil-labs/pyuvc@master ; platform_system != "Windows"
-uvc @ https://github.com/pupil-labs/pyuvc/releases/download/v0.13/uvc-0.13-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+# pupil-labs/pyuvc 0.14
+uvc @ git+https://github.com/pupil-labs/pyuvc@v0.14 ; platform_system != "Windows"
+uvc @ https://github.com/pupil-labs/pyuvc/releases/download/v0.14/uvc-0.14-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
 # pupil-labs/pyglui 1.28
 pyglui @ git+https://github.com/pupil-labs/pyglui@v1.28 ; platform_system != "Windows"
 pyglui @ https://github.com/pupil-labs/pyglui/releases/download/v1.28/pyglui-1.28-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
 
-# pupil-labs/pyndsi 1.3
-ndsi @ git+https://github.com/pupil-labs/pyndsi@v1.3 ; platform_system != "Windows"
-ndsi @ https://github.com/pupil-labs/pyndsi/releases/download/v1.3/ndsi-1.3-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"
+# pupil-labs/pyndsi 1.4
+ndsi @ git+https://github.com/pupil-labs/pyndsi@v1.4 ; platform_system != "Windows"
+ndsi @ https://github.com/pupil-labs/pyndsi/releases/download/v1.4/ndsi-1.4-cp36-cp36m-win_amd64.whl ; platform_system == "Windows"


### PR DESCRIPTION
This PR extracts Python dependencies from the documentation file, and puts them into `requirements.txt` such that it can be used with `pip`.

Tested:
- ✅  Windows
- ✅  Ubuntu
- ✅  macOS

Todo:
- [x] Add `pyproject.toml` to `PyAV` package (https://github.com/pupil-labs/PyAV/pull/25)
- [x] Make a new release for `PyAV`
- [x] Make a new release for `pyndsi`
- [x] Update `requirements.txt` to point to newly released `PyAV` and `pyndsi`


---

[ClickUp](https://app.clickup.com/t/7cvqe3)
