### PR TITLE
Raw data exporter: Add option to not export low confidence values

### DIFF
--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -117,7 +117,7 @@ class Raw_Data_Exporter(Plugin):
         should_export_pupil_positions=True,
         should_export_field_info=True,
         should_export_gaze_positions=True,
-        should_include_low_confidence_data=False,
+        should_include_low_confidence_data=True,
     ):
         super().__init__(g_pool)
 
@@ -175,10 +175,9 @@ class Raw_Data_Exporter(Plugin):
             ui.Info_Text(
                 'Pupil Core software assigns "confidence" values to its pupil '
                 "detections and gaze estimations. They indicate the quality of the "
-                "measurement. By default, the raw data export will only include data "
-                'above the "Minimum data confidence" threshold. It can be adjusted '
-                "in the general settings menu. To export all data, turn on the option "
-                "below."
+                "measurement. Disable the option below to only export data above the"
+                '"Minimum data confidence" threshold. It can be adjusted in the '
+                "general settings menu."
             )
         )
         self.menu.append(

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -130,6 +130,14 @@ class Raw_Data_Exporter(Plugin):
         self.should_export_gaze_positions = should_export_gaze_positions
         self.should_include_low_confidence_data = should_include_low_confidence_data
 
+    def get_init_dict(self):
+        return {
+            "should_export_pupil_positions": self.should_export_pupil_positions,
+            "should_export_field_info": self.should_export_field_info,
+            "should_export_gaze_positions": self.should_export_gaze_positions,
+            "should_include_low_confidence_data": self.should_include_low_confidence_data,
+        }
+
     @property
     def _is_pupil_producer_avaiable(self) -> bool:
         producers = Pupil_Producer_Base.available_pupil_producer_plugins(self.g_pool)

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -200,6 +200,11 @@ class Raw_Data_Exporter(Plugin):
                 timestamps=self.g_pool.timestamps,
                 export_window=export_window,
                 export_dir=export_dir,
+                min_confidence_threshold=(
+                    0.0
+                    if self.should_include_low_confidence_data
+                    else self.g_pool.min_data_confidence
+                ),
             )
 
         if self.should_export_gaze_positions:
@@ -209,6 +214,11 @@ class Raw_Data_Exporter(Plugin):
                 timestamps=self.g_pool.timestamps,
                 export_window=export_window,
                 export_dir=export_dir,
+                min_confidence_threshold=(
+                    0.0
+                    if self.should_include_low_confidence_data
+                    else self.g_pool.min_data_confidence
+                ),
             )
 
         if self.should_export_field_info:
@@ -237,7 +247,12 @@ class _Base_Positions_Exporter(abc.ABC):
         pass
 
     def csv_export_write(
-        self, positions_bisector, timestamps, export_window, export_dir
+        self,
+        positions_bisector,
+        timestamps,
+        export_window,
+        export_dir,
+        min_confidence_threshold=0.0,
     ):
         export_file = type(self).csv_export_filename()
         export_path = os.path.join(export_dir, export_file)
@@ -251,10 +266,7 @@ class _Base_Positions_Exporter(abc.ABC):
             dict_writer.writeheader()
 
             for g, idx in zip(export_section["data"], export_world_idc):
-                if (
-                    not self.should_include_low_confidence_data
-                    and g["confidence"] < self.g_pool.min_data_confidence
-                ):
+                if g["confidence"] < min_confidence_threshold:
                     continue
                 dict_row = type(self).dict_export(raw_value=g, world_index=idx)
                 dict_writer.writerow(dict_row)

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -172,7 +172,14 @@ class Raw_Data_Exporter(Plugin):
             )
         )
         self.menu.append(
-            ui.Info_Text("Press the export button or type 'e' to start the export.")
+            ui.Info_Text(
+                'Pupil Core software assigns "confidence" values to its pupil '
+                "detections and gaze estimations. They indicate the quality of the "
+                "measurement. By default, the raw data export will only include data "
+                'above the "Minimum data confidence" threshold. It can be adjusted '
+                "in the general settings menu. To export all data, turn on the option "
+                "below."
+            )
         )
         self.menu.append(
             ui.Switch(

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -176,7 +176,7 @@ class Raw_Data_Exporter(Plugin):
                 'Pupil Core software assigns "confidence" values to its pupil '
                 "detections and gaze estimations. They indicate the quality of the "
                 "measurement. Disable the option below to only export data above the"
-                '"Minimum data confidence" threshold. It can be adjusted in the '
+                '"Minimum data confidence" threshold. This threshold can be adjusted in the '
                 "general settings menu."
             )
         )

--- a/pupil_src/shared_modules/raw_data_exporter.py
+++ b/pupil_src/shared_modules/raw_data_exporter.py
@@ -117,6 +117,7 @@ class Raw_Data_Exporter(Plugin):
         should_export_pupil_positions=True,
         should_export_field_info=True,
         should_export_gaze_positions=True,
+        should_include_low_confidence_data=False,
     ):
         super().__init__(g_pool)
 
@@ -127,6 +128,7 @@ class Raw_Data_Exporter(Plugin):
         self.should_export_pupil_positions = should_export_pupil_positions
         self.should_export_field_info = should_export_field_info
         self.should_export_gaze_positions = should_export_gaze_positions
+        self.should_include_low_confidence_data = should_include_low_confidence_data
 
     @property
     def _is_pupil_producer_avaiable(self) -> bool:
@@ -159,6 +161,16 @@ class Raw_Data_Exporter(Plugin):
         self.menu.append(
             ui.Switch(
                 "should_export_gaze_positions", self, label="Export Gaze Positions"
+            )
+        )
+        self.menu.append(
+            ui.Info_Text("Press the export button or type 'e' to start the export.")
+        )
+        self.menu.append(
+            ui.Switch(
+                "should_include_low_confidence_data",
+                self,
+                label="Include low confidence data",
             )
         )
         self.menu.append(
@@ -231,6 +243,11 @@ class _Base_Positions_Exporter(abc.ABC):
             dict_writer.writeheader()
 
             for g, idx in zip(export_section["data"], export_world_idc):
+                if (
+                    not self.should_include_low_confidence_data
+                    and g["confidence"] < self.g_pool.min_data_confidence
+                ):
+                    continue
                 dict_row = type(self).dict_export(raw_value=g, world_index=idx)
                 dict_writer.writerow(dict_row)
 


### PR DESCRIPTION
Pupil Core software assigns "confidence" values to its pupil  detections and gaze estimations. They indicate the quality of the measurement. Until now, the raw data exporter plugin exported all data, independently of its confidence. New users are often not aware of this and wonder why the exported data looks noisier than what they have seen in Pupil Player.

For visualization, Pupil Player hides gaze data below the "Minimum data confidence" threshold (adjustable in the general settings menu). Often, we recommend users to filter their data by a confidence threshold after exporting.

Starting with this PR, users will have the option to only including data  above the "Minimum data confidence" threshold in the export. The option can be enabled in the raw data exporter's menu.

(credits to @N-M-T for raising awareness of this issue)

![Screenshot 2021-11-18 at 15 48 00](https://user-images.githubusercontent.com/168390/142437758-1ab52f67-bad9-4acb-9582-16e12f71eca4.png)

