### PR TITLE
Fix Pupil Invisible rewrite timestamps

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
@@ -79,12 +79,14 @@ def validator_optional_type(value_type) -> T.Callable[[T.Any], None]:
 
 
 def read_info_csv_file(rec_dir: str) -> dict:
+    """Read `info.csv` file from recording."""
     file_path = os.path.join(rec_dir, "info.csv")
     with open(file_path, "r") as file:
         return csv_utils.read_key_value_file(file)
 
 
 def read_info_json_file(rec_dir: str) -> dict:
+    """Read `info.json` file from recording."""
     file_path = os.path.join(rec_dir, "info.json")
     with open(file_path, "r") as file:
         return json.load(file)

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
@@ -99,6 +99,14 @@ def read_info_invisible_json_file(rec_dir: str) -> dict:
         return json.load(file)
 
 
+def read_pupil_invisible_info_file(rec_dir: str) -> dict:
+    """Read info file from Pupil Invisible recording."""
+    try:
+        return read_info_json_file(rec_dir)
+    except FileNotFoundError:
+        return read_info_invisible_json_file(rec_dir)
+
+
 def parse_duration_string(duration_string: str) -> int:
     """Returns number of seconds from string 'HH:MM:SS'."""
     H, M, S = [int(part) for part in duration_string.split(":")]

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
@@ -92,6 +92,13 @@ def read_info_json_file(rec_dir: str) -> dict:
         return json.load(file)
 
 
+def read_info_invisible_json_file(rec_dir: str) -> dict:
+    """Read `info.invisible.json` file from recording."""
+    file_path = os.path.join(rec_dir, "info.invisible.json")
+    with open(file_path, "r") as file:
+        return json.load(file)
+
+
 def parse_duration_string(duration_string: str) -> int:
     """Returns number of seconds from string 'HH:MM:SS'."""
     H, M, S = [int(part) for part in duration_string.split(":")]

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -137,14 +137,18 @@ def _pi_path_core_path_pairs(recording: PupilRecording):
 
 
 def _rewrite_timestamps(recording: PupilRecording):
-    start_time = recording.meta_info.start_time_synced_ns
+
+    # Use start time from info file (instead of recording.meta_info.start_time_synced_ns)
+    # to have a more precise value and avoid having a negative first timestamp when rewriting
+    info_json = utils.read_pupil_invisible_info_file(recording.rec_dir)
+    start_time_synced_ns = int(info_json["start_time"])
 
     def conversion(timestamps: np.array):
         # Subtract start_time from all times in the recording, so timestamps
         # start at 0. This is to increase precision when converting
         # timestamps to float32, e.g. for OpenGL!
         SECONDS_PER_NANOSECOND = 1e-9
-        return (timestamps - start_time) * SECONDS_PER_NANOSECOND
+        return (timestamps - start_time_synced_ns) * SECONDS_PER_NANOSECOND
 
     update_utils._rewrite_times(recording, dtype="<u8", conversion=conversion)
 


### PR DESCRIPTION
This PR fixes an issue where a less precise version of start time was used when rewriting timestamps as part of the update procedure for Pupil Invisible recordings.

---
[ClickUp Task](https://app.clickup.com/t/h18pw0)
