### PR TITLE
Make model_id optional for pupil 3d raw data export

### DIFF
--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -296,7 +296,6 @@ class Pupil_Positions_Exporter(_Base_Positions_Exporter):
         try:
             diameter_3d = raw_value["diameter_3d"]
             model_confidence = raw_value["model_confidence"]
-            model_id = raw_value["model_id"]
             sphere_center = raw_value["sphere"]["center"]
             sphere_radius = raw_value["sphere"]["radius"]
             circle_3d_center = raw_value["circle_3d"]["center"]
@@ -310,7 +309,6 @@ class Pupil_Positions_Exporter(_Base_Positions_Exporter):
         except KeyError:
             diameter_3d = None
             model_confidence = None
-            model_id = None
             sphere_center = [None, None, None]
             sphere_radius = None
             circle_3d_center = [None, None, None]
@@ -321,6 +319,9 @@ class Pupil_Positions_Exporter(_Base_Positions_Exporter):
             projected_sphere_center = [None, None]
             projected_sphere_axis = [None, None]
             projected_sphere_angle = None
+
+        # pye3d no longer includes this field. Keeping for backwards-compatibility.
+        model_id = raw_value.get("model_id", None)
 
         return {
             # 2d data


### PR DESCRIPTION
pye3d no longer includes this field. Previously, this would result
in all 3d outputs being empty. This PR changes continues to export
all 3d fields, even if this one is not present.