### PR TITLE
Close eye window on crash

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -814,10 +814,10 @@ def eye(
             plugin.alive = False
         g_pool.plugins.clean()
 
-        glfw.destroy_window(main_window)
-        g_pool.gui.terminate()
-        glfw.terminate()
-        logger.info("Process shutting down.")
+    glfw.destroy_window(main_window)
+    g_pool.gui.terminate()
+    glfw.terminate()
+    logger.info("Process shutting down.")
 
 
 def eye_profiled(


### PR DESCRIPTION
Currently, if the eye process crashes due to a faulty plugin, the window will remain opened, but unresponsive (at least on macOS).

This PR will close the window and terminate glfw even if an error occurs, effectively closing the window in any case.