### PR TITLE
Recording-specific hotkeys

### DIFF
--- a/pupil_src/tests/annotations/test_annotation_deserialization.py
+++ b/pupil_src/tests/annotations/test_annotation_deserialization.py
@@ -1,4 +1,5 @@
 import io
+import json
 import pytest
 
 from annotations import Annotation_Player
@@ -10,15 +11,11 @@ def expected_definitions():
 
 
 @pytest.fixture
-def serialized_definitions_valid(expected_definitions):
-    json_buffer = io.StringIO()
-    Annotation_Player._serialize_definitions_to_file(
-        writable_file=json_buffer,
-        definitions=expected_definitions,
-        version=Annotation_Player._FILE_DEFINITIONS_VERSION,
-    )
-    json_buffer.seek(0)
-    return json_buffer
+def expected_definitions_json_object(expected_definitions):
+    return {
+        "version": Annotation_Player._FILE_DEFINITIONS_VERSION,
+        "definitions": dict(expected_definitions),
+    }
 
 
 def test_expected_version():
@@ -28,10 +25,74 @@ def test_expected_version():
 
 
 def test_deserialize_definitions_from_file(
-    serialized_definitions_valid, expected_definitions
+    expected_definitions_json_object, expected_definitions
 ):
+    json_buffer = io.StringIO()
+    json.dump(expected_definitions_json_object, json_buffer)
+    json_buffer.seek(0)
+
     definitions = Annotation_Player._deserialize_definitions_from_file(
-        readable_json_file=serialized_definitions_valid,
+        readable_json_file=json_buffer,
         expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
     )
     assert definitions == expected_definitions
+
+
+def test_deserialize_definitions_from_file_missing_version(
+    expected_definitions_json_object,
+):
+    json_buffer = io.StringIO()
+    del expected_definitions_json_object["version"]
+    json.dump(expected_definitions_json_object, json_buffer)
+    json_buffer.seek(0)
+
+    with pytest.raises(Annotation_Player.VersionMismatchError):
+        Annotation_Player._deserialize_definitions_from_file(
+            readable_json_file=json_buffer,
+            expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+        )
+
+
+def test_deserialize_definitions_from_file_missing_definitions(
+    expected_definitions_json_object,
+):
+    json_buffer = io.StringIO()
+    del expected_definitions_json_object["definitions"]
+    json.dump(expected_definitions_json_object, json_buffer)
+    json_buffer.seek(0)
+
+    with pytest.raises(KeyError):
+        Annotation_Player._deserialize_definitions_from_file(
+            readable_json_file=json_buffer,
+            expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+        )
+
+
+def test_deserialize_definitions_from_file_definitions_not_a_map(
+    expected_definitions_json_object,
+):
+    json_buffer = io.StringIO()
+    # should be map, but setting to sequence to trigger AttributeError down the line
+    expected_definitions_json_object["definitions"] = []
+    json.dump(expected_definitions_json_object, json_buffer)
+    json_buffer.seek(0)
+
+    with pytest.raises(AttributeError):
+        Annotation_Player._deserialize_definitions_from_file(
+            readable_json_file=json_buffer,
+            expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+        )
+
+
+def test_deserialize_definitions_from_file_invalid_json(
+    expected_definitions_json_object,
+):
+    json_buffer = io.StringIO()
+    json.dump(expected_definitions_json_object, json_buffer)
+    json_buffer.seek(1)  # 1 instead of 0, looks like invalid json to parser
+
+    with pytest.raises(json.JSONDecodeError):
+        Annotation_Player._deserialize_definitions_from_file(
+            readable_json_file=json_buffer,
+            expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+        )

--- a/pupil_src/tests/annotations/test_annotation_deserialization.py
+++ b/pupil_src/tests/annotations/test_annotation_deserialization.py
@@ -1,0 +1,37 @@
+import io
+import pytest
+
+from annotations import Annotation_Player
+
+
+@pytest.fixture
+def expected_definitions():
+    return (("label 0", "hotkey 0"), ("label 1", "hotkey 1"))
+
+
+@pytest.fixture
+def serialized_definitions_valid(expected_definitions):
+    json_buffer = io.StringIO()
+    Annotation_Player._serialize_definitions_to_file(
+        writable_file=json_buffer,
+        definitions=expected_definitions,
+        version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+    )
+    json_buffer.seek(0)
+    return json_buffer
+
+
+def test_expected_version():
+    assert (
+        Annotation_Player._FILE_DEFINITIONS_VERSION == 1
+    ), "Version changed. Adjust tests accordingly!"
+
+
+def test_deserialize_definitions_from_file(
+    serialized_definitions_valid, expected_definitions
+):
+    definitions = Annotation_Player._deserialize_definitions_from_file(
+        readable_json_file=serialized_definitions_valid,
+        expected_version=Annotation_Player._FILE_DEFINITIONS_VERSION,
+    )
+    assert definitions == expected_definitions


### PR DESCRIPTION
Starting with this PR, annotation definitions are stored in `<recording dir>/offline_data/annotation_definitions.json` with the format
```json
{
    "version": 1,
    "definitions": {
        "<label>": "<hotkey>"
    }
}
```
This file can be shared between recordings.

On load, Pupil Player attempts to load the annotation definitions from the recording-specific file. If it is not found or invalid, it will fallback to the session settings, i.e. the last known annotation definitions.