### PR TITLE
Add Neon support to Pupil Service

### DIFF
--- a/pupil_src/launchables/service.py
+++ b/pupil_src/launchables/service.py
@@ -107,6 +107,7 @@ def service(
         from service_ui import Service_UI
         from uvc import get_time_monotonic
         from version_utils import parse_version
+        from video_capture.neon_backend.plugin import Neon_Manager
 
         IPC_Logging_Task_Proxy.push_url = ipc_push_url
 
@@ -158,6 +159,7 @@ def service(
             Pupil_Groups,
             NetworkApiPlugin,
             Blink_Detection,
+            Neon_Manager,
         ] + runtime_plugins
         plugin_by_index = (
             runtime_plugins
@@ -169,6 +171,7 @@ def service(
         plugin_by_name = dict(zip(name_by_index, plugin_by_index))
         default_plugins = [
             ("Service_UI", {}),
+            ("Neon_Manager", {}),
             # Calibration choreography plugin is added bellow by calling
             # patch_world_session_settings_with_choreography_plugin
             ("NetworkApiPlugin", {}),

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -23,6 +23,7 @@ GLFWErrorReporting.set_default()
 
 from plugin import System_Plugin_Base
 from pyglui import cygl, ui
+from video_capture.neon_backend.plugin import Neon_Manager
 
 # UI Platform tweaks
 if platform.system() == "Linux":
@@ -168,6 +169,23 @@ class Service_UI(System_Plugin_Base):
                 label="Detect eye 1",
                 setter=lambda alive: self.start_stop_eye(1, alive),
                 getter=lambda: g_pool.eye_procs_alive[1].value,
+            )
+        )
+        g_pool.menubar.append(
+            ui.Info_Text(
+                "To use Neon, connect it to your PC and click the button below."
+            )
+        )
+        g_pool.menubar.append(
+            ui.Button(
+                "Activate Neon",
+                lambda: self.notify_all(
+                    {
+                        "subject": Neon_Manager.SUBJECT_REQUEST_AUTO_ACTIVATE,
+                        "scene": False,
+                        "eyes": True,
+                    }
+                ),
             )
         )
 


### PR DESCRIPTION
Activate the connected Neon device by clicking the button in the UI or by sending the following notification:
```py
{
    "subject": "neon_backend.auto_activate",
    "scene": False,
    "eyes": True,
}
``` 