### PR TITLE
main: Pass parent_application to eye process

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -65,6 +65,7 @@ def eye(
     hide_ui=False,
     debug=False,
     pub_socket_hwm=None,
+    parent_application="capture",
 ):
     """reads eye video and detects the pupil.
 
@@ -190,7 +191,7 @@ def eye(
         g_pool.debug = debug
         g_pool.user_dir = user_dir
         g_pool.version = version
-        g_pool.app = "capture"
+        g_pool.app = parent_application
         g_pool.eye_id = eye_id
         g_pool.process = f"eye{eye_id}"
         g_pool.timebase = timebase
@@ -833,6 +834,7 @@ def eye_profiled(
     hide_ui=False,
     debug=False,
     pub_socket_hwm=None,
+    parent_application="capture",
 ):
     import cProfile
     import subprocess
@@ -840,7 +842,23 @@ def eye_profiled(
     from .eye import eye
 
     cProfile.runctx(
-        "eye(timebase, is_alive_flag,ipc_pub_url,ipc_sub_url,ipc_push_url, user_dir, version, eye_id, overwrite_cap_settings, hide_ui, debug)",
+        (
+            "eye("
+            "timebase, "
+            "is_alive_flag, "
+            "ipc_pub_url, "
+            "ipc_sub_url, "
+            "ipc_push_url, "
+            "user_dir, "
+            "version, "
+            "eye_id, "
+            "overwrite_cap_settings, "
+            "hide_ui, "
+            "debug, "
+            "pub_socket_hwm, "
+            "parent_application, "
+            ")"
+        ),
         {
             "timebase": timebase,
             "is_alive_flag": is_alive_flag,
@@ -854,6 +872,7 @@ def eye_profiled(
             "hide_ui": hide_ui,
             "debug": debug,
             "pub_socket_hwm": pub_socket_hwm,
+            "parent_application": parent_application,
         },
         locals(),
         "eye{}.pstats".format(eye_id),

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -310,6 +310,7 @@ def launcher():
                             parsed_args.hide_ui,
                             parsed_args.debug,
                             n.get("pub_socket_hwm"),
+                            parsed_args.app,  # parent_application
                         ),
                     ).start()
                 elif "notify.player_process.should_start" in topic:


### PR DESCRIPTION
Until there is no way for the eye process to detect if it runs
within Pupil Capture, Player, or Service. This PR passes this info
explicitly to the process which stores it in `g_pool.app`