### PR TITLE
Disable temporarily unsupported calibrations on Apple Silicone machines

### DIFF
--- a/pupil_src/shared_modules/calibration_choreography/screen_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/screen_marker_plugin.py
@@ -50,6 +50,8 @@ from .base_plugin import (
     ChoreographyNotification,
 )
 
+from stdlib_utils import is_apple_silicone_platform
+
 
 logger = logging.getLogger(__name__)
 
@@ -279,6 +281,12 @@ class ScreenMarkerChoreographyPlugin(
         if not self.g_pool.capture.online:
             logger.error(
                 f"{self.current_mode.label} requiers world capture video input."
+            )
+            return
+
+        if is_apple_silicone_platform():
+            logger.error(
+                f"{self.label} currently not supported on Apple Silicone platforms."
             )
             return
 

--- a/pupil_src/shared_modules/calibration_choreography/screen_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/screen_marker_plugin.py
@@ -286,7 +286,8 @@ class ScreenMarkerChoreographyPlugin(
 
         if is_apple_silicone_platform():
             logger.error(
-                f"{self.label} currently not supported on Apple Silicone platforms."
+                f"{self.label} currently not supported on Apple Silicone platforms. "
+                "Please use Single Marker Calibration in Physical mode instead."
             )
             return
 

--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -379,7 +379,7 @@ class SingleMarkerChoreographyPlugin(
 
         if is_apple_silicone_platform() and self.marker_mode != SingleMarkerMode.MANUAL:
             logger.error(
-                f"{self.label} in {self.marker_mode.label} currently not supported on Apple Silicone platforms."
+                f"{self.label} in {self.marker_mode.label} mode currently not supported on Apple Silicone platforms."
             )
             return
 

--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -49,6 +49,8 @@ from .base_plugin import (
     ChoreographyAction,
 )
 
+from stdlib_utils import is_apple_silicone_platform
+
 
 logger = logging.getLogger(__name__)
 

--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -379,7 +379,8 @@ class SingleMarkerChoreographyPlugin(
 
         if is_apple_silicone_platform() and self.marker_mode != SingleMarkerMode.MANUAL:
             logger.error(
-                f"{self.label} in {self.marker_mode.label} mode currently not supported on Apple Silicone platforms."
+                f"{self.label} in {self.marker_mode.label} mode currently not supported on Apple Silicone platforms. "
+                "Please use Physical mode instead."
             )
             return
 

--- a/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
+++ b/pupil_src/shared_modules/calibration_choreography/single_marker_plugin.py
@@ -375,6 +375,12 @@ class SingleMarkerChoreographyPlugin(
             )
             return
 
+        if is_apple_silicone_platform() and self.marker_mode != SingleMarkerMode.MANUAL:
+            logger.error(
+                f"{self.label} in {self.marker_mode.label} currently not supported on Apple Silicone platforms."
+            )
+            return
+
         self.__auto_stop_tracker.reset()
 
         super()._perform_start()

--- a/pupil_src/shared_modules/stdlib_utils.py
+++ b/pupil_src/shared_modules/stdlib_utils.py
@@ -8,7 +8,7 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-
+import os
 import typing
 import functools
 import itertools
@@ -18,9 +18,13 @@ import platform
 
 
 def is_apple_silicone_platform() -> bool:
-    # Ex: 'macOS-11.1-arm64-arm-64bit'
-    p = platform.platform()
-    return "macOS" in p and "arm64" in p
+    if "Darwin" != platform.system():
+        return False
+
+    # Ex: Darwin Kernel Version 20.2.0: Wed Dec  2 20:40:21 PST 2020; root:xnu-7195.60.75~1/RELEASE_ARM64_T810
+    # Ex: Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64
+    os_version = os.uname().version
+    return "ARM64" in os_version
 
 
 is_none = functools.partial(operator.is_, None)

--- a/pupil_src/shared_modules/stdlib_utils.py
+++ b/pupil_src/shared_modules/stdlib_utils.py
@@ -14,6 +14,13 @@ import functools
 import itertools
 import operator
 import collections
+import platform
+
+
+def is_apple_silicone_platform() -> bool:
+    # Ex: 'macOS-11.1-arm64-arm-64bit'
+    p = platform.platform()
+    return "macOS" in p and "arm64" in p
 
 
 is_none = functools.partial(operator.is_, None)


### PR DESCRIPTION
This PR temporarily disables `Screen Marker` and `Single Marker` (in `Full screen` and `Window` modes) calibration methods on Apple Silicone machines. This change will be reversed once the underlying issues will be resolved.
