### PR TITLE
Handle zero-byte video files when looking up Pupil Mobile intrinsics

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/update_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/update/update_utils.py
@@ -41,6 +41,9 @@ def _try_patch_world_instrinsics_file(rec_dir: str, videos: T.Sequence[Path]) ->
         except av.AVError:
             continue
 
+        if container.streams.video[0].format is None:
+            continue
+
         for camera in cm.default_intrinsics:
             if camera in video.name:
                 camera_hint = camera


### PR DESCRIPTION
Zero-byte files do not trigger an AVError when attempting to open them. Their `format` is `None` which causes an `AttributeError` down the line. This PR handles these files as if they were broken containers (which they are effectively).