### PR TITLE
screen detector for stationary setups

### DIFF
--- a/pupil_src/shared_modules/surface_tracker/surface_marker.py
+++ b/pupil_src/shared_modules/surface_tracker/surface_marker.py
@@ -39,6 +39,7 @@ Surface_Marker_TagID = typing.NewType("Surface_Marker_TagID", int)
 
 @enum.unique
 class Surface_Marker_Type(enum.Enum):
+    SCREEN = "screen"
     SQUARE = "legacy"
     APRILTAG_V3 = "apriltag_v3"
 
@@ -184,6 +185,40 @@ class _Square_Marker_Detection(_Square_Marker_Detection_Raw, Surface_Base_Marker
     def tag_id(self) -> Surface_Marker_TagID:
         return Surface_Marker_TagID(int(self.raw_id))
 
+class _Screen_Marker_Detection(_Square_Marker_Detection_Raw, Surface_Base_Marker):
+    __slots__ = ()
+
+    marker_type = Surface_Marker_Type.SCREEN
+
+    @staticmethod
+    def from_tuple(state: tuple) -> "_Screen_Marker_Detection":
+        cls = _Screen_Marker_Detection
+        expected_marker_type = cls.marker_type
+
+        assert len(state) > 0
+        assert isinstance(state[-1], str)
+
+        try:
+            real_marker_type = Surface_Marker_Type(state[-1])
+        except ValueError:
+            real_marker_type = expected_marker_type
+            state = (*state, real_marker_type.value)
+
+        assert real_marker_type == expected_marker_type
+        return cls(*state)
+
+    def to_tuple(self) -> tuple:
+        return tuple(self)
+
+    @property
+    def uid(self) -> Surface_Marker_UID:
+        return create_surface_marker_uid(
+            marker_type=self.marker_type, tag_family=None, tag_id=self.tag_id
+        )
+
+    @property
+    def tag_id(self) -> Surface_Marker_TagID:
+        return Surface_Marker_TagID(int(self.raw_id))
 
 _Apriltag_V3_Marker_Detection_Raw = collections.namedtuple(
     "Apriltag_V3_Marker_Detection",
@@ -312,6 +347,8 @@ class Surface_Marker(_Surface_Marker_Raw, Surface_Base_Marker):
         marker_type = state[-1]
         if marker_type == _Square_Marker_Detection.marker_type.value:
             raw_marker = _Square_Marker_Detection.from_tuple(state)
+        elif marker_type == _Screen_Marker_Detection.marker_type.value:
+            raw_marker = _Screen_Marker_Detection.from_tuple(state)
         elif marker_type == _Apriltag_V3_Marker_Detection.marker_type.value:
             raw_marker = _Apriltag_V3_Marker_Detection.from_tuple(state)
         else:


### PR DESCRIPTION
This PR is for learning purposes only. I known it is incomplete considering some code standards, and there are margin for customization with better UI (for example, allow different minimum surface size). It examplifies how to create a new marker detector type that is used to detect a computer screen as a surface (potentially, any rigid brighter rect surface in regard to the background).

- The new type creates markers from square corners detected from the biggest one at the field of view.

- Orientation is obtained by sorting corners with pre-defined assumptions and will always return top-to-bottom surface.

- For stationary setups, I found it to be cleaner (no visual markers at all needed) and a lot more precise and stable than fiducial markers.