### PR TITLE
Fix logging setup in Service

### DIFF
--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -71,6 +71,7 @@ def service(
     logging.getLogger("OpenGL").setLevel(logging.ERROR)
     logger = logging.getLogger()
     logger.handlers = []
+    logger.setLevel(logging.NOTSET)
     logger.addHandler(zmq_tools.ZMQ_handler(zmq_ctx, ipc_push_url))
     # create logger for the context of this function
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
The Pupil Service logger log-level was set to the default value (warning) and did not display any info- or debug-level messages. By setting the log-level to `NOTSET`, the handlers get the chance to process every message based on their on level.