### PR TITLE
fix crash when trying to record before calibration 

### DIFF
--- a/pupil_src/shared_modules/recorder.py
+++ b/pupil_src/shared_modules/recorder.py
@@ -393,6 +393,8 @@ class Recorder(System_Plugin_Base):
                 writer.append(note_dict)
             except FileNotFoundError:
                 continue
+            except ValueError:
+                continue
 
         self.pldata_writers["notify"] = writer
 


### PR DESCRIPTION

fix crash when trying to record before calibration when no past calibration data exists
If I understand correctly what that portion of code is doing, it should ignore when no calibration data are available, but it can raise another error than `FileNotFoundError`

example traceback before the fix

```
Process world:
Traceback (most recent call last):
  File "/home/basile/data/src/pupil/pupil_src/shared_modules/gaze_mapping/notifications.py", line 48, in from_dict
    dict_ = cls.sanitize_serialized_dict(dict_)
  File "/home/basile/data/src/pupil/pupil_src/shared_modules/gaze_mapping/notifications.py", line 107, in sanitize_serialized_dict
    return super().sanitize_serialized_dict(dict_)
  File "/home/basile/data/src/pupil/pupil_src/shared_modules/gaze_mapping/notifications.py", line 100, in sanitize_serialized_dict
    return super().sanitize_serialized_dict(dict_)
  File "/home/basile/data/src/pupil/pupil_src/shared_modules/gaze_mapping/notifications.py", line 58, in sanitize_serialized_dict
    dict_[field_name] = field_cls(dict_[field_name])
TypeError: 'ForwardRef' object is not callable

```