### PR TITLE
Update default annotation hotkey

### DIFF
--- a/pupil_src/shared_modules/annotations.py
+++ b/pupil_src/shared_modules/annotations.py
@@ -57,18 +57,20 @@ class AnnotationPlugin(Plugin, abc.ABC):
     icon_chr = chr(0xE866)
     icon_font = "pupil_icons"
 
+    _DEFAULT_HOTKEY = "a"
+
     def __init__(self, g_pool, annotation_definitions=None):
         super().__init__(g_pool)
         self.menu = None
         self._annotation_list_menu = None
 
         if annotation_definitions is None:
-            annotation_definitions = [["My annotation", "E"]]
+            annotation_definitions = [["My annotation", self._DEFAULT_HOTKEY]]
         self._initial_annotation_definitions = annotation_definitions
         self._definition_to_buttons = {}
 
         self._new_annotation_label = "new annotation label"
-        self._new_annotation_hotkey = "E"
+        self._new_annotation_hotkey = self._DEFAULT_HOTKEY
 
     def get_init_dict(self):
         annotation_definitions = list(self._definition_to_buttons.keys())


### PR DESCRIPTION
This PR changes the default annotation hotkey from "E" to "a". This is to make it harder to accidentally trigger an export ("e" hotkey).

[ClickUp Task](https://app.clickup.com/t/gb1rv9)
