### PR TITLE
Neon-specific 3d calibration parameters

### DIFF
--- a/pupil_src/shared_modules/gaze_mapping/__init__.py
+++ b/pupil_src/shared_modules/gaze_mapping/__init__.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Type
 
 from . import gazer_base, matching
 from .gazer_2d import Gazer2D
-from .gazer_3d import Gazer3D, GazerHMD3D, PosthocGazerHMD3D
+from .gazer_3d import Gazer3D, GazerHMD3D, NeonGazer3D, PosthocGazerHMD3D
 from .gazer_base import CalibrationError
 
 

--- a/pupil_src/shared_modules/gaze_mapping/gazer_3d/__init__.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_3d/__init__.py
@@ -8,5 +8,5 @@ Lesser General Public License (LGPL v3.0).
 See COPYING and COPYING.LESSER for license details.
 ---------------------------------------------------------------------------~(*)
 """
-from .gazer_headset import Gazer3D
+from .gazer_headset import Gazer3D, NeonGazer3D
 from .gazer_hmd import GazerHMD3D, PosthocGazerHMD3D

--- a/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_headset.py
+++ b/pupil_src/shared_modules/gaze_mapping/gazer_3d/gazer_headset.py
@@ -344,7 +344,10 @@ class Gazer3D(GazerBase):
 
     @classmethod
     def _gazer_description_text(cls) -> str:
-        return "3D gaze mapping: default method; able to compensate for small movements of the headset (slippage); uses 3d eye model as input."
+        return (
+            "3D gaze mapping: default method; able to compensate for small movements "
+            "of the headset (slippage); uses 3d eye model as input."
+        )
 
     def _init_left_model(self) -> Model:
         return Model3D_Monocular(
@@ -456,3 +459,17 @@ class Gazer3D(GazerBase):
         pupil_data = list(filter(lambda p: "3d" in p["method"], pupil_data))
         pupil_data = super().filter_pupil_data(pupil_data, confidence_threshold)
         return pupil_data
+
+
+class NeonGazer3D(Gazer3D):
+    label = "3D Neon"
+
+    eye0_hardcoded_translation = 30, 5, -10
+    eye1_hardcoded_translation = -30, 5, -10
+
+    @classmethod
+    def _gazer_description_text(cls) -> str:
+        return (
+            "3D gaze mapping: optimized for Neon; able to compensate for small "
+            "movements of the headset (slippage); uses 3d eye model as input."
+        )

--- a/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
+++ b/pupil_src/shared_modules/gaze_producer/model/calibration_storage.py
@@ -169,8 +169,7 @@ class CalibrationStorage(Storage, Observable):
             pass
         self._load_recorded_calibrations()
 
-    def _load_calibration_from_file(self, file_name):
-        file_path = os.path.join(self._calibration_folder, file_name)
+    def _load_calibration_from_file(self, file_path):
         calibration_dict = self._load_data_from_file(file_path)
         if not calibration_dict:
             return


### PR DESCRIPTION
The 3d calibration assumes an initial translation of the eyeball centers relative to the scene camera. Since Neon has a different scene camera placement relative to the eyes, the result is worse when using the Pupil Core translation values with Neon hardware.

This PR introduces a new gazer class that uses translation values optimized for Neon.

To use it, select `3D Neon` as `Gaze Mapping` method in the `Calibration` menu.

Bundle: https://github.com/pupil-labs/pupil/actions/runs/4135338823