### PR TITLE
Gracefully handle PI recordings with broken video #2

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -215,6 +215,7 @@ class BrokenFirstFrameRecordingIssue:
                 # Keep track of streams that should skip frame
                 stream_should_skip_frame = {
                     in_stream: in_stream.codec_context.type == "video"
+                    or in_stream.codec_context.type == "audio"
                     for in_stream in stream_mapping.keys()
                 }
 


### PR DESCRIPTION
This PR adds to the [fix for PI with broken video](https://github.com/pupil-labs/pupil/pull/2077). 
