### PR TITLE
Fix loading 200 Hz gaze data in Pupil Invisible recordings

### DIFF
--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -363,32 +363,45 @@ def pi_gaze_items(root_dir):
     # - starts with "gaze ps"
     # - is followed by one or more digits
     # - ends with "_timestamps.npy"
-    pattern = r"^gaze ps[0-9]+_timestamps.npy$"
-    gaze_timestamp_paths = matched_files_by_name_pattern(root_dir, pattern)
+    timestamps_realtime_pattern = r"^gaze ps[0-9]+_timestamps.npy$"
+    timestamps_realtime_paths = matched_files_by_name_pattern(
+        root_dir, timestamps_realtime_pattern
+    )
     # Use 200hz data only if both gaze data and timestamps are available at 200hz
-    if _find_raw_200hz_path(root_dir) and _find_timestamps_200hz_path(root_dir):
-        yield from _pi_posthoc_200hz_gaze_items(root_dir, gaze_timestamp_paths)
+    raw_200hz_path = _find_raw_200hz_path(root_dir)
+    timestamps_200hz_path = _find_timestamps_200hz_path(root_dir)
+    if raw_200hz_path and timestamps_200hz_path:
+        worn_200hz_path = _find_worn_200hz_path(root_dir)
+        yield from _pi_posthoc_200hz_gaze_items(
+            raw_200hz_path,
+            timestamps_200hz_path,
+            worn_200hz_path,
+            timestamps_realtime_paths,
+        )
     else:
-        yield from _pi_realtime_recorded_gaze_items(gaze_timestamp_paths)
+        yield from _pi_realtime_recorded_gaze_items(timestamps_realtime_paths)
 
 
-def _pi_posthoc_200hz_gaze_items(root_dir: Path, gaze_timestamp_paths):
-    raw_data = _load_raw_data(_find_raw_200hz_path(root_dir))
-    timestamps = _load_timestamps_data(_find_timestamps_200hz_path(root_dir))
+def _pi_posthoc_200hz_gaze_items(
+    raw_200hz_path, timestamps_200hz_path, worn_200hz_path, timestamps_realtime_paths
+):
+    raw_data = _load_raw_data(raw_200hz_path)
+    timestamps = _load_timestamps_data(timestamps_200hz_path)
 
-    worn_200hz_path = _find_worn_200hz_path(root_dir)
     if worn_200hz_path is not None:
         conf_data = _load_worn_data(worn_200hz_path)
     else:
-        conf_data = _load_densified_worn_data(root_dir, gaze_timestamp_paths)
+        conf_data = _find_and_load_densified_worn_data(
+            timestamps, timestamps_realtime_paths
+        )
 
     raw_data, timestamps = _equalize_length_if_necessary(raw_data, timestamps)
     conf_data = _validated_conf_data(conf_data, timestamps)
     yield from zip(raw_data, timestamps, conf_data)
 
 
-def _pi_realtime_recorded_gaze_items(gaze_timestamp_paths):
-    for timestamps_path in gaze_timestamp_paths:
+def _pi_realtime_recorded_gaze_items(timestamps_realtime_paths):
+    for timestamps_path in timestamps_realtime_paths:
         raw_data = _load_raw_data(_find_raw_path(timestamps_path))
         timestamps = _load_timestamps_data(timestamps_path)
         conf_data = _load_worn_data(_find_worn_path(timestamps_path))
@@ -460,26 +473,29 @@ def _load_worn_data(path: Path):
     return np.clip(confidences, 0.0, 1.0)
 
 
-def _load_densified_worn_data(root_dir: Path, gaze_timestamp_paths: T.List[Path]):
-    if not gaze_timestamp_paths:
+def _find_and_load_densified_worn_data(
+    timestamps_200hz, timestamps_realtime_paths: T.List[Path]
+):
+    if not timestamps_realtime_paths:
         return None
     # Load and densify confidence data when 200hz gaze is available, but only
     # non-200hz confidence is available
-    ts_200hz_ = _load_timestamps_data(_find_timestamps_200hz_path(root_dir))
-    conf_data, ts_ = _realtime_recorded_worn_data(gaze_timestamp_paths)
-    densification_idc = pm.find_closest(ts_, ts_200hz_)
+    conf_data, timestamps_realtime = _find_and_load_realtime_recorded_worn_data(
+        timestamps_realtime_paths
+    )
+    densification_idc = pm.find_closest(timestamps_realtime, timestamps_200hz)
     return conf_data[densification_idc]
 
 
-def _realtime_recorded_worn_data(gaze_timestamp_paths: T.List[Path]):
-    # assumes at least one path in `gaze_timestamp_paths`, otherwise np.concatenate will
-    # raise ValueError: need at least one array to concatenate
+def _find_and_load_realtime_recorded_worn_data(timestamps_realtime_paths: T.List[Path]):
+    # assumes at least one path in `timestamps_realtime_paths`, otherwise np.concatenate
+    # will raise ValueError: need at least one array to concatenate
     assert (
-        len(gaze_timestamp_paths) > 0
+        len(timestamps_realtime_paths) > 0
     ), "Requires at least one real-time recorded gaze timestamp path"
     conf_all = []
     ts_all = []
-    for timestamps_path in gaze_timestamp_paths:
+    for timestamps_path in timestamps_realtime_paths:
         ts = _load_timestamps_data(timestamps_path)
         conf_data = _load_worn_data(_find_worn_path(timestamps_path))
         conf_data = _validated_conf_data(conf_data, ts)

--- a/pupil_src/shared_modules/pupil_recording/update/invisible.py
+++ b/pupil_src/shared_modules/pupil_recording/update/invisible.py
@@ -380,7 +380,7 @@ def _pi_posthoc_200hz_gaze_items(root_dir: Path, gaze_timestamp_paths):
     if worn_200hz_path is not None:
         conf_data = _load_worn_data(worn_200hz_path)
     else:
-        conf_data = _load_densified_worn_data(gaze_timestamp_paths)
+        conf_data = _load_densified_worn_data(root_dir, gaze_timestamp_paths)
 
     raw_data, timestamps = _equalize_length_if_necessary(raw_data, timestamps)
     conf_data = _validated_conf_data(conf_data, timestamps)

--- a/pupil_src/shared_modules/video_capture/utils.py
+++ b/pupil_src/shared_modules/video_capture/utils.py
@@ -10,20 +10,13 @@ See COPYING and COPYING.LESSER for license details.
 """
 import logging
 import os
-import pathlib as pl
 import typing as T
 from pathlib import Path
-import re
-
 
 import av
 import cv2
 import numpy as np
-
-
-import player_methods as pm
 from methods import container_decode
-
 
 logger = logging.getLogger(__name__)
 
@@ -485,145 +478,3 @@ class VideoSet:
         lookup.timestamp = timestamps
         lookup.container_idx = -1  # virtual container by default
         return lookup
-
-
-def pi_gaze_items(root_dir):
-    def find_timestamps_200hz_path(timestamps_path):
-        path = timestamps_path.with_name("gaze_200hz_timestamps.npy")
-        if path.is_file():
-            return path
-        else:
-            return None
-
-    def find_raw_path(timestamps_path):
-        name = timestamps_path.name.replace("_timestamps", "")
-        path = timestamps_path.with_name(name).with_suffix(".raw")
-        assert path.is_file(), f"The file does not exist at path: {path}"
-        return path
-
-    def find_raw_200hz_path(timestamps_path):
-        path = timestamps_path.with_name("gaze_200hz.raw")
-        if path.is_file():
-            return path
-        else:
-            return None
-
-    def find_worn_path(timestamps_path):
-        name = timestamps_path.name
-        name = name.replace("gaze", "worn")
-        name = name.replace("_timestamps", "")
-        path = timestamps_path.with_name(name).with_suffix(".raw")
-        if path.is_file():
-            return path
-        else:
-            return None
-
-    def find_worn_200hz_path(timestamps_path):
-        path = timestamps_path.with_name("worn_200hz.raw")
-        if path.is_file():
-            return path
-        else:
-            return None
-
-    def is_200hz(path: Path) -> bool:
-        return "200hz" in path.name
-
-    def load_timestamps_data(path):
-        timestamps = np.load(str(path))
-        return timestamps
-
-    def load_raw_data(path):
-        raw_data = np.fromfile(str(path), "<f4")
-        raw_data_dtype = raw_data.dtype
-        raw_data.shape = (-1, 2)
-        return np.asarray(raw_data, dtype=raw_data_dtype)
-
-    def load_worn_data(path):
-        if not (path and path.exists()):
-            return None
-
-        confidences = np.fromfile(str(path), "<u1") / 255.0
-        return np.clip(confidences, 0.0, 1.0)
-
-    # This pattern will match any filename that:
-    # - starts with "gaze ps"
-    # - is followed by one or more digits
-    # - ends with "_timestamps.npy"
-    gaze_timestamp_paths = matched_files_by_name_pattern(
-        pl.Path(root_dir), r"^gaze ps[0-9]+_timestamps.npy$"
-    )
-
-    for timestamps_path in gaze_timestamp_paths:
-        # Use 200hz data only if both gaze data and timestamps are available at 200hz
-        is_200hz_data_available = (find_raw_200hz_path(timestamps_path)) and (
-            find_timestamps_200hz_path(timestamps_path) is not None
-        )
-
-        if is_200hz_data_available:
-            raw_data = load_raw_data(find_raw_200hz_path(timestamps_path))
-        else:
-            raw_data = load_raw_data(find_raw_path(timestamps_path))
-
-        if is_200hz_data_available:
-            timestamps = load_timestamps_data(
-                find_timestamps_200hz_path(timestamps_path)
-            )
-        else:
-            timestamps = load_timestamps_data(timestamps_path)
-
-        if is_200hz_data_available:
-            ts_ = load_timestamps_data(timestamps_path)
-            ts_200hz_ = load_timestamps_data(
-                find_timestamps_200hz_path(timestamps_path)
-            )
-            densification_idc = pm.find_closest(ts_, ts_200hz_)
-        else:
-            densification_idc = np.asarray(range(len(raw_data)))
-
-        # Load confidence data when both 200hz gaze and 200hz confidence data is available
-        if (
-            is_200hz_data_available
-            and find_worn_200hz_path(timestamps_path) is not None
-        ):
-            conf_data = load_worn_data(find_worn_200hz_path(timestamps_path))
-        # Load and densify confidence data when 200hz gaze is available, but only non-200hz confidence is available
-        elif is_200hz_data_available and find_worn_path(timestamps_path) is not None:
-            conf_data = load_worn_data(find_worn_path(timestamps_path))
-            conf_data = conf_data[densification_idc]
-        # Load confidence data when both non-200hz gaze and non-200hz confidence is available
-        elif (
-            not is_200hz_data_available and find_worn_path(timestamps_path) is not None
-        ):
-            conf_data = load_worn_data(find_worn_path(timestamps_path))
-        # Otherwise, don't load confidence data
-        else:
-            conf_data = None
-
-        if len(raw_data) != len(timestamps):
-            logger.warning(
-                f"There is a mismatch between the number of raw data ({len(raw_data)}) "
-                f"and the number of timestamps ({len(timestamps)})!"
-            )
-            size = min(len(raw_data), len(timestamps))
-            raw_data = raw_data[:size]
-            timestamps = timestamps[:size]
-
-        if conf_data is not None and len(conf_data) != len(timestamps):
-            logger.warning(
-                f"There is a mismatch between the number of confidence data ({len(conf_data)}) "
-                f"and the number of timestamps ({len(timestamps)})! Not using confidence data."
-            )
-
-            conf_data = None
-
-        if conf_data is None:
-            conf_data = (1.0 for _ in range(len(raw_data)))
-
-        yield from zip(raw_data, timestamps, conf_data)
-
-
-def matched_files_by_name_pattern(parent_dir: Path, name_pattern: str) -> T.List[Path]:
-    # Get all non-recursive directory contents
-    contents = filter(Path.is_file, parent_dir.iterdir())
-    # Filter content that matches the name by regex pattern
-    return [c for c in contents if re.match(name_pattern, c.name) is not None]


### PR DESCRIPTION
When Pupil Player opens a Pupil Invisible recording for the first time, it performs an in-place upgrade procedure due to compatibility reasons. In this process, it loads PI gaze data and generates Pupil Player compatible gaze data based on it. 

Due to a flaw in the previous gaze conversion procedure, Pupil Cloud post-processed 200 Hz gaze data could be loaded multiple times or not at all.

This PR moves the prior implementation from `video_capture.utils` to `pupil_recording.update.invisible` and restructures the code flow such that 200 Hz gaze data is processed separately from the case where gaze data is loaded from the real-time recorded files.

Below a detailed description of what should be happening:

Pupil Invisible Companion records gaze data into three different sets of files. Their 
names can be matched by the following regex patterns:
- `^gaze ps[0-9]+.raw$`
- `^gaze ps[0-9]+.time$`
- `^worn ps[0-9]+.raw$`

The worn data is a stream of values of either 0 or 255, indicating that the glasses
were (not) worn. Pupil Player maps these to gaze confidence values of 0.0 and 1.0
respectively.

Since all `*.time` files are converted to Pupil Player before this function is being
called, we match the `^gaze ps[0-9]+_timestamps.npy$` pattern on the recording files
instead. When looking for the location and worn data, the function just replaces the
necessary parts of the timestamp file names instead of performing separate regex
matches.

If the recording was successfully post-processed and downloaded from Pupil Cloud, it
will contain 200Hz-densified gaze data. This data replaces the real-time recorded
data by Pupil Invisible Companion and is stored in three files:
- `gaze_200hz.raw`
- `gaze_200hz.time` (or `gaze_200hz_timestamps.npy` if upgraded)
- `worn_200hz.raw`

The worn data is a special case as it was introduced at different points in time to
Pupil Invisible Companion and Pupil Cloud. In other words, it is possible that there
is no worn data, only real-time recorded worn data, or 200 Hz worn data. The latter
is preferred. If 200 Hz gaze data is only available with real-time recorded worn
data, the latter is interpolated to 200 Hz using a k-nearest-neighbour (k=1)
approach. If no worn data is available, or the numbers of worn samples and gaze
timestamps are not consistent, Pupil Player assumes a confidence value of 1.0 for
every gaze point.