### PR TITLE
Fix Travis black tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ jobs:
 
     - name: black formatting check
       language: python
+      # Travis automatically runs `pip install -r requirements.txt` if such a file is present.
+      # Source: https://docs.travis-ci.com/user/languages/python/#dependency-management
+      # Since we do not need the requirements to be installed, we overwrite 
+      install: ~
       before_script:
         - pip install -U pip
         - pip install black


### PR DESCRIPTION
[Travis automatically runs `pip install -r requirements.txt` if such a file is present.](https://docs.travis-ci.com/user/languages/python/#dependency-management). Since we do not need the requirements to be installed, we need to explicitly overwrite the `install` command.