### PR TITLE
Support recordings with decoding issues

### DIFF
--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -277,10 +277,13 @@ class Audio_Playback(System_Plugin_Base):
             self.seek_to_audio_frame(audio_idx)
 
     def on_notify(self, notification):
-        if notification["subject"] == "seek_control.was_seeking":
-            if self.pa_stream is not None and not self.pa_stream.is_stopped():
-                self.pa_stream.stop_stream()
-                self.play = False
+        if (
+            notification["subject"] == "seek_control.was_seeking"
+            and self.pa_stream is not None
+            and not self.pa_stream.is_stopped()
+        ):
+            self.pa_stream.stop_stream()
+            self.play = False
 
     def recent_events(self, events):
         self.update_audio_viz()

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -26,6 +26,7 @@ from pyglui import ui
 
 import gl_utils
 from audio_utils import Audio_Viz_Transform, NoAudioLoadedError, load_audio
+from methods import make_change_loglevel_fn
 from plugin import System_Plugin_Base
 from version_utils import parse_version
 
@@ -35,6 +36,9 @@ assert parse_version(av.__version__) >= parse_version("0.4.4")
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logger.DEBUG)
+
+av_logger = logging.getLogger("libav.aac")
+av_logger.addFilter(make_change_loglevel_fn(logging.DEBUG))
 
 # av.logging.set_level(av.logging.DEBUG)
 # logging.getLogger('libav').setLevel(logging.DEBUG)

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -15,6 +15,7 @@ import logging
 from bisect import bisect_left as bisect
 from threading import Timer
 from time import monotonic
+import traceback
 
 import av
 import av.filter
@@ -249,9 +250,12 @@ class Audio_Playback(System_Plugin_Base):
 
     def get_audio_frame_iterator(self):
         for packet in self.audio.container.demux(self.audio.stream):
-            for frame in packet.decode():
-                if frame:
-                    yield frame
+            try:
+                for frame in packet.decode():
+                    if frame:
+                        yield frame
+            except av.AVError:
+                logger.debug(traceback.format_exc())
 
     def audio_idx_to_pts(self, idx):
         return idx * self.audio_pts_rate

--- a/pupil_src/shared_modules/audio_utils.py
+++ b/pupil_src/shared_modules/audio_utils.py
@@ -10,6 +10,7 @@ See COPYING and COPYING.LESSER for license details.
 """
 import collections
 import logging
+import traceback
 
 import av
 import numpy as np
@@ -114,9 +115,12 @@ class Audio_Viz_Transform:
 
     def _next_audio_frame(self):
         for packet in self.audio.container.demux(self.audio.stream):
-            for frame in packet.decode():
-                if frame:
-                    yield frame
+            try:
+                for frame in packet.decode():
+                    if frame:
+                        yield frame
+            except av.AVError:
+                logger.debug(traceback.format_exc())
 
     def sec_to_frames(self, sec):
         return int(np.ceil(sec * self.audio.stream.rate / self.audio.stream.frame_size))

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -24,7 +24,7 @@ from av.packet import Packet
 
 import audio_utils
 from video_capture.utils import Video, InvalidContainerError
-from player_methods import iter_catch
+from methods import iter_catch
 
 logger = logging.getLogger(__name__)
 

--- a/pupil_src/shared_modules/av_writer.py
+++ b/pupil_src/shared_modules/av_writer.py
@@ -24,6 +24,7 @@ from av.packet import Packet
 
 import audio_utils
 from video_capture.utils import Video, InvalidContainerError
+from player_methods import iter_catch
 
 logger = logging.getLogger(__name__)
 
@@ -501,7 +502,11 @@ class _AudioPacketIterator:
         for part_idx, audio_part in enumerate(audio_parts):
 
             frames = audio_part.container.decode(audio=0)
+            frames = iter_catch(frames, av.AVError)
             for frame, timestamp in zip(frames, audio_part.timestamps):
+                if frame is None:
+                    continue  # ignore audio decoding errors
+
                 frame.pts = None
 
                 audio_frame = _AudioPacketIterator._AudioFrame(

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -800,3 +800,12 @@ def iter_catch(
             yield None
         except StopIteration:
             return
+
+
+def make_change_loglevel_fn(level):
+    def _change_level(record):
+        record.levelno = level
+        record.levelname = logging.getLevelName(record.levelno)
+        return record
+
+    return _change_level

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -9,16 +9,20 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import os, sys, platform, getpass
+import getpass
+import logging
+import os
+import platform
+import sys
 from time import time
+
+import cv2
 import numpy as np
 
 try:
     import numexpr as ne
 except Exception:
     ne = None
-import cv2
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/pupil_src/shared_modules/methods.py
+++ b/pupil_src/shared_modules/methods.py
@@ -14,6 +14,8 @@ import logging
 import os
 import platform
 import sys
+import traceback
+import typing as T
 from time import time
 
 import cv2
@@ -778,3 +780,23 @@ def timeit(method):
         return result
 
     return timed
+
+
+X = T.TypeVar("X")
+
+
+def iter_catch(
+    iterator: T.Iterator[X],
+    errors_to_catch: T.Union[Exception, T.Tuple[Exception]],
+    log_on_catch: bool = True,
+) -> T.Iterator[T.Optional[X]]:
+    iterator = iter(iterator)
+    while True:
+        try:
+            yield next(iterator)
+        except errors_to_catch:
+            if log_on_catch:
+                logger.debug(traceback.format_exc())
+            yield None
+        except StopIteration:
+            return

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -24,6 +24,7 @@ from pyglui import ui
 
 from camera_models import Camera_Model
 from pupil_recording import PupilRecording
+from player_methods import iter_catch
 
 from .base_backend import Base_Manager, Base_Source, EndofVideoError, Playback_Source
 from .utils import VideoSet, InvalidContainerError
@@ -185,10 +186,11 @@ class OnDemandDecoder(Decoder):
         self.video_stream.seek(pts_position)
 
     def get_frame_iterator(self):
-        for packet in self.container.demux(self.video_stream):
-            for frame in packet.decode():
-                if frame:
-                    yield frame
+        frames = self.container.decode(self.video_stream)
+        frames = iter_catch(frames, av.AVError)
+        for frame in frames:
+            if frame:
+                yield frame
 
 
 # NOTE:Base_Source is included as base class for uniqueness:by_base_class to work

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -23,7 +23,7 @@ import numpy as np
 from pyglui import ui
 
 from camera_models import Camera_Model
-from methods import iter_catch
+from methods import make_change_loglevel_fn, iter_catch
 from pupil_recording import PupilRecording
 
 from .base_backend import Base_Manager, Base_Source, EndofVideoError, Playback_Source
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 av.logging.set_level(av.logging.ERROR)
 logging.getLogger("libav").setLevel(logging.ERROR)
 logging.getLogger("av.buffered_decoder").setLevel(logging.WARNING)
+
+# convert 2h64 decoding errors to debug messages
+av_logger = logging.getLogger("libav.h264")
+av_logger.addFilter(make_change_loglevel_fn(logging.DEBUG))
 
 assert av.__version__ >= "0.4.5", "pyav is out-of-date, please update"
 

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -391,6 +391,7 @@ class File_Source(Playback_Source, Base_Source):
             self._setup_video(target_entry.container_idx)
 
         # advance frame iterator until we hit the target frame
+        av_frame = None
         for av_frame in self.frame_iterator:
             if not av_frame:
                 raise EndofVideoError
@@ -414,6 +415,8 @@ class File_Source(Playback_Source, Base_Source):
                     raise EndofVideoError
                 self.target_frame_idx = pts_indices[0]
                 break
+        if av_frame is None:
+            return self._get_fake_frame_and_advance(target_entry)
 
         # update indices, we know that we advanced until target_frame_index!
         self.current_frame_idx = self.target_frame_idx

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -23,8 +23,8 @@ import numpy as np
 from pyglui import ui
 
 from camera_models import Camera_Model
+from methods import iter_catch
 from pupil_recording import PupilRecording
-from player_methods import iter_catch
 
 from .base_backend import Base_Manager, Base_Source, EndofVideoError, Playback_Source
 from .utils import VideoSet, InvalidContainerError

--- a/pupil_src/shared_modules/video_capture/file_backend.py
+++ b/pupil_src/shared_modules/video_capture/file_backend.py
@@ -397,9 +397,7 @@ class File_Source(Playback_Source, Base_Source):
                 raise EndofVideoError
             if av_frame.pts == target_entry.pts:
                 break
-            elif av_frame.pts < target_entry.pts:
-                pass
-            else:
+            elif av_frame.pts > target_entry.pts:
                 # This should never happen, but just in case we should make sure
                 # that our current_frame_idx is actually correct afterwards!
                 logger.warn("Advancing frame iterator went past the target frame!")


### PR DESCRIPTION
Ignores audio and video decoding issues in the middle of the stream. (Decoding issues at the start of the stream disables the audio/video stream as it assumes the complete stream to be broken.)

Previously, the software crashed when encountering such decoding issues. The new implementation can lead to audio desync or silence when encountering any audio decoding issues. This is assumed to be an acceptable trade-off given the previous behavior.