### PR TITLE
Export-in-progress file-name suffixes

### DIFF
--- a/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
+++ b/pupil_src/shared_modules/video_export/plugins/world_video_exporter.py
@@ -110,8 +110,8 @@ def _export_world_video(
     import player_methods as pm
     from av_writer import MPEG_Audio_Writer
 
-    # we are not importing manual gaze correction. In Player corrections have already been applied.
-    # in batch exporter this plugin makes little sense.
+    # We are not importing manual gaze correction. In Player corrections have already
+    # been applied.
     from fixation_detector import Offline_Fixation_Detector
 
     # Plug-ins
@@ -125,8 +125,8 @@ def _export_world_video(
     from vis_watermark import Vis_Watermark
 
     PID = str(os.getpid())
-    logger = logging.getLogger(__name__ + " with pid: " + PID)
-    start_status = "Starting video export with pid: {}".format(PID)
+    logger = logging.getLogger(f"{__name__} with pid: {PID}")
+    start_status = f"Starting video export with pid: {PID}"
     logger.info(start_status)
     yield start_status, 0
 
@@ -197,16 +197,14 @@ def _export_world_video(
         if start_frame is None:
             start_frame = 0
 
-        # these two vars are shared with the launching process and give a job length and progress report.
+        # these two vars are shared with the launching process and
+        # give a job length and progress report.
         frames_to_export = len(trimmed_timestamps)
         current_frame = 0
-        exp_info = (
-            "Will export from frame {} to frame {}. This means I will export {} frames."
-        )
         logger.debug(
-            exp_info.format(
-                start_frame, start_frame + frames_to_export, frames_to_export
-            )
+            f"Will export from frame {start_frame} to frame "
+            f"{start_frame + frames_to_export}. This means I will export "
+            f"{frames_to_export} frames."
         )
 
         cap.seek_to_frame(start_frame)
@@ -278,7 +276,7 @@ def _export_world_video(
                 current_frame += 1
                 yield "Exporting with pid {}".format(PID), current_frame
         except GeneratorExit:
-            logger.warning("Video export with pid {} was canceled.".format(os.getpid()))
+            logger.warning(f"Video export with pid {PID} was canceled.")
             writer.close(timestamp_export_format=None, closed_suffix=".canceled")
             return
 
@@ -287,11 +285,12 @@ def _export_world_video(
         duration = time() - start_time
         effective_fps = float(current_frame) / duration
 
-        result = "Export done: Exported {} frames to {}. This took {} seconds. Exporter ran at {} frames per second."
         logger.info(
-            result.format(current_frame, out_file_path, duration, effective_fps)
+            f"Export done: Exported {current_frame} frames to {out_file_path}. "
+            f"This took {duration} seconds. "
+            f"Exporter ran at {effective_fps} frames per second."
         )
         yield "Export done. This took {:.0f} seconds.".format(duration), current_frame
 
     except GeneratorExit:
-        logger.warning("Video export with pid {} was canceled.".format(os.getpid()))
+        logger.warning(f"Video export with pid {PID} was canceled.")


### PR DESCRIPTION
Exporting video can take a long time. Pupil Player writes the result incrementally to disk. Specifically, it writes the result directly to the final export location. While the export is ongoing, the video file is invalid but still available to the user. This can lead to users opening the video before it has finished exporting and then encountering playback issues.

This PR changes the video exports to include a `.writing` file name suffix during the export. This prevents other applications from recognizing the partially exported video file as complete. Once the export is done, the suffix is removed and other applications are able to recognize the file type as video.