### PR TITLE
Fix renaming world video file if no file was written

### DIFF
--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -495,8 +495,8 @@ class Recorder(System_Plugin_Base):
             # explicit release of VideoWriter
             try:
                 self.writer.release()
-            except RuntimeError:
-                logger.error("No world video recorded")
+            except (RuntimeError, FileNotFoundError):
+                logger.warning("No world video recorded")
             else:
                 logger.debug("Closed media container")
                 self.g_pool.capture.intrinsics.save(self.rec_path, custom_name="world")


### PR DESCRIPTION
Follow up PR for #2167

- Fixes crash below
- Demotes "No world video recorded" log message from `error` to `warning`

Crash if no world camera is connected during recording:
```py
world - [ERROR] launchables.world: Process Capture crashed with trace
Traceback (most recent call last):
  File ".../pupil/pupil_src/launchables/world.py", line 741, in world
    p.on_notify(n)
  File ".../pupil/pupil_src/shared_modules/recorder.py", line 289, in on_notify
    self.stop()
  File ".../pupil/pupil_src/shared_modules/recorder.py", line 497, in stop
    self.writer.release()
  File ".../pupil/pupil_src/shared_modules/av_writer.py", line 243, in release
    self.close()
  File ".../pupil/pupil_src/shared_modules/av_writer.py", line 234, in close
    os.rename(self.output_file_path_in_porgress, output_file_path)
FileNotFoundError: [Errno 2] No such file or directory: '.../recordings/2021_09_08/000/world.mp4.writing' -> '.../recordings/2021_09_08/000/world.mp4'
```