### PR TITLE
Windows: Create start menu entries and desktop shortcuts for all users on install

### DIFF
--- a/deployment/generate_msi_installer.py
+++ b/deployment/generate_msi_installer.py
@@ -165,7 +165,8 @@ template = f"""
 
         <Package Id='*' Keywords='Installer'
         Description="{package_description}" Manufacturer='{manufacturer}'
-        InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
+        InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252'
+        InstallScope='perMachine' />
 
         <Media Id='1' Cabinet='Cabinet.cab' EmbedCab='yes' DiskPrompt="CD-ROM #1" />
         <Property Id='DiskPrompt' Value="{package_description} Installer [1]" />


### PR DESCRIPTION
Pupil Core software is installed to `C:\Program Files (x86)\Pupil-Labs` by default. This directory should be accessible by all users but the start menu entry and desktop shortcut are only installed for the current user. With this PR, future MSI installers will create start menu entries and desktop shortcuts for all users on install.