### PR TITLE
Flip gaze with negative z-component

### DIFF
--- a/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_headset.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_headset.py
@@ -157,6 +157,10 @@ class Model3D_Monocular(Model3D):
         gaze_3d = self._toWorld(gaze_point)
         normal_3d = np.dot(self.rotation_matrix, pupil_normal)
 
+        # Check if gaze is in front of camera. If it is not, flip direction.
+        if gaze_3d[-1] < 0:
+            gaze_3d *= -1.0
+
         g = {
             "eye_center_3d": eye_center.tolist(),
             "gaze_normal_3d": normal_3d.tolist(),
@@ -283,6 +287,10 @@ class Model3D_Binocular(Model3D):
 
         if nearest_intersection_point is None:
             return None
+
+        # Check if gaze is in front of camera. If it is not, flip direction.
+        if nearest_intersection_point[-1] < 0:
+            nearest_intersection_point *= -1.0
 
         g = {
             "eye_centers_3d": {0: s0_center.tolist(), 1: s1_center.tolist()},


### PR DESCRIPTION
In order to estimate the `gaze_point_3d`, we calculate the nearest intersection between the `gaze_normal`s. If these are nearly parallel and there is some noise, it is possible that the estimate is actually behind the scene camera. Until now, this case has not been explicitly been handled.

Unfortunately, when using the fixation detector with `gaze_point_3d` input, it is possible that such an estimate breaks a larger fixation into multiple smaller ones. 

Hmd-eyes has been handling this case [by flipping the `gaze_point_3d`](https://github.com/pupil-labs/hmd-eyes/blob/master/plugin/Scripts/GazeData.cs#L182-L187) in case it lies behind the camera.

With this PR, we start applying this flipping strategy directly in the gazer, before publishing the gaze data.