### PR TITLE
Player: Check for file write permissions when opening a recording

### DIFF
--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -932,6 +932,13 @@ def player_drop(
             glfont.set_color_float((1.0, 1.0, 1.0, 1.0))
             glfont.draw_text(x, y, string)
 
+        def display_multiline_string(string, font_size, top_y, split_chr="\n"):
+            for idx, line in enumerate(string.split(split_chr)):
+                center_y = top_y + font_size * idx * 1.2
+                display_string(line, font_size=font_size, center_y=center_y)
+            bottom_y = top_y + font_size * (idx + 1) * 1.2
+            return bottom_y
+
         while not glfw.window_should_close(window) and not process_was_interrupted:
 
             fb_size = glfw.get_framebuffer_size(window)
@@ -956,11 +963,8 @@ def player_drop(
 
             gl_utils.clear_gl_screen()
 
-            display_string(text, font_size=51, center_y=216)
-            for idx, line in enumerate(tip.split("\n")):
-                tip_font_size = 42
-                center_y = 288 + tip_font_size * idx * 1.2
-                display_string(line, font_size=tip_font_size, center_y=center_y)
+            top_y = display_multiline_string(text, font_size=51, top_y=216)
+            display_multiline_string(tip, font_size=42, top_y=top_y + 50)
 
             glfw.swap_buffers(window)
 

--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -10,6 +10,7 @@ See COPYING and COPYING.LESSER for license details.
 """
 
 import enum
+import os
 from pathlib import Path
 
 from .info import recording_info_utils
@@ -74,6 +75,7 @@ def assert_valid_rec_dir(rec_dir: str):
         - rec_dir does not exist
         - rec_dir points to a video file instead of the directory
         - rec_dir points to a file in general
+        - rec_dir is readable and writable
     """
     rec_dir = Path(rec_dir).resolve()
 
@@ -107,6 +109,12 @@ def assert_valid_rec_dir(rec_dir: str):
             raise InvalidRecordingException(
                 reason=f"Target at path is not a directory:\n{rec_dir}", recovery=""
             )
+
+    if not os.access(rec_dir, os.W_OK):
+        raise InvalidRecordingException(
+            reason=f"Player must be able to write files to\n{rec_dir}",
+            recovery="Please change the file permission accordingly.",
+        )
 
 
 # NOTE: The following functions are actually not correct given their name, only in the

--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -94,18 +94,18 @@ def assert_valid_rec_dir(rec_dir: str):
 
     if not rec_dir.exists():
         raise InvalidRecordingException(
-            reason=f"Target at path does not exist: {rec_dir}", recovery=""
+            reason=f"Target at path does not exist:\n{rec_dir}", recovery=""
         )
 
     if not rec_dir.is_dir():
         if is_video_file(rec_dir):
             raise InvalidRecordingException(
                 reason=f"The provided path is a video, not a recording directory",
-                recovery="Please provide a recording directory",
+                recovery="Please provide a recording directory.",
             )
         else:
             raise InvalidRecordingException(
-                reason=f"Target at path is not a directory: {rec_dir}", recovery=""
+                reason=f"Target at path is not a directory:\n{rec_dir}", recovery=""
             )
 
 

--- a/pupil_src/shared_modules/pupil_recording/recording_utils.py
+++ b/pupil_src/shared_modules/pupil_recording/recording_utils.py
@@ -77,6 +77,12 @@ def assert_valid_rec_dir(rec_dir: str):
         - rec_dir points to a file in general
         - rec_dir is readable and writable
     """
+    if not os.access(rec_dir, os.R_OK):
+        raise InvalidRecordingException(
+            reason=f"Player does not have sufficient permissions to read the directory",
+            recovery="",
+        )
+
     rec_dir = Path(rec_dir).resolve()
 
     def normalize_extension(ext: str) -> str:


### PR DESCRIPTION
Pupil Player needs to be able to write to a recording directory for multiple reasons, e.g. upgrading recordings, caching results, exporting data, etc. To avoid issues, Pupil Player will check if it has sufficient permissions before opening a recording and warn the user if this is not the case.

Users on macOS Monterey will encounter this issue frequently as they are required to run Pupil Capture with root privileges (https://github.com/libusb/libusb/issues/1014). In these cases, Pupil Player will present the user the option to change the file ownership from `root` to their current user.
![Screenshot 2021-11-25 at 11 13 54](https://user-images.githubusercontent.com/168390/143427711-c4c85484-bb2e-45c1-8589-94582bedf5fe.png)
This change of ownership only needs to be done once and can be performed alternatively via the terminal using the `sudo chown -R $USER <recording dir>` command.