### PR TITLE
Easy plugin icon customization

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -144,7 +144,7 @@ def player(
         )
 
         assert parse_version(pyglui_version) >= parse_version(
-            "1.30.0"
+            "1.31.0"
         ), "pyglui out of date, please upgrade to newest version"
 
         process_was_interrupted = False

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -130,7 +130,7 @@ def world(
         from pyglui import ui, cygl, __version__ as pyglui_version
 
         assert parse_version(pyglui_version) >= parse_version(
-            "1.30.0"
+            "1.31.0"
         ), "pyglui out of date, please upgrade to newest version"
         from pyglui.cygl.utils import Named_Texture
         import gl_utils

--- a/pupil_src/shared_modules/plugin.py
+++ b/pupil_src/shared_modules/plugin.py
@@ -53,6 +53,13 @@ class Plugin(object):
     # or custom loaded font name
     icon_font = "roboto"
     icon_chr = "?"  # character shown in menu icon
+    # icon placement and sizing:
+    # icon_pos_delta: (x, y) offset relative to default position
+    # icon_size_delta: negative values decrease font size, positive values increase it
+    # icon_line_height: distance between lines, only relevant for multi-line labels
+    icon_pos_delta = (0, 0)
+    icon_size_delta = 0
+    icon_line_height = 1.0
 
     def __init__(self, g_pool):
         self.g_pool = g_pool
@@ -288,6 +295,10 @@ class Plugin(object):
             self.menu,
             label=self.icon_chr,
             label_font=self.icon_font,
+            label_offset_size=self.icon_size_delta,
+            label_offset_x=self.icon_pos_delta[0],
+            label_offset_y=self.icon_pos_delta[1],
+            label_line_height=self.icon_line_height,
             on_val=False,
             off_val=True,
             setter=toggle_menu,

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ opencv-python==3.* ; platform_system == "Windows"
 pupil-apriltags==1.0.4
 pupil-detectors==2.0.*
 pye3d==0.2.0
-pyglui>=1.30.0
+pyglui>=1.31.0
 
 # pupil-labs/PyAV 0.4.6
 av @ git+https://github.com/pupil-labs/PyAV@v0.4.6 ; platform_system != "Windows"


### PR DESCRIPTION
Plugins can now overwrite the following class attributes to customize the menu icon:
- icon_pos_delta: relative positioning
- icon_size_delta: relative font resizing
- icon_line_height (multi-line icons only): line distance

Requires pyglui v1.31.0 or higher