### PR TITLE
avoid crash for bad intrinsics sampling

### DIFF
--- a/pupil_src/shared_modules/camera_intrinsics_estimation.py
+++ b/pupil_src/shared_modules/camera_intrinsics_estimation.py
@@ -329,7 +329,7 @@ class Camera_Intrinsics_Estimation(Plugin):
                     img, (4, 11), flags=cv2.CALIB_CB_ASYMMETRIC_GRID
                 )
             except cv2.error:
-                logger.exception(
+                logger.warning(
                     f"Exception in cv2.findCirclesGrid() using shape={img.shape!r} "
                     f"dtype={img.dtype!r}"
                 )


### PR DESCRIPTION
I don't see a real need to raise an exception and crashing the application in production here. Please, make me known if I am wrong. Note that this error may also happen for Pupil cameras, not only for third party cameras as originally documented by me.