### PR TITLE
HMD Streaming: Support custom receiver high-water mark and set default value from None to 1

### DIFF
--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -134,7 +134,7 @@ class HMD_Streaming_Source(Base_Source):
             self.g_pool.zmq_ctx,
             self.g_pool.ipc_sub_url,
             topics=self.__topics,
-            hwm=self.__hwm
+            hwm=self.__hwm,
         )
 
     def get_init_dict(self):

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -124,7 +124,7 @@ FRAME_CLASS_BY_FORMAT = {"rgb": RGBFrame, "bgr": BGRFrame, "gray": GrayFrame}
 class HMD_Streaming_Source(Base_Source):
     name = "HMD Streaming"
 
-    def __init__(self, g_pool, topics=("hmd_streaming.world",), hwm=None, *args, **kwargs):
+    def __init__(self, g_pool, topics=("hmd_streaming.world",), hwm=1, *args, **kwargs):
         super().__init__(g_pool, *args, **kwargs)
         self.fps = 30
         self.projection_matrix = None

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -128,11 +128,15 @@ class HMD_Streaming_Source(Base_Source):
         super().__init__(g_pool, *args, **kwargs)
         self.fps = 30
         self.projection_matrix = None
+        self.hwm = None
+        if "hwm" in kwargs:
+            self.hwm = kwargs.get("hwm")
         self.__topics = topics
         self.frame_sub = zmq_tools.Msg_Receiver(
             self.g_pool.zmq_ctx,
             self.g_pool.ipc_sub_url,
             topics=self.__topics,
+            hwm=self.hwm
         )
 
     def get_init_dict(self):

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -124,12 +124,12 @@ FRAME_CLASS_BY_FORMAT = {"rgb": RGBFrame, "bgr": BGRFrame, "gray": GrayFrame}
 class HMD_Streaming_Source(Base_Source):
     name = "HMD Streaming"
 
-    def __init__(self, g_pool, topics=("hmd_streaming.world",), *args, **kwargs):
+    def __init__(self, g_pool, hwm=None, topics=("hmd_streaming.world",), *args, **kwargs):
         super().__init__(g_pool, *args, **kwargs)
         self.fps = 30
         self.projection_matrix = None
         self.__topics = topics
-        self.__hwm = None
+        self.__hwm = hwm
         if "hwm" in kwargs:
             self.__hwm = kwargs.get("hwm")
         self.frame_sub = zmq_tools.Msg_Receiver(

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -130,8 +130,6 @@ class HMD_Streaming_Source(Base_Source):
         self.projection_matrix = None
         self.__topics = topics
         self.__hwm = hwm
-        if "hwm" in kwargs:
-            self.__hwm = kwargs.get("hwm")
         self.frame_sub = zmq_tools.Msg_Receiver(
             self.g_pool.zmq_ctx,
             self.g_pool.ipc_sub_url,

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -128,20 +128,21 @@ class HMD_Streaming_Source(Base_Source):
         super().__init__(g_pool, *args, **kwargs)
         self.fps = 30
         self.projection_matrix = None
-        self.hwm = None
-        if "hwm" in kwargs:
-            self.hwm = kwargs.get("hwm")
         self.__topics = topics
+        self.__hwm = None
+        if "hwm" in kwargs:
+            self.__hwm = kwargs.get("hwm")
         self.frame_sub = zmq_tools.Msg_Receiver(
             self.g_pool.zmq_ctx,
             self.g_pool.ipc_sub_url,
             topics=self.__topics,
-            hwm=self.hwm
+            hwm=self.__hwm
         )
 
     def get_init_dict(self):
         init_dict = super().get_init_dict()
         init_dict["topics"] = self.__topics
+        init_dict["hwm"] = self.__hwm
         return init_dict
 
     def cleanup(self):

--- a/pupil_src/shared_modules/video_capture/hmd_streaming.py
+++ b/pupil_src/shared_modules/video_capture/hmd_streaming.py
@@ -124,7 +124,7 @@ FRAME_CLASS_BY_FORMAT = {"rgb": RGBFrame, "bgr": BGRFrame, "gray": GrayFrame}
 class HMD_Streaming_Source(Base_Source):
     name = "HMD Streaming"
 
-    def __init__(self, g_pool, hwm=None, topics=("hmd_streaming.world",), *args, **kwargs):
+    def __init__(self, g_pool, topics=("hmd_streaming.world",), hwm=None, *args, **kwargs):
         super().__init__(g_pool, *args, **kwargs)
         self.fps = 30
         self.projection_matrix = None


### PR DESCRIPTION
Forwards an HWM argument from HMD_Streaming_Source to Msg_Receiver (which has a hmw=None argument already).