### PR TITLE
Decode text files using utf-8 encoding explicitly for files that are guaranteed to be utf-8 encoded

### DIFF
--- a/pupil_src/shared_modules/log_history.py
+++ b/pupil_src/shared_modules/log_history.py
@@ -54,7 +54,7 @@ class Log_History(Plugin):
         )
         self.menu.append(ui.Info_Text(help_str))
 
-        with open(self.logfile, "r") as fh:
+        with open(self.logfile, "r", encoding="utf-8") as fh:
             for l in fh.readlines():
                 self.menu.insert(2, ui.Info_Text(l[26:-1]))
 

--- a/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/info/recording_info_utils.py
@@ -88,14 +88,16 @@ def read_info_csv_file(rec_dir: str) -> dict:
 def read_info_json_file(rec_dir: str) -> dict:
     """Read `info.json` file from recording."""
     file_path = os.path.join(rec_dir, "info.json")
-    with open(file_path, "r") as file:
+    # guaranteed to be utf-8 encoded
+    with open(file_path, "r", encoding="utf-8") as file:
         return json.load(file)
 
 
 def read_info_invisible_json_file(rec_dir: str) -> dict:
     """Read `info.invisible.json` file from recording."""
     file_path = os.path.join(rec_dir, "info.invisible.json")
-    with open(file_path, "r") as file:
+    # guaranteed to be utf-8 encoded
+    with open(file_path, "r", encoding="utf-8") as file:
         return json.load(file)
 
 


### PR DESCRIPTION
> If encoding is not specified, the default is platform dependent (see open())

https://docs.python.org/3/tutorial/inputoutput.html

This can lead to problems when reading files that were generated on different platforms and contain characters that are incompatible with the default encoding, e.g. info.json file recorded by Pupil Invisible Companion.

This PR uses utf-8 to decode all text-files that are guaranteed to be utf-8 encoded (log file and Pupil Invisible Companion info files).

For all other recordings, it is not possible to assume the utf-8 encoding. Should one encounter `UnicodeDecodingError`s when opening recordings in Player, once can start Player with the `-X UTF-8` flag to enforce utf-8 decoding everywhere.