### PR TITLE
Support Pupil Invisible recording format v1.4

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -29,7 +29,7 @@ from version_utils import parse_version
 
 logger = logging.getLogger(__name__)
 
-NEWEST_SUPPORTED_VERSION = parse_version("1.3")
+NEWEST_SUPPORTED_VERSION = parse_version("1.4")
 
 
 def transform_invisible_to_corresponding_new_style(rec_dir: str):


### PR DESCRIPTION
This new recording format has been introduced in Pupil Companion 1.0.0.
This version provides support for the OnePus 8 and Android 11.

On the OnePlus 8, eye videos will be h264-encoded which is why a
recording format bump was necessary. Pupil Player is already able to handle
these. Therefore, a simple version bump is necessary to support the new
recording format.