### PR TITLE
add missing launcher_process.should_stop handling

### DIFF
--- a/docs/dependencies-windows.md
+++ b/docs/dependencies-windows.md
@@ -90,7 +90,7 @@ The following steps require you to store dynamic libraries in the `pupil_externa
 
 #### FFMPEG
 
-- [Download FFMPEG v4.0 Windows **shared** binaries](https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2020-10-12-12-31/ffmpeg-n4.3.1-20-g8a2acdc6da-win64-lgpl-shared-4.3.zip)
+- [Download FFMPEG v4.3 Windows **shared** binaries](https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2020-12-08-13-03/ffmpeg-n4.3.1-26-gca55240b8c-win64-lgpl-shared-4.3.zip)
 - Unzip `ffmpeg-*-shared-4.3.zip` to your work dir
 - Copy the following 8 `.dll` files to `pupil_external`
     - `avcodec-58.dll`

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -392,6 +392,14 @@ def launcher():
                             "doc": launcher.__doc__,
                         }
                     )
+                elif "notify.launcher_process.should_stop":
+                    if parsed_args.app == "capture":
+                        cmd_push.notify({"subject": "world_process.should_stop"})
+                    elif parsed_args.app == "service":
+                        cmd_push.notify({"subject": "service_process.should_stop"})
+                    elif parsed_args.app == "player":
+                        cmd_push.notify({"subject": "player_process.should_stop"})
+
             else:
                 if not active_children():
                     break


### PR DESCRIPTION
The code states that the launcher process should react to ` launcher_process.should_stop` though it seems not to be the case :
https://github.com/pupil-labs/pupil/blob/af660c38447cc6b199bd3eda292f4e4c769a0147/pupil_src/main.py#L124 

It assumes that closing children processes will lead to the launcher process exit.
Wrote that quickly, so would need feedback on implementation.

Thanks