### PR TITLE
Fix minimizing 3d detector debug window on Windows OS

### DIFF
--- a/pupil_src/shared_modules/gl_utils/trackball.py
+++ b/pupil_src/shared_modules/gl_utils/trackball.py
@@ -62,6 +62,9 @@ class Trackball(object):
         self.distance[2] += dy
 
     def set_window_size(self, w, h):
+        h = max(h, 1)
+        w = max(w, 1)
+
         self.aspect = float(w) / h
         self.window = w, h
 


### PR DESCRIPTION
Issue reported on [Discord](https://discord.com/channels/285728493612957698/285728493612957698/775366466496888839).

Traceback provided via email
```py
2020-11-09 10:01:22,385 - eye0 - [ERROR] launchables.eye: Process Eye0 crashed with trace:
Traceback (most recent call last):
  File "launchables\eye.py", line 731, in eye
  File "site-packages\glfw\__init__.py", line 1772, in poll_events
  File "site-packages\glfw\__init__.py", line 632, in errcheck
  File "site-packages\glfw\__init__.py", line 54, in _reraise
  File "site-packages\glfw\__init__.py", line 611, in callback_wrapper
  File "shared_modules\pupil_detector_plugins\visualizer_3d.py", line 290, in on_resize
  File "shared_modules\gl_utils\trackball.py", line 57, in set_window_size
ZeroDivisionError: float division by zero
```

- Cause: On Windows OS, the window size becomes zero in both dimensions when then window is minimized
- Fix: Assume a minimum height/width of 1. [Precedence](https://github.com/pupil-labs/pupil/blob/859c766829b369dbfbe92073d3ab9d7c355f7043/pupil_src/shared_modules/visualizer.py#L252-L253).