### PR TITLE
Deinit UI when cleaning plugin list for eye processes

### DIFF
--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -471,7 +471,10 @@ class Plugin_List(object):
         """
         for p in self._plugins[::-1]:
             if not p.alive:
-                if self.g_pool.app in ("capture", "player"):
+                if self.g_pool.app in ("capture", "player") or self.g_pool.process in (
+                    "eye0",
+                    "eye1",
+                ):
                     p.deinit_ui()
                 p.cleanup()
                 logger.debug("Unloaded Plugin: {}".format(p))


### PR DESCRIPTION
This PR fixes an issue where a new video source in the eye process wouldn't completely replace the previous one.

---
[ClickUp](https://app.clickup.com/t/gh73dm)
