### PR TITLE
Custom Pupil Player plugin list for Invisible/Mobile recordings

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -577,11 +577,13 @@ def player(
             ("Pupil_From_Recording", {}),
             ("Offline_Pupil_Detection", {}),
         ]
+        _pupil_producer_plugins = list(reversed(_pupil_producer_plugins))
         _gaze_producer_plugins = [
             # In priority order (first is default)
             ("GazeFromRecording", {}),
             ("GazeFromOfflineCalibration", {}),
         ]
+        _gaze_producer_plugins = list(reversed(_gaze_producer_plugins))
         default_plugins = [
             ("Plugin_Manager", {}),
             ("Seek_Control", {}),
@@ -592,8 +594,8 @@ def player(
             ("System_Graphs", {}),
             ("System_Timelines", {}),
             ("World_Video_Exporter", {}),
-            *reversed(_pupil_producer_plugins),
-            *reversed(_gaze_producer_plugins),
+            *_pupil_producer_plugins,
+            *_gaze_producer_plugins,
             ("Audio_Playback", {}),
         ]
 

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -598,10 +598,21 @@ def player(
             *_gaze_producer_plugins,
             ("Audio_Playback", {}),
         ]
+        _plugins_to_load = session_settings.get("loaded_plugins", None)
+        if _plugins_to_load is None:
+            # If no plugins are available from a previous session,
+            # then use the default plugin list
+            _plugins_to_load = default_plugins
+        else:
+            # If there are plugins available from a previous session,
+            # then prepend plugins that are required, but might have not been available before
+            _plugins_to_load = [
+                *_pupil_producer_plugins,
+                *_gaze_producer_plugins,
+                *_plugins_to_load,
+            ]
 
-        g_pool.plugins = Plugin_List(
-            g_pool, session_settings.get("loaded_plugins", default_plugins)
-        )
+        g_pool.plugins = Plugin_List(g_pool, _plugins_to_load)
 
         # Manually add g_pool.capture to the plugin list
         g_pool.plugins._plugins.append(g_pool.capture)

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -572,6 +572,16 @@ def player(
         g_pool.gui.append(g_pool.quickbar)
 
         # we always load these plugins
+        _pupil_producer_plugins = [
+            # In priority order (first is default)
+            ("Pupil_From_Recording", {}),
+            ("Offline_Pupil_Detection", {}),
+        ]
+        _gaze_producer_plugins = [
+            # In priority order (first is default)
+            ("GazeFromRecording", {}),
+            ("GazeFromOfflineCalibration", {}),
+        ]
         default_plugins = [
             ("Plugin_Manager", {}),
             ("Seek_Control", {}),
@@ -582,8 +592,8 @@ def player(
             ("System_Graphs", {}),
             ("System_Timelines", {}),
             ("World_Video_Exporter", {}),
-            ("Pupil_From_Recording", {}),
-            ("GazeFromRecording", {}),
+            *reversed(_pupil_producer_plugins),
+            *reversed(_gaze_producer_plugins),
             ("Audio_Playback", {}),
         ]
 

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -26,7 +26,6 @@ from pyglui import ui
 import gl_utils
 from audio_utils import Audio_Viz_Transform, NoAudioLoadedError, load_audio
 from plugin import System_Plugin_Base
-from pupil_recording import PupilRecording, RecordingInfo
 from version_utils import parse_version
 
 
@@ -54,19 +53,6 @@ class Audio_Playback(System_Plugin_Base):
 
     icon_chr = chr(0xE050)
     icon_font = "pupil_icons"
-
-    @classmethod
-    def is_available_within_context(cls, g_pool) -> bool:
-        if g_pool.app == "player":
-            recording = PupilRecording(rec_dir=g_pool.rec_dir)
-            meta_info = recording.meta_info
-            if (
-                meta_info.recording_software_name
-                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
-            ):
-                # Disable audio playback in Player if Pupil Mobile recording
-                return False
-        return super().is_available_within_context(g_pool)
 
     def __init__(self, g_pool):
         super().__init__(g_pool)

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -60,7 +60,10 @@ class Audio_Playback(System_Plugin_Base):
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
+            ):
                 # Disable audio playback in Player if Pupil Mobile recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -26,6 +26,7 @@ from pyglui import ui
 import gl_utils
 from audio_utils import Audio_Viz_Transform, NoAudioLoadedError, load_audio
 from plugin import System_Plugin_Base
+from pupil_recording import PupilRecording, RecordingInfo
 from version_utils import parse_version
 
 
@@ -53,6 +54,16 @@ class Audio_Playback(System_Plugin_Base):
 
     icon_chr = chr(0xE050)
     icon_font = "pupil_icons"
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+                # Disable audio playback in Player if Pupil Mobile recording
+                return False
+        return super().is_available_within_context(g_pool)
 
     def __init__(self, g_pool):
         super().__init__(g_pool)

--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -186,13 +186,15 @@ class Blink_Detection(Plugin):
 
 
 class Offline_Blink_Detection(Observable, Blink_Detection):
-
     @classmethod
     def is_available_within_context(cls, g_pool) -> bool:
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
                 # Disable blink detector in Player if Pupil Invisible recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -28,6 +28,7 @@ import gl_utils
 import player_methods as pm
 from observable import Observable
 from plugin import Plugin
+from pupil_recording import PupilRecording, RecordingInfo
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +186,17 @@ class Blink_Detection(Plugin):
 
 
 class Offline_Blink_Detection(Observable, Blink_Detection):
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+                # Disable blink detector in Player if Pupil Invisible recording
+                return False
+        return super().is_available_within_context(g_pool)
+
     def __init__(
         self,
         g_pool,

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -275,7 +275,10 @@ class Offline_Fixation_Detector(Observable, Fixation_Detector_Base):
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
                 # Disable fixation detector in Player if Pupil Invisible recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/fixation_detector.py
+++ b/pupil_src/shared_modules/fixation_detector.py
@@ -50,6 +50,7 @@ from observable import Observable
 import player_methods as pm
 from methods import denormalize
 from plugin import Plugin
+from pupil_recording import PupilRecording, RecordingInfo
 
 logger = logging.getLogger(__name__)
 
@@ -268,6 +269,16 @@ class Offline_Fixation_Detector(Observable, Fixation_Detector_Base):
     visual angle within the coordinate system of the world camera. These
     fixations will have their method field set to "gaze".
     """
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+                # Disable fixation detector in Player if Pupil Invisible recording
+                return False
+        return super().is_available_within_context(g_pool)
 
     def __init__(
         self,

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -28,7 +28,10 @@ class GazeFromOfflineCalibration(GazeProducerBase):
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
                 # Disable post-hoc gaze calibration in Player if Pupil Invisible recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_offline_calibration.py
@@ -13,7 +13,7 @@ from gaze_producer import controller, model
 from gaze_producer import ui as plugin_ui
 from gaze_producer.gaze_producer_base import GazeProducerBase
 from plugin_timeline import PluginTimeline
-from pupil_recording import PupilRecording
+from pupil_recording import PupilRecording, RecordingInfo
 from tasklib.manager import UniqueTaskManager
 
 
@@ -22,6 +22,16 @@ from tasklib.manager import UniqueTaskManager
 class GazeFromOfflineCalibration(GazeProducerBase):
     icon_chr = chr(0xEC14)
     icon_font = "pupil_icons"
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+                # Disable post-hoc gaze calibration in Player if Pupil Invisible recording
+                return False
+        return super().is_available_within_context(g_pool)
 
     @classmethod
     def plugin_menu_label(cls) -> str:

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
@@ -17,13 +17,15 @@ from pupil_recording import PupilRecording, RecordingInfo
 
 
 class GazeFromRecording(GazeProducerBase):
-
     @classmethod
     def is_available_within_context(cls, g_pool) -> bool:
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
+            ):
                 # Disable gaze from recording in Player if Pupil Mobile recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_from_recording.py
@@ -13,9 +13,21 @@ from pyglui import ui
 import file_methods as fm
 import player_methods as pm
 from gaze_producer.gaze_producer_base import GazeProducerBase
+from pupil_recording import PupilRecording, RecordingInfo
 
 
 class GazeFromRecording(GazeProducerBase):
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+                # Disable gaze from recording in Player if Pupil Mobile recording
+                return False
+        return super().is_available_within_context(g_pool)
+
     @classmethod
     def plugin_menu_label(cls) -> str:
         return "Gaze Data From Recording"

--- a/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
@@ -56,6 +56,11 @@ class GazeProducerBase(Observable, System_Plugin_Base):
             for p in self.g_pool.plugin_by_name.values()
             if issubclass(p, GazeProducerBase)
         ]
+        # Skip gaze producers that are not available within g_pool context
+        gaze_producer_plugins = [
+            p for p in gaze_producer_plugins
+            if p.is_available_within_context(self.g_pool)
+        ]
         gaze_producer_plugins.sort(key=lambda p: p.gaze_data_source_selection_label())
         gaze_producer_plugins.sort(key=lambda p: p.gaze_data_source_selection_order())
         gaze_producer_labels = [

--- a/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
+++ b/pupil_src/shared_modules/gaze_producer/gaze_producer_base.py
@@ -58,7 +58,8 @@ class GazeProducerBase(Observable, System_Plugin_Base):
         ]
         # Skip gaze producers that are not available within g_pool context
         gaze_producer_plugins = [
-            p for p in gaze_producer_plugins
+            p
+            for p in gaze_producer_plugins
             if p.is_available_within_context(self.g_pool)
         ]
         gaze_producer_plugins.sort(key=lambda p: p.gaze_data_source_selection_label())

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -400,6 +400,12 @@ class Plugin_List(object):
         """
         add a plugin instance to the list.
         """
+
+        # Check if the plugin class is supported within the current g_pool context
+        if not new_plugin_cls.is_available_within_context(self.g_pool):
+            logger.error(f"Plugin {new_plugin_cls.__name__} not available; skip adding it to plugin list.")
+            return
+
         self._find_and_remove_duplicates(new_plugin_cls)
 
         plugin_instance = new_plugin_cls(self.g_pool, **args)

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -411,7 +411,7 @@ class Plugin_List(object):
 
         # Check if the plugin class is supported within the current g_pool context
         if not new_plugin_cls.is_available_within_context(self.g_pool):
-            logger.error(f"Plugin {new_plugin_cls.__name__} not available; skip adding it to plugin list.")
+            logger.debug(f"Plugin {new_plugin_cls.__name__} not available; skip adding it to plugin list.")
             return
 
         self._find_and_remove_duplicates(new_plugin_cls)

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -411,7 +411,9 @@ class Plugin_List(object):
 
         # Check if the plugin class is supported within the current g_pool context
         if not new_plugin_cls.is_available_within_context(self.g_pool):
-            logger.debug(f"Plugin {new_plugin_cls.__name__} not available; skip adding it to plugin list.")
+            logger.debug(
+                f"Plugin {new_plugin_cls.__name__} not available; skip adding it to plugin list."
+            )
             return
 
         self._find_and_remove_duplicates(new_plugin_cls)

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -371,6 +371,14 @@ class Plugin_List(object):
 
         expanded_initializers.sort(key=lambda data: data[0].order)
 
+        # skip plugins that are not available within g_pool context
+        # not removing them here will break the uniqueness logic bellow
+        expanded_initializers = [
+            (plugin, name, args)
+            for (plugin, name, args) in expanded_initializers
+            if plugin.is_available_within_context(self.g_pool)
+        ]
+
         # only add plugins that won't be replaced by newer plugins
         for i, (plugin, name, args) in enumerate(expanded_initializers):
             for new_plugin, new_name, _ in expanded_initializers[i + 1 :]:

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -253,6 +253,13 @@ class Plugin(object):
     def parse_pretty_class_name(cls) -> str:
         return cls.__name__.replace("_", " ")
 
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        """
+        Returns `True` if the plugin class is available within the `g_pool` context.
+        """
+        return True
+
     def add_menu(self):
         """
         This fn is called when the plugin ui is initialized. Do not change!

--- a/pupil_src/shared_modules/plugin_manager.py
+++ b/pupil_src/shared_modules/plugin_manager.py
@@ -8,12 +8,16 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
+import logging
 
 from plugin import System_Plugin_Base
 from pyglui import ui
 from calibration_choreography import CalibrationChoreographyPlugin
 from gaze_mapping.gazer_base import GazerBase
 from video_capture import Base_Manager, Base_Source
+
+
+logger = logging.getLogger(__name__)
 
 
 class Plugin_Manager(System_Plugin_Base):
@@ -29,13 +33,21 @@ class Plugin_Manager(System_Plugin_Base):
             CalibrationChoreographyPlugin,
             GazerBase,
         )
-        self.user_plugins = [
-            p
-            for p in sorted(
-                g_pool.plugin_by_name.values(), key=lambda p: p.__name__.lower()
-            )
-            if not issubclass(p, non_user_plugins)
-        ]
+        all_available_plugins = sorted(
+            g_pool.plugin_by_name.values(), key=lambda p: p.__name__.lower()
+        )
+
+        available_and_supported_user_plugins = []
+
+        for plugin in all_available_plugins:
+            if issubclass(plugin, non_user_plugins):
+                continue
+            if not plugin.is_available_within_context(g_pool):
+                logger.debug(f"Plugin {plugin.__name__} not available; skip adding it to plugin list.")
+                continue
+            available_and_supported_user_plugins.append(plugin)
+
+        self.user_plugins = available_and_supported_user_plugins
 
     def init_ui(self):
         self.add_menu()

--- a/pupil_src/shared_modules/plugin_manager.py
+++ b/pupil_src/shared_modules/plugin_manager.py
@@ -43,7 +43,9 @@ class Plugin_Manager(System_Plugin_Base):
             if issubclass(plugin, non_user_plugins):
                 continue
             if not plugin.is_available_within_context(g_pool):
-                logger.debug(f"Plugin {plugin.__name__} not available; skip adding it to plugin list.")
+                logger.debug(
+                    f"Plugin {plugin.__name__} not available; skip adding it to plugin list."
+                )
                 continue
             available_and_supported_user_plugins.append(plugin)
 

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -81,6 +81,11 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
             for p in self.g_pool.plugin_by_name.values()
             if issubclass(p, Pupil_Producer_Base)
         ]
+        # Skip pupil producers that are not available within g_pool context
+        pupil_producer_plugins = [
+            p for p in pupil_producer_plugins
+            if p.is_available_within_context(self.g_pool)
+        ]
         pupil_producer_plugins.sort(key=lambda p: p.pupil_data_source_selection_label())
         pupil_producer_plugins.sort(key=lambda p: p.pupil_data_source_selection_order())
         pupil_producer_labels = [

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -83,7 +83,8 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
         ]
         # Skip pupil producers that are not available within g_pool context
         pupil_producer_plugins = [
-            p for p in pupil_producer_plugins
+            p
+            for p in pupil_producer_plugins
             if p.is_available_within_context(self.g_pool)
         ]
         pupil_producer_plugins.sort(key=lambda p: p.pupil_data_source_selection_label())
@@ -291,13 +292,15 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
 
 
 class Pupil_From_Recording(Pupil_Producer_Base):
-
     @classmethod
     def is_available_within_context(cls, g_pool) -> bool:
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE
+            ):
                 # Disable pupil from recording in Player if Pupil Mobile recording
                 return False
         return super().is_available_within_context(g_pool)
@@ -334,7 +337,10 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
         if g_pool.app == "player":
             recording = PupilRecording(rec_dir=g_pool.rec_dir)
             meta_info = recording.meta_info
-            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
                 # Disable post-hoc pupil detector in Player if Pupil Invisible recording
                 return False
         return super().is_available_within_context(g_pool)

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -27,6 +27,7 @@ import pyglui.cygl.utils as cygl_utils
 import zmq_tools
 from observable import Observable
 from plugin import System_Plugin_Base
+from pupil_recording import PupilRecording, RecordingInfo
 from pyglui import ui
 from pyglui.pyfontstash import fontstash as fs
 from video_capture.utils import VideoSet
@@ -311,6 +312,16 @@ class Offline_Pupil_Detection(Pupil_Producer_Base):
 
     session_data_version = 4
     session_data_name = "offline_pupil"
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE:
+                # Disable post-hoc pupil detector in Player if Pupil Invisible recording
+                return False
+        return super().is_available_within_context(g_pool)
 
     @classmethod
     def plugin_menu_label(cls) -> str:

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -286,6 +286,17 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
 
 
 class Pupil_From_Recording(Pupil_Producer_Base):
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if meta_info.recording_software_name == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_MOBILE:
+                # Disable pupil from recording in Player if Pupil Mobile recording
+                return False
+        return super().is_available_within_context(g_pool)
+
     @classmethod
     def plugin_menu_label(cls) -> str:
         return "Pupil Data From Recording"

--- a/pupil_src/shared_modules/pupil_recording/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/__init__.py
@@ -8,6 +8,6 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-from .info import RecordingInfoFile
+from .info import RecordingInfoFile, RecordingInfo
 from .recording import PupilRecording
 from .recording_utils import InvalidRecordingException, assert_valid_recording_type

--- a/pupil_src/shared_modules/pupil_recording/info/__init__.py
+++ b/pupil_src/shared_modules/pupil_recording/info/__init__.py
@@ -8,7 +8,7 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-from .recording_info import RecordingInfoFile
+from .recording_info import RecordingInfoFile, RecordingInfo
 from .recording_info_2_0 import _RecordingInfoFile_2_0
 from .recording_info_2_1 import _RecordingInfoFile_2_1
 from .recording_info_2_2 import _RecordingInfoFile_2_2


### PR DESCRIPTION
This PR makes some Pupuil Player plugins explicitly unavailable, depending on the software used to create the recording.

| Player Plugin | Pupil Invisible | Pupil Mobile |
| :-- | :-: | :-: |
| Blink detection | `unavailable ` | - |
| Fixation detection | `unavailable ` | - |
| Post-hoc pupil detection | `unavailable ` | - |
| Post-hoc gaze calibration | `unavailable ` | - |
| Pupil from recording | - | `unavailable ` |
| Gaze from recording | - | `unavailable ` |

---

- [x] Test plugin availability in `Plugin Manager`, according to the matrix above
- [x] Test `Pupil Data From Recording`/`Post-Hoc Pupil Detection` options are removed from `Pupil Data` dropdown
- [x] Test `Gaze Data From Recording`/`Post-Hoc Gaze Calibration` options are removed from `Gaze Data` dropdown
- [x] Test recordings of different types work as expected in the same Pupil Player session

---
[ClickUp Task](https://app.clickup.com/t/cpw1mg)
