### PR TITLE
Disable "Pupil from Recording" for Pupil Invisible recordings

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -113,7 +113,11 @@ def player(
         from annotations import Annotation_Player
         from raw_data_exporter import Raw_Data_Exporter
         from log_history import Log_History
-        from pupil_producers import Pupil_From_Recording, Offline_Pupil_Detection
+        from pupil_producers import (
+            DisabledPupilProducer,
+            Pupil_From_Recording,
+            Offline_Pupil_Detection,
+        )
         from gaze_producer.gaze_from_recording import GazeFromRecording
         from gaze_producer.gaze_from_offline_calibration import (
             GazeFromOfflineCalibration,
@@ -180,6 +184,7 @@ def player(
             Raw_Data_Exporter,
             Annotation_Player,
             Log_History,
+            DisabledPupilProducer,
             Pupil_From_Recording,
             Offline_Pupil_Detection,
             GazeFromRecording,
@@ -576,6 +581,7 @@ def player(
             # In priority order (first is default)
             ("Pupil_From_Recording", {}),
             ("Offline_Pupil_Detection", {}),
+            ("DisabledPupilProducer", {}),
         ]
         _pupil_producer_plugins = list(reversed(_pupil_producer_plugins))
         _gaze_producer_plugins = [

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -291,6 +291,53 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
             self.glfont.pop_state()
 
 
+class DisabledPupilProducer(Pupil_Producer_Base):
+    """
+    This is a stub implementation of a pupil producer,
+    intended to be used when no (other) pupil producer is available.
+    """
+
+    @classmethod
+    def is_available_within_context(cls, g_pool) -> bool:
+        if g_pool.app == "player":
+            recording = PupilRecording(rec_dir=g_pool.rec_dir)
+            meta_info = recording.meta_info
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
+                # Enable in Player only if Pupil Invisible recording
+                return True
+        return False
+
+    @classmethod
+    def plugin_menu_label(cls) -> str:
+        raise RuntimeError()  # This method should never be called
+        return "Disabled Pupil Producer"
+
+    @classmethod
+    def pupil_data_source_selection_order(cls) -> float:
+        raise RuntimeError()  # This method should never be called
+        return 0.1
+
+    def __init__(self, g_pool):
+        super().__init__(g_pool)
+        # Create empty pupil_positions for all plugins that depend on it
+        pupil_data = pm.PupilDataBisector(data=fm.PLData([], [], []))
+        g_pool.pupil_positions = pupil_data
+        self._pupil_changed_announcer.announce_existing()
+        logger.debug("pupil positions changed")
+
+    def init_ui(self):
+        pass
+
+    def deinit_ui(self):
+        pass
+
+    def _refresh_timelines(self):
+        pass
+
+
 class Pupil_From_Recording(Pupil_Producer_Base):
     @classmethod
     def is_available_within_context(cls, g_pool) -> bool:

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -57,6 +57,21 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
     def pupil_data_source_selection_label(cls) -> str:
         return cls.plugin_menu_label()
 
+    @staticmethod
+    def available_pupil_producer_plugins(g_pool) -> list:
+        def is_plugin_included(p, g_pool) -> bool:
+            # Skip plugins that are not pupil producers
+            if not issubclass(p, Pupil_Producer_Base):
+                return False
+            # Skip pupil producers that are not available within g_pool context
+            if not p.is_available_within_context(g_pool):
+                return False
+            return True
+
+        return [
+            p for p in g_pool.plugin_by_name.values() if is_plugin_included(p, g_pool)
+        ]
+
     @classmethod
     def pupil_data_source_selection_order(cls) -> float:
         return float("inf")
@@ -76,17 +91,7 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
     def init_ui(self):
         self.add_menu()
 
-        pupil_producer_plugins = [
-            p
-            for p in self.g_pool.plugin_by_name.values()
-            if issubclass(p, Pupil_Producer_Base)
-        ]
-        # Skip pupil producers that are not available within g_pool context
-        pupil_producer_plugins = [
-            p
-            for p in pupil_producer_plugins
-            if p.is_available_within_context(self.g_pool)
-        ]
+        pupil_producer_plugins = self.available_pupil_producer_plugins(self.g_pool)
         pupil_producer_plugins.sort(key=lambda p: p.pupil_data_source_selection_label())
         pupil_producer_plugins.sort(key=lambda p: p.pupil_data_source_selection_order())
         pupil_producer_labels = [

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -63,6 +63,9 @@ class Pupil_Producer_Base(Observable, System_Plugin_Base):
             # Skip plugins that are not pupil producers
             if not issubclass(p, Pupil_Producer_Base):
                 return False
+            # Skip pupil producer stub
+            if p is DisabledPupilProducer:
+                return False
             # Skip pupil producers that are not available within g_pool context
             if not p.is_available_within_context(g_pool):
                 return False

--- a/pupil_src/shared_modules/pupil_producers.py
+++ b/pupil_src/shared_modules/pupil_producers.py
@@ -355,6 +355,12 @@ class Pupil_From_Recording(Pupil_Producer_Base):
             ):
                 # Disable pupil from recording in Player if Pupil Mobile recording
                 return False
+            if (
+                meta_info.recording_software_name
+                == RecordingInfo.RECORDING_SOFTWARE_NAME_PUPIL_INVISIBLE
+            ):
+                # Disable pupil from recording in Player if Pupil Invisible recording
+                return False
         return super().is_available_within_context(g_pool)
 
     @classmethod


### PR DESCRIPTION
This PR removes the `"Pupil from Recording"` pupil data option from Player for Pupil Invisible recordings. These recordings don't contain any pupil data, so this PR is only meant to provide consistency in the way Player works. This PR also prevents raw data exports from generating an empty `pupil_positions.csv` when no pupil data is available.

---
[ClickUp Task](https://app.clickup.com/t/fh1cqd)
