### PR TITLE
remove from module import *

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ jobs:
 
     - name: black formatting check
       language: python
+      # Travis automatically runs `pip install -r requirements.txt` if such a file is present.
+      # Source: https://docs.travis-ci.com/user/languages/python/#dependency-management
+      # Since we do not need the requirements to be installed, we overwrite 
+      install: ~
       before_script:
         - pip install -U pip
         - pip install black

--- a/deployment/deploy_capture/version.py
+++ b/deployment/deploy_capture/version.py
@@ -8,7 +8,8 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.join("../../", "pupil_src", "shared_modules"))
-from version_utils import *
+from version_utils import get_tag_commit, pupil_version, write_version_file

--- a/deployment/deploy_player/version.py
+++ b/deployment/deploy_player/version.py
@@ -8,7 +8,8 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.join("../../", "pupil_src", "shared_modules"))
-from version_utils import *
+from version_utils import get_tag_commit, pupil_version, write_version_file

--- a/deployment/deploy_service/version.py
+++ b/deployment/deploy_service/version.py
@@ -8,7 +8,8 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.join("../../", "pupil_src", "shared_modules"))
-from version_utils import *
+from version_utils import get_tag_commit, pupil_version, write_version_file

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -121,6 +121,8 @@ def eye(
         import numpy as np
         import cv2
 
+        from OpenGL.GL import GL_COLOR_BUFFER_BIT
+
         # display
         import glfw
 
@@ -301,7 +303,7 @@ def eye(
 
             # Always clear buffers on resize to make sure that there are no overlapping
             # artifacts from previous frames.
-            gl_utils.glClear(gl_utils.GL_COLOR_BUFFER_BIT)
+            gl_utils.glClear(GL_COLOR_BUFFER_BIT)
             gl_utils.glClearColor(0, 0, 0, 1)
 
             active_window = glfw.get_current_context()

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -69,6 +69,8 @@ def player(
         # imports
         from file_methods import Persistent_Dict, next_export_sub_dir
 
+        from OpenGL.GL import GL_COLOR_BUFFER_BIT
+
         # display
         import glfw
 
@@ -238,7 +240,7 @@ def player(
 
             # Always clear buffers on resize to make sure that there are no overlapping
             # artifacts from previous frames.
-            gl_utils.glClear(gl_utils.GL_COLOR_BUFFER_BIT)
+            gl_utils.glClear(GL_COLOR_BUFFER_BIT)
             gl_utils.glClearColor(0, 0, 0, 1)
 
             content_scale = gl_utils.get_content_scale(window)

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -116,6 +116,8 @@ def world(
 
         IPCLoggingPatch.ipc_push_url = ipc_push_url
 
+        from OpenGL.GL import GL_COLOR_BUFFER_BIT
+
         # display
         import glfw
 
@@ -380,7 +382,7 @@ def world(
 
             # Always clear buffers on resize to make sure that there are no overlapping
             # artifacts from previous frames.
-            gl_utils.glClear(gl_utils.GL_COLOR_BUFFER_BIT)
+            gl_utils.glClear(GL_COLOR_BUFFER_BIT)
             gl_utils.glClearColor(0, 0, 0, 1)
 
             content_scale = gl_utils.get_content_scale(window)

--- a/pupil_src/shared_modules/gl_utils/__init__.py
+++ b/pupil_src/shared_modules/gl_utils/__init__.py
@@ -9,22 +9,24 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 from .trackball import Trackball
-from .utils import _Rectangle
-from .utils import adjust_gl_view
-from .utils import basic_gl_setup
-from .utils import clear_gl_screen
-from .utils import Coord_System
-from .utils import cvmat_to_glmat
-from .utils import get_content_scale
-from .utils import get_framebuffer_scale
-from .utils import get_monitor_workarea_rect
-from .utils import get_window_frame_size_margins
-from .utils import glClear
-from .utils import glClearColor
-from .utils import glFlush
-from .utils import glViewport
-from .utils import is_window_visible
-from .utils import make_coord_system_norm_based
-from .utils import make_coord_system_pixel_based
-from .utils import window_coordinate_to_framebuffer_coordinate
+from .utils import (
+    _Rectangle,
+    adjust_gl_view,
+    basic_gl_setup,
+    clear_gl_screen,
+    Coord_System,
+    cvmat_to_glmat,
+    get_content_scale,
+    get_framebuffer_scale,
+    get_monitor_workarea_rect,
+    get_window_frame_size_margins,
+    glClear,
+    glClearColor,
+    glFlush,
+    glViewport,
+    is_window_visible,
+    make_coord_system_norm_based,
+    make_coord_system_pixel_based,
+    window_coordinate_to_framebuffer_coordinate,
+)
 from .window_position_manager import WindowPositionManager

--- a/pupil_src/shared_modules/gl_utils/__init__.py
+++ b/pupil_src/shared_modules/gl_utils/__init__.py
@@ -8,7 +8,23 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
-from .utils import *
-from .trackball import *
+from .trackball import Trackball
+from .utils import _Rectangle
+from .utils import adjust_gl_view
+from .utils import basic_gl_setup
+from .utils import clear_gl_screen
+from .utils import Coord_System
+from .utils import cvmat_to_glmat
+from .utils import get_content_scale
+from .utils import get_framebuffer_scale
+from .utils import get_monitor_workarea_rect
+from .utils import get_window_frame_size_margins
+from .utils import glClear
+from .utils import glClearColor
+from .utils import glFlush
+from .utils import glViewport
+from .utils import is_window_visible
+from .utils import make_coord_system_norm_based
+from .utils import make_coord_system_pixel_based
+from .utils import window_coordinate_to_framebuffer_coordinate
 from .window_position_manager import WindowPositionManager

--- a/pupil_src/shared_modules/gl_utils/trackball.py
+++ b/pupil_src/shared_modules/gl_utils/trackball.py
@@ -8,14 +8,16 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-from OpenGL.GL import GL_MODELVIEW
-from OpenGL.GL import GL_PROJECTION
-from OpenGL.GL import glLoadIdentity
-from OpenGL.GL import glMatrixMode
-from OpenGL.GL import glPopMatrix
-from OpenGL.GL import glPushMatrix
-from OpenGL.GL import glRotatef
-from OpenGL.GL import glTranslatef
+from OpenGL.GL import (
+    GL_MODELVIEW,
+    GL_PROJECTION,
+    glLoadIdentity,
+    glMatrixMode,
+    glPopMatrix,
+    glPushMatrix,
+    glRotatef,
+    glTranslatef,
+)
 from OpenGL.GLU import gluPerspective
 
 

--- a/pupil_src/shared_modules/gl_utils/trackball.py
+++ b/pupil_src/shared_modules/gl_utils/trackball.py
@@ -8,8 +8,14 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
-from OpenGL.GL import *
+from OpenGL.GL import GL_MODELVIEW
+from OpenGL.GL import GL_PROJECTION
+from OpenGL.GL import glLoadIdentity
+from OpenGL.GL import glMatrixMode
+from OpenGL.GL import glPopMatrix
+from OpenGL.GL import glPushMatrix
+from OpenGL.GL import glRotatef
+from OpenGL.GL import glTranslatef
 from OpenGL.GLU import gluPerspective
 
 

--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -15,30 +15,31 @@ import typing as T
 import glfw
 import numpy as np
 import OpenGL.error
-from OpenGL.GL import GL_BLEND
-from OpenGL.GL import GL_COLOR_BUFFER_BIT
-from OpenGL.GL import GL_LINE_SMOOTH
-from OpenGL.GL import GL_MODELVIEW
-from OpenGL.GL import GL_NO_ERROR
-from OpenGL.GL import GL_ONE_MINUS_SRC_ALPHA
-from OpenGL.GL import GL_POINT_SPRITE
-from OpenGL.GL import GL_PROJECTION
-from OpenGL.GL import GL_SRC_ALPHA
-from OpenGL.GL import GL_VERTEX_PROGRAM_POINT_SIZE
-from OpenGL.GL import glBlendFunc
-from OpenGL.GL import glClear
-from OpenGL.GL import glClearColor
-from OpenGL.GL import glEnable
-from OpenGL.GL import glFlush
-from OpenGL.GL import glGetError
-from OpenGL.GL import glLoadIdentity
-from OpenGL.GL import glMatrixMode
-from OpenGL.GL import glOrtho
-from OpenGL.GL import glPopMatrix
-from OpenGL.GL import glPushMatrix
-from OpenGL.GL import glViewport
-from OpenGL.GLU import gluErrorString
-from OpenGL.GLU import gluPerspective
+from OpenGL.GL import (
+    GL_BLEND,
+    GL_COLOR_BUFFER_BIT,
+    GL_LINE_SMOOTH,
+    GL_MODELVIEW,
+    GL_NO_ERROR,
+    GL_ONE_MINUS_SRC_ALPHA,
+    GL_POINT_SPRITE,
+    GL_PROJECTION,
+    GL_SRC_ALPHA,
+    GL_VERTEX_PROGRAM_POINT_SIZE,
+    glBlendFunc,
+    glClear,
+    glClearColor,
+    glEnable,
+    glFlush,
+    glGetError,
+    glLoadIdentity,
+    glMatrixMode,
+    glOrtho,
+    glPopMatrix,
+    glPushMatrix,
+    glViewport,
+)
+from OpenGL.GLU import gluErrorString, gluPerspective
 
 glfw.ERROR_REPORTING = "raise"
 

--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -12,13 +12,33 @@ import logging
 import math
 import typing as T
 
-import numpy as np
-import OpenGL
-import OpenGL.error
-from OpenGL.GL import *
-from OpenGL.GLU import gluPerspective, gluErrorString
-
 import glfw
+import numpy as np
+import OpenGL.error
+from OpenGL.GL import GL_BLEND
+from OpenGL.GL import GL_COLOR_BUFFER_BIT
+from OpenGL.GL import GL_LINE_SMOOTH
+from OpenGL.GL import GL_MODELVIEW
+from OpenGL.GL import GL_NO_ERROR
+from OpenGL.GL import GL_ONE_MINUS_SRC_ALPHA
+from OpenGL.GL import GL_POINT_SPRITE
+from OpenGL.GL import GL_PROJECTION
+from OpenGL.GL import GL_SRC_ALPHA
+from OpenGL.GL import GL_VERTEX_PROGRAM_POINT_SIZE
+from OpenGL.GL import glBlendFunc
+from OpenGL.GL import glClear
+from OpenGL.GL import glClearColor
+from OpenGL.GL import glEnable
+from OpenGL.GL import glFlush
+from OpenGL.GL import glGetError
+from OpenGL.GL import glLoadIdentity
+from OpenGL.GL import glMatrixMode
+from OpenGL.GL import glOrtho
+from OpenGL.GL import glPopMatrix
+from OpenGL.GL import glPushMatrix
+from OpenGL.GL import glViewport
+from OpenGL.GLU import gluErrorString
+from OpenGL.GLU import gluPerspective
 
 glfw.ERROR_REPORTING = "raise"
 

--- a/pupil_src/shared_modules/marker_auto_trim_marks.py
+++ b/pupil_src/shared_modules/marker_auto_trim_marks.py
@@ -8,7 +8,6 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
 import logging
 
 logger = logging.getLogger(__name__)
@@ -21,7 +20,8 @@ from ctypes import c_int
 from pyglui import ui
 from gl_utils import adjust_gl_view, clear_gl_screen, basic_gl_setup, cvmat_to_glmat
 from pyglui.cygl.utils import RGBA, draw_points, draw_polyline
-from OpenGL.GL import *
+from OpenGL.GL import (GL_LINES, GL_MODELVIEW, GL_PROJECTION, glLoadIdentity, glMatrixMode,
+                       glPopMatrix, glPushMatrix, glTranslatef)
 
 import glfw
 

--- a/pupil_src/shared_modules/marker_auto_trim_marks.py
+++ b/pupil_src/shared_modules/marker_auto_trim_marks.py
@@ -20,8 +20,16 @@ from ctypes import c_int
 from pyglui import ui
 from gl_utils import adjust_gl_view, clear_gl_screen, basic_gl_setup, cvmat_to_glmat
 from pyglui.cygl.utils import RGBA, draw_points, draw_polyline
-from OpenGL.GL import (GL_LINES, GL_MODELVIEW, GL_PROJECTION, glLoadIdentity, glMatrixMode,
-                       glPopMatrix, glPushMatrix, glTranslatef)
+from OpenGL.GL import (
+    GL_LINES,
+    GL_MODELVIEW,
+    GL_PROJECTION,
+    glLoadIdentity,
+    glMatrixMode,
+    glPopMatrix,
+    glPushMatrix,
+    glTranslatef,
+)
 
 import glfw
 

--- a/pupil_src/shared_modules/math_helper/__init__.py
+++ b/pupil_src/shared_modules/math_helper/__init__.py
@@ -8,6 +8,4 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
-from .intersections import *
-from .transformations import *
+from .intersections import nearest_intersection

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_3d.py
@@ -8,14 +8,20 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
+import math
 
-from visualizer import Visualizer
-from OpenGL.GL import *
+import numpy as np
+from gl_utils.trackball import Trackball
+from OpenGL.GL import GL_LINES
+from OpenGL.GL import GL_MODELVIEW
+from OpenGL.GL import GL_TRIANGLE_FAN
+from OpenGL.GL import glLoadMatrixf
+from OpenGL.GL import glMatrixMode
+from OpenGL.GL import glPopMatrix
+from OpenGL.GL import glPushMatrix
 from pyglui.cygl import utils as glutils
 from pyglui.cygl.utils import RGBA
-from gl_utils.trackball import Trackball
-import numpy as np
-import math
+from visualizer import Visualizer
 
 
 def get_perpendicular_vector(v):

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_3d.py
@@ -12,13 +12,15 @@ import math
 
 import numpy as np
 from gl_utils.trackball import Trackball
-from OpenGL.GL import GL_LINES
-from OpenGL.GL import GL_MODELVIEW
-from OpenGL.GL import GL_TRIANGLE_FAN
-from OpenGL.GL import glLoadMatrixf
-from OpenGL.GL import glMatrixMode
-from OpenGL.GL import glPopMatrix
-from OpenGL.GL import glPushMatrix
+from OpenGL.GL import (
+    GL_LINES,
+    GL_MODELVIEW,
+    GL_TRIANGLE_FAN,
+    glLoadMatrixf,
+    glMatrixMode,
+    glPopMatrix,
+    glPushMatrix,
+)
 from pyglui.cygl import utils as glutils
 from pyglui.cygl.utils import RGBA
 from visualizer import Visualizer

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
@@ -13,23 +13,25 @@ from collections import deque
 
 import numpy as np
 from gl_utils.trackball import Trackball
-from OpenGL.GL import GL_LINES
-from OpenGL.GL import GL_MODELVIEW
-from OpenGL.GL import GL_PROJECTION
-from OpenGL.GL import GL_QUADS
-from OpenGL.GL import glBegin
-from OpenGL.GL import glColor4f
-from OpenGL.GL import glEnd
-from OpenGL.GL import glLineWidth
-from OpenGL.GL import glLoadIdentity
-from OpenGL.GL import glLoadMatrixf
-from OpenGL.GL import glMatrixMode
-from OpenGL.GL import glOrtho
-from OpenGL.GL import glPopMatrix
-from OpenGL.GL import glPushMatrix
-from OpenGL.GL import glScale
-from OpenGL.GL import glTranslatef
-from OpenGL.GL import glVertex3f
+from OpenGL.GL import (
+    GL_LINES,
+    GL_MODELVIEW,
+    GL_PROJECTION,
+    GL_QUADS,
+    glBegin,
+    glColor4f,
+    glEnd,
+    glLineWidth,
+    glLoadIdentity,
+    glLoadMatrixf,
+    glMatrixMode,
+    glOrtho,
+    glPopMatrix,
+    glPushMatrix,
+    glScale,
+    glTranslatef,
+    glVertex3f,
+)
 from pye3d.geometry.eye import LeGrandEye
 from pyglui.cygl import utils as glutils
 from pyglui.cygl.utils import RGBA

--- a/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/visualizer_pye3d.py
@@ -9,17 +9,31 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 import math
+from collections import deque
 
 import numpy as np
-from OpenGL.GL import *
 from gl_utils.trackball import Trackball
+from OpenGL.GL import GL_LINES
+from OpenGL.GL import GL_MODELVIEW
+from OpenGL.GL import GL_PROJECTION
+from OpenGL.GL import GL_QUADS
+from OpenGL.GL import glBegin
+from OpenGL.GL import glColor4f
+from OpenGL.GL import glEnd
+from OpenGL.GL import glLineWidth
+from OpenGL.GL import glLoadIdentity
+from OpenGL.GL import glLoadMatrixf
+from OpenGL.GL import glMatrixMode
+from OpenGL.GL import glOrtho
+from OpenGL.GL import glPopMatrix
+from OpenGL.GL import glPushMatrix
+from OpenGL.GL import glScale
+from OpenGL.GL import glTranslatef
+from OpenGL.GL import glVertex3f
+from pye3d.geometry.eye import LeGrandEye
 from pyglui.cygl import utils as glutils
 from pyglui.cygl.utils import RGBA
 from visualizer import Visualizer
-
-from pye3d.geometry.eye import LeGrandEye
-
-from collections import deque
 
 
 class Eye_Visualizer(Visualizer):

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -15,6 +15,8 @@ import socket
 
 import numpy as np
 
+from OpenGL.GL import GL_COLOR_BUFFER_BIT
+
 import glfw
 
 glfw.ERROR_REPORTING = "raise"
@@ -79,7 +81,7 @@ class Service_UI(System_Plugin_Base):
         def on_resize(window, w, h):
             # Always clear buffers on resize to make sure that there are no overlapping
             # artifacts from previous frames.
-            gl_utils.glClear(gl_utils.GL_COLOR_BUFFER_BIT)
+            gl_utils.glClear(GL_COLOR_BUFFER_BIT)
             gl_utils.glClearColor(0, 0, 0, 1)
 
             self.window_size = w, h

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -8,13 +8,19 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
 import glfw
 
 glfw.ERROR_REPORTING = "raise"
 
 import gl_utils
-from OpenGL.GL import *
+from OpenGL.GL import (GL_BLEND, GL_COLOR_BUFFER_BIT, GL_LINES, GL_LINE_LOOP, GL_LINE_SMOOTH,
+                       GL_LINE_SMOOTH_HINT, GL_LINE_STRIP, GL_MODELVIEW, GL_NICEST,
+                       GL_ONE_MINUS_SRC_ALPHA, GL_POINT_SPRITE, GL_POLYGON_SMOOTH,
+                       GL_POLYGON_SMOOTH_HINT, GL_PROJECTION, GL_SRC_ALPHA,
+                       GL_VERTEX_PROGRAM_POINT_SIZE, glBegin, glBlendFunc, glClear, glClearColor,
+                       glColor3f, glColor4f, glEnable, glEnd, glHint, glLineWidth, glLoadIdentity,
+                       glMatrixMode, glOrtho, glPopMatrix, glPushMatrix, glScale, glTranslatef,
+                       glVertex3f, glViewport)
 from platform import system
 
 from pyglui.cygl.utils import RGBA

--- a/pupil_src/shared_modules/visualizer.py
+++ b/pupil_src/shared_modules/visualizer.py
@@ -13,14 +13,43 @@ import glfw
 glfw.ERROR_REPORTING = "raise"
 
 import gl_utils
-from OpenGL.GL import (GL_BLEND, GL_COLOR_BUFFER_BIT, GL_LINES, GL_LINE_LOOP, GL_LINE_SMOOTH,
-                       GL_LINE_SMOOTH_HINT, GL_LINE_STRIP, GL_MODELVIEW, GL_NICEST,
-                       GL_ONE_MINUS_SRC_ALPHA, GL_POINT_SPRITE, GL_POLYGON_SMOOTH,
-                       GL_POLYGON_SMOOTH_HINT, GL_PROJECTION, GL_SRC_ALPHA,
-                       GL_VERTEX_PROGRAM_POINT_SIZE, glBegin, glBlendFunc, glClear, glClearColor,
-                       glColor3f, glColor4f, glEnable, glEnd, glHint, glLineWidth, glLoadIdentity,
-                       glMatrixMode, glOrtho, glPopMatrix, glPushMatrix, glScale, glTranslatef,
-                       glVertex3f, glViewport)
+from OpenGL.GL import (
+    GL_BLEND,
+    GL_COLOR_BUFFER_BIT,
+    GL_LINES,
+    GL_LINE_LOOP,
+    GL_LINE_SMOOTH,
+    GL_LINE_SMOOTH_HINT,
+    GL_LINE_STRIP,
+    GL_MODELVIEW,
+    GL_NICEST,
+    GL_ONE_MINUS_SRC_ALPHA,
+    GL_POINT_SPRITE,
+    GL_POLYGON_SMOOTH,
+    GL_POLYGON_SMOOTH_HINT,
+    GL_PROJECTION,
+    GL_SRC_ALPHA,
+    GL_VERTEX_PROGRAM_POINT_SIZE,
+    glBegin,
+    glBlendFunc,
+    glClear,
+    glClearColor,
+    glColor3f,
+    glColor4f,
+    glEnable,
+    glEnd,
+    glHint,
+    glLineWidth,
+    glLoadIdentity,
+    glMatrixMode,
+    glOrtho,
+    glPopMatrix,
+    glPushMatrix,
+    glScale,
+    glTranslatef,
+    glVertex3f,
+    glViewport,
+)
 from platform import system
 
 from pyglui.cygl.utils import RGBA


### PR DESCRIPTION
Removed from module import * as mentioned in issue #1986. 

If this merge is without any bugs this can be further improved by removing:

- deployment/deploy_capture/version.py
- deployment/deploy_player/version.py
- deployment/deploy_service/version.py

since these are only used to import pupil_src/shared_modules/version_utils.py to different location