### PR TITLE
pye3d_plugin: Support specific pye3d version 0.0.1 only

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -10,6 +10,7 @@ See COPYING and COPYING.LESSER for license details.
 """
 import logging
 
+import pye3d
 from pye3d.detector_3d import Detector3D, CameraModel
 from pyglui import ui
 
@@ -18,6 +19,16 @@ from .visualizer_2d import draw_eyeball_outline, draw_pupil_outline, draw_ellips
 from .visualizer_pye3d import Eye_Visualizer
 
 logger = logging.getLogger(__name__)
+
+version_installed = getattr(pye3d, "__version__", "0.0.1")
+version_supported = "0.0.1"
+
+if version_installed != version_supported:
+    logger.info(
+        f"Requires pye3d version {version_supported} "
+        f"(Installed: {version_installed})"
+    )
+    raise ImportError
 
 
 class Pye3DPlugin(PupilDetectorPlugin):


### PR DESCRIPTION
As there will be backward-incompatible changes to https://github.com/pupil-labs/pye3d-detector/, we pin the supported version to the current version to avoid any future issues.