### PR TITLE
Make pye3d plugin colors consistent

### DIFF
--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -42,9 +42,9 @@ class Pye3DPlugin(PupilDetectorPlugin):
     order = 0.101
 
     # Visualization
-    COLOR_ULTRA_LONG_TERM_MODEL = (0.5, 0, 0, 1)
-    COLOR_LONG_TERM_MODEL = (0.8, 0.8, 0, 1)
-    COLOR_SHORT_TERM_MODEL = (0, 1, 0, 1)
+    COLOR_ULTRA_LONG_TERM_MODEL = (0.5, 0, 0.5, 1)  # purple
+    COLOR_LONG_TERM_MODEL = (0, 0.9, 0.1, 1)  # green
+    COLOR_SHORT_TERM_MODEL = (0.8, 0.8, 0, 1)  # yellow
 
     @property
     def pupil_detector(self):

--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -192,14 +192,14 @@ class Pye3DPlugin(PupilDetectorPlugin):
     def gl_display(self):
         self.debug_window_update()
         result = self._recent_detection_result
+
         if result is not None:
             if not self.is_debug_window_open:
-                # normal drawing
+                # normal eyeball drawing
                 draw_eyeball_outline(result)
-                draw_pupil_outline(result)
 
             elif "debug_info" in result:
-                # debug drawing
+                # debug eyeball drawing
                 debug_info = result["debug_info"]
                 draw_ellipse(
                     ellipse=debug_info["projected_ultra_long_term"],
@@ -216,6 +216,10 @@ class Pye3DPlugin(PupilDetectorPlugin):
                     rgba=self.COLOR_SHORT_TERM_MODEL,
                     thickness=2,
                 )
+
+            # always draw pupil
+            draw_pupil_outline(result)
+
         if self.__debug_window_button:
             self.__debug_window_button.label = self.__debug_window_button_label
 

--- a/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
+++ b/pupil_src/shared_modules/pupil_detector_plugins/pye3d_plugin.py
@@ -41,6 +41,11 @@ class Pye3DPlugin(PupilDetectorPlugin):
     icon_chr = chr(0xEC19)
     order = 0.101
 
+    # Visualization
+    COLOR_ULTRA_LONG_TERM_MODEL = (0.5, 0, 0, 1)
+    COLOR_LONG_TERM_MODEL = (0.8, 0.8, 0, 1)
+    COLOR_SHORT_TERM_MODEL = (0, 1, 0, 1)
+
     @property
     def pupil_detector(self):
         return self.detector
@@ -198,17 +203,17 @@ class Pye3DPlugin(PupilDetectorPlugin):
                 debug_info = result["debug_info"]
                 draw_ellipse(
                     ellipse=debug_info["projected_ultra_long_term"],
-                    rgba=(0.5, 0, 0, 1),
+                    rgba=self.COLOR_ULTRA_LONG_TERM_MODEL,
                     thickness=2,
                 )
                 draw_ellipse(
                     ellipse=debug_info["projected_long_term"],
-                    rgba=(0.8, 0.8, 0, 1),
+                    rgba=self.COLOR_LONG_TERM_MODEL,
                     thickness=2,
                 )
                 draw_ellipse(
                     ellipse=debug_info["projected_short_term"],
-                    rgba=(0, 1, 0, 1),
+                    rgba=self.COLOR_SHORT_TERM_MODEL,
                     thickness=2,
                 )
         if self.__debug_window_button:


### PR DESCRIPTION
This PR changes the colors in pye3d debug window to make them consistent with pupil and eye outlines.

---
[ClickUp Task](https://app.clickup.com/t/gv5r7u)
