### PR TITLE
move clipboard updates to a focus callback, perfs enh + stability fix

### DIFF
--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -12,8 +12,8 @@ import os
 import platform
 import signal
 import time
-from types import SimpleNamespace
 from functools import partial
+from types import SimpleNamespace
 
 
 class Is_Alive_Manager:

--- a/pupil_src/launchables/eye.py
+++ b/pupil_src/launchables/eye.py
@@ -13,6 +13,7 @@ import platform
 import signal
 import time
 from types import SimpleNamespace
+from functools import partial
 
 
 class Is_Alive_Manager:
@@ -281,16 +282,7 @@ def eye(
             cpu_graph.draw()
 
             # render GUI
-            try:
-                clipboard = glfw.get_clipboard_string(main_window).decode()
-            except (AttributeError, glfw.GLFWError):
-                # clipboard is None, might happen on startup
-                clipboard = ""
-            g_pool.gui.update_clipboard(clipboard)
             user_input = g_pool.gui.update()
-            if user_input.clipboard != clipboard:
-                # only write to clipboard if content changed
-                glfw.set_clipboard_string(main_window, user_input.clipboard)
 
             for button, action, mods in user_input.buttons:
                 x, y = glfw.get_cursor_pos(main_window)
@@ -564,6 +556,8 @@ def eye(
         g_pool.writer = None
         g_pool.rec_path = None
 
+        on_focus = partial(gl_utils.window_focus_clipboard_callback, g_pool)
+
         # Register callbacks main_window
         glfw.set_framebuffer_size_callback(main_window, on_resize)
         glfw.set_window_iconify_callback(main_window, on_iconify)
@@ -573,6 +567,7 @@ def eye(
         glfw.set_cursor_pos_callback(main_window, on_pos)
         glfw.set_scroll_callback(main_window, on_scroll)
         glfw.set_drop_callback(main_window, on_drop)
+        glfw.set_window_focus_callback(main_window, on_focus)
 
         # load last gui configuration
         g_pool.gui.configuration = session_settings.get("ui_config", {})

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -14,7 +14,6 @@ import platform
 import signal
 from functools import partial
 from types import SimpleNamespace
-from functools import partial
 
 # UI Platform tweaks
 if platform.system() == "Linux":

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -14,6 +14,7 @@ import platform
 import signal
 from functools import partial
 from types import SimpleNamespace
+from functools import partial
 
 # UI Platform tweaks
 if platform.system() == "Linux":
@@ -654,6 +655,8 @@ def player(
             ),
         )
 
+        on_focus = partial(gl_utils.window_focus_clipboard_callback, g_pool)
+
         # Register callbacks main_window
         glfw.set_framebuffer_size_callback(main_window, on_resize)
         glfw.set_key_callback(main_window, on_window_key)
@@ -662,6 +665,7 @@ def player(
         glfw.set_cursor_pos_callback(main_window, on_pos)
         glfw.set_scroll_callback(main_window, on_scroll)
         glfw.set_drop_callback(main_window, on_drop)
+        glfw.set_window_focus_callback( main_window, on_focus)
 
         toggle_general_settings(True)
 
@@ -741,16 +745,7 @@ def player(
 
                 gl_utils.glViewport(0, 0, *window_size)
 
-                try:
-                    clipboard = glfw.get_clipboard_string(main_window).decode()
-                except (AttributeError, glfw.GLFWError):
-                    # clipbaord is None, might happen on startup
-                    clipboard = ""
-                g_pool.gui.update_clipboard(clipboard)
                 user_input = g_pool.gui.update()
-                if user_input.clipboard and user_input.clipboard != clipboard:
-                    # only write to clipboard if content changed
-                    glfw.set_clipboard_string(main_window, user_input.clipboard)
 
                 for b in user_input.buttons:
                     button, action, mods = b

--- a/pupil_src/launchables/player.py
+++ b/pupil_src/launchables/player.py
@@ -665,7 +665,7 @@ def player(
         glfw.set_cursor_pos_callback(main_window, on_pos)
         glfw.set_scroll_callback(main_window, on_scroll)
         glfw.set_drop_callback(main_window, on_drop)
-        glfw.set_window_focus_callback( main_window, on_focus)
+        glfw.set_window_focus_callback(main_window, on_focus)
 
         toggle_general_settings(True)
 

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -11,8 +11,8 @@ See COPYING and COPYING.LESSER for license details.
 import os
 import platform
 import signal
-from types import SimpleNamespace
 from functools import partial
+from types import SimpleNamespace
 
 
 def world(

--- a/pupil_src/launchables/world.py
+++ b/pupil_src/launchables/world.py
@@ -12,6 +12,7 @@ import os
 import platform
 import signal
 from types import SimpleNamespace
+from functools import partial
 
 
 def world(
@@ -344,16 +345,7 @@ def world(
                 p.gl_display()
 
             gl_utils.glViewport(0, 0, *window_size)
-            try:
-                clipboard = glfw.get_clipboard_string(main_window).decode()
-            except (AttributeError, glfw.GLFWError):
-                # clipboard is None, might happen on startup
-                clipboard = ""
-            g_pool.gui.update_clipboard(clipboard)
             user_input = g_pool.gui.update()
-            if user_input.clipboard != clipboard:
-                # only write to clipboard if content changed
-                glfw.set_clipboard_string(main_window, user_input.clipboard)
 
             for button, action, mods in user_input.buttons:
                 x, y = glfw.get_cursor_pos(main_window)
@@ -674,6 +666,8 @@ def world(
                 g_pool.plugin_by_name[default_capture_name], default_capture_settings
             )
 
+        on_focus = partial(gl_utils.window_focus_clipboard_callback, g_pool)
+
         # Register callbacks main_window
         glfw.set_framebuffer_size_callback(main_window, on_resize)
         glfw.set_key_callback(main_window, on_window_key)
@@ -682,6 +676,7 @@ def world(
         glfw.set_cursor_pos_callback(main_window, on_pos)
         glfw.set_scroll_callback(main_window, on_scroll)
         glfw.set_drop_callback(main_window, on_drop)
+        glfw.set_window_focus_callback(main_window, on_focus)
 
         # gl_state settings
         gl_utils.basic_gl_setup()
@@ -781,16 +776,8 @@ def world(
                     p.gl_display()
 
                 gl_utils.glViewport(0, 0, *window_size)
-                try:
-                    clipboard = glfw.get_clipboard_string(main_window).decode()
-                except (AttributeError, glfw.GLFWError):
-                    # clipboard is None, might happen on startup
-                    clipboard = ""
-                g_pool.gui.update_clipboard(clipboard)
+
                 user_input = g_pool.gui.update()
-                if user_input.clipboard != clipboard:
-                    # only write to clipboard if content changed
-                    glfw.set_clipboard_string(main_window, user_input.clipboard)
 
                 for button, action, mods in user_input.buttons:
                     x, y = glfw.get_cursor_pos(main_window)

--- a/pupil_src/shared_modules/gl_utils/__init__.py
+++ b/pupil_src/shared_modules/gl_utils/__init__.py
@@ -31,5 +31,6 @@ from .utils import (
     make_coord_system_norm_based,
     make_coord_system_pixel_based,
     window_coordinate_to_framebuffer_coordinate,
+    window_focus_clipboard_callback,
 )
 from .window_position_manager import WindowPositionManager

--- a/pupil_src/shared_modules/gl_utils/utils.py
+++ b/pupil_src/shared_modules/gl_utils/utils.py
@@ -129,6 +129,20 @@ def is_window_visible(window):
     return visible and not iconified
 
 
+def window_focus_clipboard_callback(g_pool, window, focused):
+    if focused:
+        try:
+            clipboard = glfw.get_clipboard_string(window).decode()
+        except (AttributeError, glfw.GLFWError):
+            # clipboard is None, might happen on startup
+            clipboard = ""
+        g_pool.gui.update_clipboard(clipboard)
+        user_input = g_pool.gui.update()
+        if user_input.clipboard != clipboard:
+            # only write to clipboard if content changed
+            glfw.set_clipboard_string(main_window, user_input.clipboard)
+
+
 def cvmat_to_glmat(m):
     mat = np.eye(4, dtype=np.float32)
     mat = mat.flatten()

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -24,6 +24,7 @@ GLFWErrorReporting.set_default()
 from plugin import System_Plugin_Base
 from pyglui import cygl, ui
 from video_capture.neon_backend.plugin import Neon_Manager
+from functools import partial
 
 # UI Platform tweaks
 if platform.system() == "Linux":
@@ -193,6 +194,8 @@ class Service_UI(System_Plugin_Base):
 
         g_pool.menubar.append(ui.Button("Restart with default settings", reset_restart))
 
+        on_focus = partial(gl_utils.window_focus_clipboard_callback, g_pool)
+
         # Register callbacks main_window
         glfw.set_framebuffer_size_callback(main_window, on_resize)
         glfw.set_key_callback(main_window, on_window_key)
@@ -200,6 +203,7 @@ class Service_UI(System_Plugin_Base):
         glfw.set_mouse_button_callback(main_window, on_window_mouse_button)
         glfw.set_cursor_pos_callback(main_window, on_pos)
         glfw.set_scroll_callback(main_window, on_scroll)
+        glfw.set_window_focus_callback(main_window, on_focus)
         g_pool.gui.configuration = ui_config
         gl_utils.basic_gl_setup()
 
@@ -217,16 +221,6 @@ class Service_UI(System_Plugin_Base):
             gl_utils.glViewport(0, 0, *self.window_size)
             glfw.poll_events()
             self.gl_display()
-            try:
-                clipboard = glfw.get_clipboard_string(self.g_pool.main_window).decode()
-            except (AttributeError, glfw.GLFWError):
-                # clipbaord is None, might happen on startup
-                clipboard = ""
-            self.g_pool.gui.update_clipboard(clipboard)
-            user_input = self.g_pool.gui.update()
-            if user_input.clipboard and user_input.clipboard != clipboard:
-                # only write to clipboard if content changed
-                glfw.set_clipboard_string(self.g_pool.main_window, user_input.clipboard)
 
             glfw.swap_buffers(self.g_pool.main_window)
         else:

--- a/pupil_src/shared_modules/service_ui.py
+++ b/pupil_src/shared_modules/service_ui.py
@@ -21,10 +21,11 @@ from OpenGL.GL import GL_COLOR_BUFFER_BIT
 
 GLFWErrorReporting.set_default()
 
+from functools import partial
+
 from plugin import System_Plugin_Base
 from pyglui import cygl, ui
 from video_capture.neon_backend.plugin import Neon_Manager
-from functools import partial
 
 # UI Platform tweaks
 if platform.system() == "Linux":


### PR DESCRIPTION
We had a curious issue for years where eye or world window would freeze on our production setup only. However moving the mouse over the frozen window would usually unfreeze it. The main issue was data loss, because the software was not processing camera frames and the network buffers would overflow.

After inspecting the stack when that freezing occurs, it seems that calls to `glfw.get_clipboard_string` sometimes hangs.
This might be specific interactions with our software / hardware, or that in our config (FPS/ screen framerate) the clipboard was concurrently written/read by eye and world windows, causing the hangs.

In the meantime, profiling would show that a small but non-negligible portion of the CPU cycles would be spent querying the clipboard.

I here moved that call to the focus callback: the logic being, if the OS clipboard (not the pyglui one that seems separate IIUC)  was modified, it is only happening if the focus was given to another window, so we can retrieve it only when the pupil window get focus again. 
That way, the clipboard is not probed at the screen framerate and likelyhood of hangs is largely dimished. It also separates the processing loop from call to OS clipboard that seems likely to disrupt RT reqs of pupil.  

Let me know if that makes any sense and if you want me to make changes. 

