### PR TITLE
Add `surf_to_dist_img_trans` and `dist_img_to_surf_trans` to surface events

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface_tracker.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_tracker.py
@@ -490,6 +490,8 @@ class Surface_Tracker(Plugin, metaclass=ABCMeta):
                     "name": surface.name,
                     "surf_to_img_trans": surface.surf_to_img_trans.tolist(),
                     "img_to_surf_trans": surface.img_to_surf_trans.tolist(),
+                    "surf_to_dist_img_trans": surface.surf_to_dist_img_trans.tolist(),
+                    "dist_img_to_surf_trans": surface.dist_img_to_surf_trans.tolist(),
                     "gaze_on_surfaces": gaze_on_surf,
                     "fixations_on_surfaces": fixations_on_surf,
                     "timestamp": timestamp,


### PR DESCRIPTION
These two homographies are necessary to transform points from the [surface coordinate system](https://docs.pupil-labs.com/core/terminology/#surface-aoi-coordinate-system) to the [2d image space](https://docs.pupil-labs.com/core/terminology/#coordinate-system) of the scene camera, and vice versa. They have been available as part of the surface location exports in Pupil Player. With this PR, they also become available to other plugins in Pupil Capture or via its Network API.