### PR TITLE
Add argument to Pupil Capture and Service to skip the automatic driver installation on Windows

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -66,6 +66,7 @@ def eye(
     debug=False,
     pub_socket_hwm=None,
     parent_application="capture",
+    skip_driver_installation=False,
 ):
     """reads eye video and detects the pupil.
 
@@ -196,6 +197,7 @@ def eye(
         g_pool.process = f"eye{eye_id}"
         g_pool.timebase = timebase
         g_pool.camera_render_size = None
+        g_pool.skip_driver_installation = skip_driver_installation
 
         g_pool.zmq_ctx = zmq_ctx
         g_pool.ipc_pub = ipc_socket

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -25,6 +25,7 @@ def world(
     preferred_remote_port,
     hide_ui,
     debug,
+    skip_driver_installation,
 ):
     """Reads world video and runs plugins.
 
@@ -234,6 +235,7 @@ def world(
         g_pool.ipc_push_url = ipc_push_url
         g_pool.eye_procs_alive = eye_procs_alive
         g_pool.preferred_remote_port = preferred_remote_port
+        g_pool.skip_driver_installation = skip_driver_installation
 
         def get_timestamp():
             return get_time_monotonic() - g_pool.timebase.value

--- a/pupil_src/main.py
+++ b/pupil_src/main.py
@@ -26,6 +26,7 @@ default_args = {
     "version": False,
     "hide_ui": False,
     "port": 50020,
+    "skip_driver_installation": False,
 }
 parsed_args, unknown_args = PupilArgParser().parse(running_from_bundle, **default_args)
 
@@ -322,6 +323,7 @@ def launcher():
                             parsed_args.debug,
                             n.get("pub_socket_hwm"),
                             parsed_args.app,  # parent_application
+                            parsed_args.skip_driver_installation,
                         ),
                     ).start()
                 elif "notify.player_process.should_start" in topic:
@@ -353,6 +355,7 @@ def launcher():
                             parsed_args.port,
                             parsed_args.hide_ui,
                             parsed_args.debug,
+                            parsed_args.skip_driver_installation,
                         ),
                     ).start()
                 elif "notify.clear_settings_process.should_start" in topic:

--- a/pupil_src/shared_modules/launchable_args.py
+++ b/pupil_src/shared_modules/launchable_args.py
@@ -88,6 +88,12 @@ class PupilArgParser:
             parser.add_argument(
                 "--hide-ui", action="store_true", help="hide ui on startup"
             )
+            parser.add_argument(
+                "-skip-driv",
+                "--skip-driver-installation",
+                action="store_true",
+                help="skip automatic driver installation on Windows",
+            )
 
         if app == "player":
             parser.add_argument(

--- a/pupil_src/shared_modules/video_capture/uvc_backend.py
+++ b/pupil_src/shared_modules/video_capture/uvc_backend.py
@@ -75,7 +75,10 @@ class UVC_Source(Base_Source):
         assert name or preferred_names or uid
 
         if platform.system() == "Windows":
-            self.verify_drivers()
+            if g_pool.skip_driver_installation:
+                logger.debug("Skipping driver installation")
+            else:
+                self.verify_drivers()
 
         self.devices = uvc.Device_List()
 


### PR DESCRIPTION
Fixes #2207

Using the `-skip-driv` or `--skip-driver-installation` flags, one can now launch Pupil Capture and Pupil Service without running the automatic driver installation on Windows.

@N-M-T could you please give this PR a try? You should see a debug log message that the driver installation was skipped when using the flags.