### PR TITLE
Avoid ZeroDivisionError in post-hoc blink detection

### DIFF
--- a/pupil_src/shared_modules/blink_detection.py
+++ b/pupil_src/shared_modules/blink_detection.py
@@ -335,7 +335,7 @@ class Offline_Blink_Detection(Observable, Blink_Detection):
     def recalculate(self):
         import time
 
-        t0 = time.time()
+        t0 = time.perf_counter()
         all_pp = self._pupil_data()
         if not all_pp:
             self.filter_response = []
@@ -372,7 +372,7 @@ class Offline_Blink_Detection(Observable, Blink_Detection):
 
         self.consolidate_classifications()
 
-        tm1 = time.time()
+        tm1 = time.perf_counter()
         logger.debug(
             "Recalculating took\n\t{:.4f}sec for {} pp\n\t{} pp/sec\n\tsize: {}".format(
                 tm1 - t0, len(all_pp), len(all_pp) / (tm1 - t0), filter_size


### PR DESCRIPTION
If no pupil data is available the calculation can happen very fast and `time.time()` might not have sufficient resolution to measure a time difference > 0. As a result, `tm1 - t0` might equal zero and cause a ZeroDivisionError in the log statement.

Using time.perf_counter should yield sufficient precision to avoid this issue.

Issue reported via [Discord](https://discord.com/channels/285728493612957698/285728493612957698/968845448204939314)

Workaround plugin for Pupil Core software <3.6 can be found [here](https://gist.github.com/papr/c02bf229ac9a94e9fbee633cd53113db).