### PR TITLE
 Make scene video recording optional 

### DIFF
--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -183,7 +183,11 @@ class Recorder(System_Plugin_Base):
         )
         self.menu.append(
             ui.Switch(
-                "record_eye", self, on_val=True, off_val=False, label="Record eye"
+                "record_eye",
+                self,
+                on_val=True,
+                off_val=False,
+                label="Record eye videos",
             )
         )
         self.button = ui.Thumb(

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -117,15 +117,15 @@ class Recorder(System_Plugin_Base):
         self.check_space = lambda: next(check_timer)
 
     def get_init_dict(self):
-        d = {}
-        d["record_eye"] = self.record_eye
-        d["session_name"] = self.session_name
-        d["user_info"] = self.user_info
-        d["info_menu_conf"] = self.info_menu_conf
-        d["show_info_menu"] = self.show_info_menu
-        d["rec_root_dir"] = self.rec_root_dir
-        d["raw_jpeg"] = self.raw_jpeg
-        return d
+        return {
+            "record_eye": self.record_eye,
+            "session_name": self.session_name,
+            "user_info": self.user_info,
+            "info_menu_conf": self.info_menu_conf,
+            "show_info_menu": self.show_info_menu,
+            "rec_root_dir": self.rec_root_dir,
+            "raw_jpeg": self.raw_jpeg,
+        }
 
     def init_ui(self):
         self.add_menu()

--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -69,6 +69,7 @@ class Recorder(System_Plugin_Base):
         user_info={"name": "", "additional_field": "change_me"},
         info_menu_conf={},
         show_info_menu=False,
+        record_world=True,
         record_eye=True,
         raw_jpeg=True,
     ):
@@ -101,6 +102,7 @@ class Recorder(System_Plugin_Base):
 
         self.raw_jpeg = raw_jpeg
         self.order = 0.9
+        self.record_world = record_world
         self.record_eye = record_eye
         self.session_name = session_name
         self.running = False
@@ -118,6 +120,7 @@ class Recorder(System_Plugin_Base):
 
     def get_init_dict(self):
         return {
+            "record_world": self.record_world,
             "record_eye": self.record_eye,
             "session_name": self.session_name,
             "user_info": self.user_info,
@@ -179,6 +182,15 @@ class Recorder(System_Plugin_Base):
         self.menu.append(
             ui.Info_Text(
                 "Recording the raw eye video is optional. We use it for debugging."
+            )
+        )
+        self.menu.append(
+            ui.Switch(
+                "record_world",
+                self,
+                on_val=True,
+                off_val=False,
+                label="Record world video",
             )
         )
         self.menu.append(


### PR DESCRIPTION
Add UI toggle to Recorder menu to disable scene/world video recording in Pupil Capture. Recording scene video remains the default behavior.