### PR TITLE
reduce calls to glfw.window_should_close to screen fps for performance

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -588,7 +588,8 @@ def eye(
             glfw.swap_interval(0)
 
         # Event loop
-        while not glfw.window_should_close(main_window):
+        window_should_close = False
+        while not window_should_close:
 
             if notify_sub.new_data:
                 t, notification = notify_sub.recv()
@@ -740,6 +741,7 @@ def eye(
                 if is_window_visible(main_window):
                     consume_events_and_render_buffer()
                 glfw.poll_events()
+                window_should_close = glfw.window_should_close(main_window)
 
         # END while running
 


### PR DESCRIPTION
Just made a minor change to avoid calling `glfw.window_should_close` in the main event-loop, but rather in the screen-updating-loop at a lower rate. I noticed while profiling that these accumulated calls uses a significant amount of CPU time in comparison to the rest (~7%). It seems to me that checking if the window should be closed at a frequency higher than screen refresh is not necessary.

(PS: I am trying to deal with a GigEVision camera with high-framerate (250+fps) and 640x480 resolution, trying to dump the video for recording, so I am really trying to save as many CPU cycles as possible. I do not have the regular pupil headset, so I cannot check if that occurs in the more regular setting.)
