### PR TITLE
Fix msgpack unpack in Pupil Groups

### DIFF
--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -248,7 +248,7 @@ class Pupil_Groups(Plugin):
                     for msg in event.msg:
                         try:
                             # try to unpack data
-                            notification = serializer.loads(msg, encoding="utf-8")
+                            notification = serializer.loads(msg)
                             # test if dictionary and if `subject` key is present
                             notification["subject"]
                             # add peer information

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -11,6 +11,7 @@ See COPYING and COPYING.LESSER for license details.
 
 import logging
 import time
+import traceback
 import uuid
 
 import msgpack as serializer
@@ -264,6 +265,8 @@ class Pupil_Groups(Plugin):
                                     event.peer_name, event.peer_uuid
                                 )
                             )
+                            logger.debug(traceback.format_exc())
+
                 elif event.type == "JOIN" and event.group == self.active_group:
                     local_out.notify(
                         {

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -14,7 +14,7 @@ import time
 import traceback
 import uuid
 
-import msgpack as serializer
+import msgpack
 import zmq
 from pyglui import ui
 from pyre import Pyre, PyreEvent, zhelper
@@ -233,12 +233,12 @@ class Pupil_Groups(Plugin):
                 remote_key = "remote_notify"
                 if notification[remote_key] == "all":
                     del notification[remote_key]
-                    serialized = serializer.dumps(notification)
+                    serialized = msgpack.packb(notification)
                     group_member.shout(self.active_group, serialized)
                 else:
                     peer_uuid_bytes = notification[remote_key]
                     del notification[remote_key]
-                    serialized = serializer.dumps(notification)
+                    serialized = msgpack.packb(notification)
                     peer_uuid = uuid.UUID(bytes=peer_uuid_bytes)
                     group_member.whisper(peer_uuid, serialized)
 
@@ -248,7 +248,7 @@ class Pupil_Groups(Plugin):
                     for msg in event.msg:
                         try:
                             # try to unpack data
-                            notification = serializer.loads(msg)
+                            notification = msgpack.unpackb(msg)
                             # test if dictionary and if `subject` key is present
                             notification["subject"]
                             # add peer information

--- a/pupil_src/shared_modules/pupil_groups.py
+++ b/pupil_src/shared_modules/pupil_groups.py
@@ -9,15 +9,18 @@ See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
 
-import zmq, time, uuid
-from pyre import Pyre, PyreEvent, zhelper
+import logging
+import time
+import uuid
+
+import msgpack as serializer
+import zmq
 from pyglui import ui
+from pyre import Pyre, PyreEvent, zhelper
+
+import os_utils
 from plugin import Plugin
 from zmq_tools import Msg_Dispatcher, Msg_Receiver
-import msgpack as serializer
-
-import logging
-import os_utils
 
 os_utils.patch_pyre_zhelper_cdll()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
After changing to msgpack 1.0, the `encoding="utf-8"` argument has been removed, causing an exception on use. We were ignoring this, causing this issue to stay undetected for a while.

I also made the use of msgpack more explicit.